### PR TITLE
Lazy loading hook

### DIFF
--- a/TravelCostApp/components/Hooks/useLazyLoading.tsx
+++ b/TravelCostApp/components/Hooks/useLazyLoading.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useIsFocused } from "@react-navigation/native";
+import LoadingOverlay from "../UI/LoadingOverlay";
+
+/**
+ * Custom hook that implements lazy loading for tab screens.
+ * Returns a loading component until the screen has been focused at least once.
+ * This improves initial app performance by deferring rendering of non-active tabs.
+ * 
+ * @returns Object containing:
+ *  - shouldRender: boolean indicating if the screen content should be rendered
+ *  - LoadingComponent: JSX element to show while content is not yet loaded
+ */
+export const useLazyLoading = () => {
+  const isFocused = useIsFocused();
+  const hasBeenFocused = useRef(false);
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useEffect(() => {
+    if (isFocused && !hasBeenFocused.current) {
+      hasBeenFocused.current = true;
+      setShouldRender(true);
+    }
+  }, [isFocused]);
+
+  const LoadingComponent = <LoadingOverlay noText size="large" />;
+
+  return {
+    shouldRender,
+    LoadingComponent,
+  };
+};

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -17,6 +17,7 @@ import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import * as Haptics from "expo-haptics";
 import { Checkbox } from "react-native-paper";
 import { Toast } from "react-native-toast-message/lib/src/Toast";
+import { useLazyLoading } from "../components/Hooks/useLazyLoading";
 import Autocomplete from "../components/UI/Autocomplete";
 import GradientButton from "../components/UI/GradientButton";
 import IconButton from "../components/UI/IconButton";
@@ -39,6 +40,7 @@ import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
 
 const FinderScreen = () => {
+  const { shouldRender, LoadingComponent } = useLazyLoading();
   const navigation = useNavigation();
   const expCtx = useContext(ExpensesContext);
   const userCtx = useContext(UserContext);
@@ -284,6 +286,10 @@ const FinderScreen = () => {
         ...cats.slice(0, 1),
         ...suggestionData.slice(0, 1),
       ];
+
+  if (!shouldRender) {
+    return LoadingComponent;
+  }
 
   return (
     <>

--- a/TravelCostApp/screens/OverviewScreen.tsx
+++ b/TravelCostApp/screens/OverviewScreen.tsx
@@ -30,6 +30,7 @@ import { _toShortFormat } from "../util/dateTime";
 import PropTypes from "prop-types";
 import { NetworkContext } from "../store/network-context";
 import { useInterval } from "../components/Hooks/useInterval";
+import { useLazyLoading } from "../components/Hooks/useLazyLoading";
 import { DEBUG_POLLING_INTERVAL } from "../confAppConstants";
 import { ExpenseData } from "../util/expense";
 import * as Haptics from "expo-haptics";
@@ -49,6 +50,7 @@ import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
 
 const OverviewScreen = ({ navigation }) => {
+  const { shouldRender, LoadingComponent } = useLazyLoading();
   const expensesCtx = useContext(ExpensesContext);
   const tripCtx = useContext(TripContext);
   const userCtx = useContext(UserContext);
@@ -182,6 +184,11 @@ const OverviewScreen = ({ navigation }) => {
   //   tripCtx.tripCurrency
   // );
   const { isPortrait, isTablet } = useContext(OrientationContext);
+
+  if (!shouldRender) {
+    return LoadingComponent;
+  }
+
   return (
     <View style={[styles.container, isTablet && styles.tabletPaddingTop]}>
       <View

--- a/TravelCostApp/screens/ProfileScreen.tsx
+++ b/TravelCostApp/screens/ProfileScreen.tsx
@@ -20,6 +20,7 @@ import { i18n } from "../i18n/i18n";
 import React from "react";
 import { TourGuideZone, useTourGuideController } from "rn-tourguide";
 import { useInterval } from "../components/Hooks/useInterval";
+import { useLazyLoading } from "../components/Hooks/useLazyLoading";
 import LoadingBarOverlay from "../components/UI/LoadingBarOverlay";
 import { AuthContext } from "../store/auth-context";
 import { secureStoreGetItem } from "../store/secure-storage";
@@ -107,6 +108,7 @@ async function storeToken() {
 }
 
 const ProfileScreen = ({ navigation }) => {
+  const { shouldRender, LoadingComponent } = useLazyLoading();
   const userCtx = useContext(UserContext);
   const tripCtx = useContext(TripContext);
   const authCtx = useContext(AuthContext);
@@ -390,6 +392,10 @@ const ProfileScreen = ({ navigation }) => {
       </View>
     </>
   );
+
+  if (!shouldRender) {
+    return LoadingComponent;
+  }
 
   if (isFetchingLogout)
     return (

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -29,6 +29,7 @@ import { DateTime } from "luxon";
 import { i18n } from "../i18n/i18n";
 
 import { useInterval } from "../components/Hooks/useInterval";
+import { useLazyLoading } from "../components/Hooks/useLazyLoading";
 import { DEBUG_POLLING_INTERVAL } from "../confAppConstants";
 import { fetchAndSetExpenses } from "../components/ExpensesOutput/RecentExpensesUtil";
 import { _toShortFormat } from "../util/dateTime";
@@ -50,6 +51,7 @@ import { OrientationContext } from "../store/orientation-context";
 import { refreshWithToast } from "../util/refreshWithToast";
 
 function RecentExpenses({ navigation }) {
+  const { shouldRender, LoadingComponent } = useLazyLoading();
   const expensesCtx = useContext(ExpensesContext);
   const authCtx = useContext(AuthContext);
   const uid = authCtx.uid;
@@ -327,6 +329,10 @@ function RecentExpenses({ navigation }) {
       }
     />
   );
+  if (!shouldRender) {
+    return LoadingComponent;
+  }
+
   if (error && !isFetching) {
     return <ErrorOverlay message={error} onConfirm={errorHandler} />;
   }

--- a/TravelCostApp/screens/SplitSummaryScreen.tsx
+++ b/TravelCostApp/screens/SplitSummaryScreen.tsx
@@ -43,12 +43,14 @@ import { useFocusEffect } from "@react-navigation/native";
 import * as Haptics from "expo-haptics";
 import { Pressable, ScrollView } from "react-native";
 import { dynamicScale } from "../util/scalingUtil";
+import { useLazyLoading } from "../components/Hooks/useLazyLoading";
 import { OrientationContext } from "../store/orientation-context";
 import safeLogError from "../util/error";
 import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
 
 const SplitSummaryScreen = ({ navigation }) => {
+  const { shouldRender, LoadingComponent } = useLazyLoading();
   const {
     tripid,
     tripCurrency,
@@ -393,6 +395,10 @@ const SplitSummaryScreen = ({ navigation }) => {
       )}
     </View>
   );
+
+  if (!shouldRender) {
+    return LoadingComponent;
+  }
 
   if (error && !isFetching) {
     return <ErrorOverlay message={error} onConfirm={errorHandler} />;


### PR DESCRIPTION
Implement a `useLazyLoading` hook to improve initial app performance by deferring rendering of non-active tab screens.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1c898793-d91f-43c6-a910-54692f800fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c898793-d91f-43c6-a910-54692f800fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

