### PR TITLE
Fix offline-created expenses duplicating after sync (#230)

### DIFF
--- a/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
@@ -49,11 +49,61 @@ jest.mock("../../util/refreshWithToast", () => ({
   refreshWithToast: jest.fn(async () => {}),
 }));
 
+const mmkvStore: Record<string, unknown> = {};
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: { OFFLINE_QUEUE: "offlineQueue" },
+  getMMKVObject: jest.fn((key: string) => mmkvStore[key] ?? null),
+  setMMKVObject: jest.fn((key: string, value: unknown) => {
+    mmkvStore[key] = value;
+  }),
+}));
+
+jest.mock("../../util/offline-queue", () => ({
+  getOfflineQueue: jest.fn(async () => mmkvStore.offlineQueue ?? []),
+  sendOfflineQueue: jest.fn(async () => {
+    mmkvStore.offlineQueue = [];
+  }),
+}));
+
+jest.mock("../../components/ExpensesOutput/RecentExpensesUtil", () => ({
+  fetchAndSetExpenses: jest.fn(async () => {}),
+}));
+
+jest.mock("../../util/http", () => ({
+  fetchTravelerIsTouched: jest.fn(async () => true),
+}));
+
+import { waitFor } from "@testing-library/react-native";
 import RecentExpenses from "../../screens/RecentExpenses";
+import { fetchAndSetExpenses } from "../../components/ExpensesOutput/RecentExpensesUtil";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
 describe("RecentExpenses screen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+  });
+
+  it("fetches expenses after the offline queue flushes successfully", async () => {
+    mmkvStore.offlineQueue = [{ type: "add", expense: { tripid: "t1" } }];
+
+    const navigation = { navigate: jest.fn() };
+    renderWithAppProviders(<RecentExpenses navigation={navigation as any} />, {
+      expenses: {
+        expenses: [],
+        getRecentExpenses: () => [],
+        loadExpensesFromStorage: jest.fn(async () => {}),
+      },
+      network: { isConnected: true, strongConnection: true },
+    });
+
+    await waitFor(() => {
+      expect(fetchAndSetExpenses).toHaveBeenCalled();
+    });
+  });
+
   it("shows the trip name and period expense total from ExpensesSummary", () => {
     const monthExpenses = [makeExpense({ id: "e1", calcAmount: 75, amount: 75 })];
     const navigation = { navigate: jest.fn() };

--- a/TravelCostApp/__tests__/store/expenses-reducer-offline-sync.test.ts
+++ b/TravelCostApp/__tests__/store/expenses-reducer-offline-sync.test.ts
@@ -1,0 +1,66 @@
+import { expensesReducer, mergeExpenseLists } from "../../store/expenses-context";
+import { makeExpense } from "../fixtures/expense";
+
+describe("offline expense sync merge", () => {
+  const editedTimestamp = 1_700_000_000_000;
+
+  it("keeps one expense when server merge uses the same id as the offline-created expense", () => {
+    const offlineExpense = makeExpense({
+      id: "offline-client-id",
+      editedTimestamp,
+      amount: 42,
+      description: "street food",
+    });
+
+    let state = expensesReducer([], { type: "ADD", payload: offlineExpense });
+    state = mergeExpenseLists(state, [
+      makeExpense({
+        id: "offline-client-id",
+        editedTimestamp,
+        amount: 42,
+        description: "street food",
+        serverTimestamp: editedTimestamp + 1,
+      }),
+    ]);
+
+    expect(state).toHaveLength(1);
+    expect(state[0].id).toBe("offline-client-id");
+    expect(state[0].serverTimestamp).toBe(editedTimestamp + 1);
+  });
+
+  it("reconciles offline and server rows when sync used a different expense id", () => {
+    const offlineExpense = makeExpense({
+      id: "local-offline-id",
+      editedTimestamp,
+      amount: 42,
+      description: "street food",
+    });
+
+    let state = expensesReducer([], { type: "ADD", payload: offlineExpense });
+    state = mergeExpenseLists(state, [
+      makeExpense({
+        id: "server-generated-id",
+        editedTimestamp,
+        amount: 42,
+        description: "street food",
+        serverTimestamp: editedTimestamp + 1,
+      }),
+    ]);
+
+    expect(state).toHaveLength(1);
+    expect(state[0].id).toBe("server-generated-id");
+    expect(state.map((expense) => expense.id)).not.toContain("local-offline-id");
+  });
+
+  it("does not add a second row when add is called again with the same id", () => {
+    const offlineExpense = makeExpense({
+      id: "offline-client-id",
+      editedTimestamp,
+    });
+
+    let state = expensesReducer([], { type: "ADD", payload: offlineExpense });
+    state = expensesReducer(state, { type: "ADD", payload: offlineExpense });
+
+    expect(state).toHaveLength(1);
+  });
+});

--- a/TravelCostApp/__tests__/store/expenses-reducer-offline-sync.test.ts
+++ b/TravelCostApp/__tests__/store/expenses-reducer-offline-sync.test.ts
@@ -1,8 +1,12 @@
 import { expensesReducer, mergeExpenseLists } from "../../store/expenses-context";
 import { makeExpense } from "../fixtures/expense";
 
+/**
+ * Repro (#230): offline create → online sync must not duplicate ledger rows when ids differ.
+ */
 describe("offline expense sync merge", () => {
   const editedTimestamp = 1_700_000_000_000;
+  const expenseDate = new Date("2026-01-15T12:00:00.000Z");
 
   it("keeps one expense when server merge uses the same id as the offline-created expense", () => {
     const offlineExpense = makeExpense({
@@ -10,6 +14,7 @@ describe("offline expense sync merge", () => {
       editedTimestamp,
       amount: 42,
       description: "street food",
+      date: expenseDate,
     });
 
     let state = expensesReducer([], { type: "ADD", payload: offlineExpense });
@@ -19,6 +24,7 @@ describe("offline expense sync merge", () => {
         editedTimestamp,
         amount: 42,
         description: "street food",
+        date: expenseDate,
         serverTimestamp: editedTimestamp + 1,
       }),
     ]);
@@ -34,6 +40,7 @@ describe("offline expense sync merge", () => {
       editedTimestamp,
       amount: 42,
       description: "street food",
+      date: expenseDate,
     });
 
     let state = expensesReducer([], { type: "ADD", payload: offlineExpense });
@@ -43,6 +50,7 @@ describe("offline expense sync merge", () => {
         editedTimestamp,
         amount: 42,
         description: "street food",
+        date: expenseDate,
         serverTimestamp: editedTimestamp + 1,
       }),
     ]);
@@ -50,6 +58,35 @@ describe("offline expense sync merge", () => {
     expect(state).toHaveLength(1);
     expect(state[0].id).toBe("server-generated-id");
     expect(state.map((expense) => expense.id)).not.toContain("local-offline-id");
+  });
+
+  it("does not reconcile two distinct expenses that share amount and timestamp but differ by date", () => {
+    const shared = {
+      editedTimestamp,
+      amount: 42,
+      description: "street food",
+    };
+    const offlineExpense = makeExpense({
+      id: "local-offline-id",
+      date: new Date("2026-01-10T12:00:00.000Z"),
+      ...shared,
+    });
+
+    let state = expensesReducer([], { type: "ADD", payload: offlineExpense });
+    state = mergeExpenseLists(state, [
+      makeExpense({
+        id: "server-generated-id",
+        date: new Date("2026-01-11T12:00:00.000Z"),
+        ...shared,
+        serverTimestamp: editedTimestamp + 1,
+      }),
+    ]);
+
+    expect(state).toHaveLength(2);
+    expect(state.map((expense) => expense.id).sort()).toEqual([
+      "local-offline-id",
+      "server-generated-id",
+    ]);
   });
 
   it("does not add a second row when add is called again with the same id", () => {

--- a/TravelCostApp/__tests__/util/offline-expense-sync-vertical.test.ts
+++ b/TravelCostApp/__tests__/util/offline-expense-sync-vertical.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Repro (#230): create expense offline → go online → sync/refresh → one ledger row.
+ * Vertical slice: offline ADD → queue upload (server id) → UPDATE_ID → MERGE from fetch.
+ */
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+}));
+
+jest.mock("@react-native-community/netinfo", () => ({
+  fetch: jest.fn(async () => ({ isConnected: true })),
+}));
+
+jest.mock("expo-device", () => ({
+  isDevice: true,
+}));
+
+jest.mock("../../util/connectionSpeed", () => ({
+  isConnectionFastEnough: jest.fn(async () => ({ isFastEnough: true })),
+}));
+
+jest.mock("../../util/http", () => ({
+  storeExpenseWithId: jest.fn(),
+  updateExpense: jest.fn(),
+  deleteExpense: jest.fn(),
+  touchAllTravelers: jest.fn(async () => {}),
+  unTouchTraveler: jest.fn(async () => {}),
+  getAllExpenses: jest.fn(),
+}));
+
+const mmkvStore: Record<string, unknown> = {};
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: {
+    OFFLINE_QUEUE: "offlineQueue",
+  },
+  getMMKVObject: jest.fn((key: string) => mmkvStore[key] ?? null),
+  setMMKVObject: jest.fn((key: string, value: unknown) => {
+    mmkvStore[key] = value;
+  }),
+}));
+
+import { fetchAndSetExpenses } from "../../components/ExpensesOutput/RecentExpensesUtil";
+import {
+  expensesReducer,
+  mergeExpenseLists,
+} from "../../store/expenses-context";
+import { MMKV_KEYS } from "../../store/mmkv";
+import { getAllExpenses, storeExpenseWithId } from "../../util/http";
+import { sendOfflineQueue } from "../../util/offline-queue";
+import { makeExpense } from "../fixtures/expense";
+
+describe("offline expense sync (#230)", () => {
+  const editedTimestamp = 1_700_000_000_000;
+  const expenseDate = new Date("2026-01-15T12:00:00.000Z");
+  const sharedFields = {
+    editedTimestamp,
+    amount: 42,
+    description: "street food",
+    date: expenseDate,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+  });
+
+  it("offline add → queue flush with new server id → fetch merge → one expense in list state", async () => {
+    const clientId = "local-offline-id";
+    const serverId = "server-generated-id";
+    const offlineExpense = makeExpense({ id: clientId, ...sharedFields });
+
+    let listState = expensesReducer([], { type: "ADD", payload: offlineExpense });
+
+    mmkvStore[MMKV_KEYS.OFFLINE_QUEUE] = [
+      {
+        type: "add",
+        expense: {
+          tripid: "trip-1",
+          uid: "u1",
+          expenseData: offlineExpense,
+        },
+      },
+    ];
+
+    (storeExpenseWithId as jest.Mock).mockResolvedValue(serverId);
+
+    const updateExpenseId = (oldId: string, newId: string) => {
+      listState = expensesReducer(listState, {
+        type: "UPDATE_ID",
+        payload: { oldId, newId },
+      });
+    };
+
+    await sendOfflineQueue(false, jest.fn(), { updateExpenseId });
+
+    const serverExpense = makeExpense({
+      id: serverId,
+      ...sharedFields,
+      serverTimestamp: editedTimestamp + 1,
+    });
+
+    (getAllExpenses as jest.Mock).mockResolvedValue([serverExpense]);
+
+    const mergeExpenses = jest.fn();
+    const tripCtx = { setTotalSum: jest.fn() };
+
+    await fetchAndSetExpenses(
+      false,
+      false,
+      jest.fn(),
+      jest.fn(),
+      {
+        expenses: listState,
+        mergeExpenses,
+        setIsSyncing: jest.fn(),
+      } as any,
+      "trip-1",
+      "u1",
+      tripCtx as any
+    );
+
+    expect(mergeExpenses).toHaveBeenCalledWith([serverExpense]);
+
+    const ledgerState = mergeExpenseLists(listState, [serverExpense]);
+    expect(ledgerState).toHaveLength(1);
+    expect(ledgerState[0].id).toBe(serverId);
+    expect(ledgerState.map((expense) => expense.id)).not.toContain(clientId);
+  });
+});

--- a/TravelCostApp/__tests__/util/offline-queue-sync.test.ts
+++ b/TravelCostApp/__tests__/util/offline-queue-sync.test.ts
@@ -1,0 +1,85 @@
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+}));
+
+jest.mock("@react-native-community/netinfo", () => ({
+  fetch: jest.fn(async () => ({ isConnected: true })),
+}));
+
+jest.mock("expo-device", () => ({
+  isDevice: true,
+}));
+
+jest.mock("../../util/connectionSpeed", () => ({
+  isConnectionFastEnough: jest.fn(async () => ({ isFastEnough: true })),
+}));
+
+jest.mock("../../util/http", () => ({
+  storeExpenseWithId: jest.fn(),
+  updateExpense: jest.fn(),
+  deleteExpense: jest.fn(),
+  touchAllTravelers: jest.fn(async () => {}),
+}));
+
+import { MMKV_KEYS } from "../../store/mmkv";
+import { makeExpense } from "../fixtures/expense";
+import { sendOfflineQueue } from "../../util/offline-queue";
+import { storeExpenseWithId } from "../../util/http";
+
+const mmkvStore: Record<string, unknown> = {};
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: {
+    OFFLINE_QUEUE: "offlineQueue",
+  },
+  getMMKVObject: jest.fn((key: string) => mmkvStore[key] ?? null),
+  setMMKVObject: jest.fn((key: string, value: unknown) => {
+    mmkvStore[key] = value;
+  }),
+}));
+
+describe("sendOfflineQueue", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+  });
+
+  it("uploads offline-created expenses with a stable client id and clears the queue", async () => {
+    const clientId = "offline-client-id";
+    const expenseData = makeExpense({
+      id: clientId,
+      editedTimestamp: 1_700_000_000_000,
+    });
+
+    mmkvStore[MMKV_KEYS.OFFLINE_QUEUE] = [
+      {
+        type: "add",
+        expense: {
+          tripid: "trip-1",
+          uid: "traveller-1",
+          expenseData,
+        },
+      },
+    ];
+
+    (storeExpenseWithId as jest.Mock).mockResolvedValue(clientId);
+
+    const updateExpenseId = jest.fn();
+    let mutex = false;
+    const setMutex = jest.fn((value: boolean) => {
+      mutex = value;
+    });
+
+    await sendOfflineQueue(mutex, setMutex, { updateExpenseId });
+
+    expect(storeExpenseWithId).toHaveBeenCalledWith(
+      "trip-1",
+      "traveller-1",
+      clientId,
+      expect.objectContaining({ id: clientId })
+    );
+    expect(updateExpenseId).not.toHaveBeenCalled();
+    expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toEqual([]);
+  });
+});

--- a/TravelCostApp/__tests__/util/offline-queue-sync.test.ts
+++ b/TravelCostApp/__tests__/util/offline-queue-sync.test.ts
@@ -82,4 +82,43 @@ describe("sendOfflineQueue", () => {
     expect(updateExpenseId).not.toHaveBeenCalled();
     expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toEqual([]);
   });
+
+  it("remaps the local expense id when the server returns a different id", async () => {
+    const clientId = "local-offline-id";
+    const serverId = "server-generated-id";
+    const expenseData = makeExpense({
+      id: clientId,
+      editedTimestamp: 1_700_000_000_000,
+    });
+
+    mmkvStore[MMKV_KEYS.OFFLINE_QUEUE] = [
+      {
+        type: "add",
+        expense: {
+          tripid: "trip-1",
+          uid: "traveller-1",
+          expenseData,
+        },
+      },
+    ];
+
+    (storeExpenseWithId as jest.Mock).mockResolvedValue(serverId);
+
+    const updateExpenseId = jest.fn();
+    let mutex = false;
+    const setMutex = jest.fn((value: boolean) => {
+      mutex = value;
+    });
+
+    await sendOfflineQueue(mutex, setMutex, { updateExpenseId });
+
+    expect(storeExpenseWithId).toHaveBeenCalledWith(
+      "trip-1",
+      "traveller-1",
+      clientId,
+      expect.objectContaining({ id: clientId })
+    );
+    expect(updateExpenseId).toHaveBeenCalledWith(clientId, serverId);
+    expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toEqual([]);
+  });
 });

--- a/TravelCostApp/components/ExpensesOutput/RecentExpensesUtil.ts
+++ b/TravelCostApp/components/ExpensesOutput/RecentExpensesUtil.ts
@@ -3,10 +3,12 @@ import { getAllExpenses, unTouchTraveler } from "../../util/http";
 import { i18n } from "../../i18n/i18n";
 
 import { getExpensesSum } from "../../util/expense";
-import { ExpenseContextType } from "../../store/expenses-context";
+import {
+  ExpenseContextType,
+  mergeExpenseLists,
+} from "../../store/expenses-context";
 import { TripContextType } from "../../store/trip-context";
 import safeLogError from "../../util/error";
-import uniqBy from "lodash.uniqby";
 
 export async function fetchAndSetExpenses(
   showRefIndicator: boolean,
@@ -38,15 +40,9 @@ export async function fetchAndSetExpenses(
     expenses = expenses.filter((expense) => !isNaN(Number(expense.calcAmount)));
 
     if (expenses && expenses?.length !== 0) {
-      // Use mergeExpenses instead of setExpenses to properly merge new expenses with existing ones
+      const mergedForSum = mergeExpenseLists(expensesCtx.expenses, expenses);
       expensesCtx.mergeExpenses(expenses);
-
-      // Calculate the total sum from all current expenses plus new ones
-      // This gives us the correct total for immediate display
-      const currentExpenses = expensesCtx.expenses;
-      const allExpenses = [...currentExpenses, ...expenses];
-      const uniqueExpenses = uniqBy(allExpenses, "id");
-      const expensesSum = getExpensesSum(uniqueExpenses);
+      const expensesSum = getExpensesSum(mergedForSum);
       tripCtx.setTotalSum(expensesSum);
 
       // Note: The merged expenses will be automatically saved to storage

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -100,22 +100,26 @@ function RecentExpenses({ navigation }) {
       const online = netCtx.isConnected && netCtx.strongConnection;
       const offlineQueue = getMMKVObject(MMKV_KEYS.OFFLINE_QUEUE);
       const queueBlocked = offlineQueue && offlineQueue?.length > 0;
-      if (!online || queueBlocked || userCtx.isSendingOfflineQueueMutex) {
-        // if online, send offline queue
-        if (online) {
-          await sendOfflineQueue(
-            userCtx.isSendingOfflineQueueMutex,
-            userCtx.setIsSendingOfflineQueueMutex,
-            { updateExpenseId: expensesCtx.updateExpenseId }
-          );
+
+      if (userCtx.isSendingOfflineQueueMutex) {
+        return;
+      }
+
+      if (!online) {
+        await expensesCtx.loadExpensesFromStorage();
+        return;
+      }
+
+      if (queueBlocked) {
+        await sendOfflineQueue(
+          userCtx.isSendingOfflineQueueMutex,
+          userCtx.setIsSendingOfflineQueueMutex,
+          { updateExpenseId: expensesCtx.updateExpenseId }
+        );
+        const queueAfterSync = getMMKVObject(MMKV_KEYS.OFFLINE_QUEUE) || [];
+        if (queueAfterSync.length > 0) {
           return;
         }
-        // if offline, load from storage
-        // setIsFetching(true);
-        // await test_offlineLoad(expensesCtx, setRefreshing, setIsFetching);
-        await expensesCtx.loadExpensesFromStorage();
-        // setIsFetching(false);
-        return;
       }
       // checking isTouched or firstLoad
       const isTouched =

--- a/TravelCostApp/store/expenses-context.tsx
+++ b/TravelCostApp/store/expenses-context.tsx
@@ -170,6 +170,8 @@ export const ExpensesContext = createContext<ExpenseContextType>({
   setIsSyncing: (syncing: boolean) => {},
 });
 
+// Fingerprint for offline-created rows vs server rows with different ids.
+// Keep uid, editedTimestamp, amount, description, and date in sync when changing matching.
 function findOfflineCreatedDuplicateIndex(
   expenses: ExpenseData[],
   incoming: ExpenseData
@@ -177,6 +179,7 @@ function findOfflineCreatedDuplicateIndex(
   if (!incoming.editedTimestamp) {
     return -1;
   }
+  const incomingDate = Number(new Date(incoming.date));
   return expenses.findIndex(
     (exp) =>
       !exp.isDeleted &&
@@ -184,7 +187,8 @@ function findOfflineCreatedDuplicateIndex(
       exp.uid === incoming.uid &&
       exp.editedTimestamp === incoming.editedTimestamp &&
       exp.amount === incoming.amount &&
-      exp.description === incoming.description
+      exp.description === incoming.description &&
+      Number(new Date(exp.date)) === incomingDate
   );
 }
 

--- a/TravelCostApp/store/expenses-context.tsx
+++ b/TravelCostApp/store/expenses-context.tsx
@@ -170,10 +170,40 @@ export const ExpensesContext = createContext<ExpenseContextType>({
   setIsSyncing: (syncing: boolean) => {},
 });
 
-function expensesReducer(state: ExpenseData[], action) {
+function findOfflineCreatedDuplicateIndex(
+  expenses: ExpenseData[],
+  incoming: ExpenseData
+): number {
+  if (!incoming.editedTimestamp) {
+    return -1;
+  }
+  return expenses.findIndex(
+    (exp) =>
+      !exp.isDeleted &&
+      exp.id !== incoming.id &&
+      exp.uid === incoming.uid &&
+      exp.editedTimestamp === incoming.editedTimestamp &&
+      exp.amount === incoming.amount &&
+      exp.description === incoming.description
+  );
+}
+
+export function mergeExpenseLists(
+  state: ExpenseData[],
+  newExpenses: ExpenseData[]
+): ExpenseData[] {
+  return expensesReducer(state, { type: "MERGE", payload: newExpenses });
+}
+
+export function expensesReducer(state: ExpenseData[], action) {
   switch (action.type) {
-    case "ADD":
+    case "ADD": {
+      const id = action.payload?.id;
+      if (id && state.some((expense) => expense.id === id)) {
+        return state;
+      }
       return [action.payload, ...state];
+    }
     case "SET": {
       const getSortedState = (data: ExpenseData[]) =>
         data.sort((a: ExpenseData, b: ExpenseData) => {
@@ -226,8 +256,15 @@ function expensesReducer(state: ExpenseData[], action) {
           }
           // If existing is newer or equal, keep existing (do nothing)
         } else {
-          // New expense, add it
-          mergedExpenses.push(newExpense);
+          const offlineDuplicateIndex = findOfflineCreatedDuplicateIndex(
+            mergedExpenses,
+            newExpense
+          );
+          if (offlineDuplicateIndex !== -1) {
+            mergedExpenses[offlineDuplicateIndex] = newExpense;
+          } else {
+            mergedExpenses.push(newExpense);
+          }
         }
       });
 


### PR DESCRIPTION
## Summary

- Reconcile server-fetched expenses with offline-created rows when sync used a different expense id (match on `uid`, `editedTimestamp`, `amount`, `description`, and `date`).
- After the offline queue flushes successfully, continue into the normal fetch path on Recent Expenses instead of returning early.
- Compute trip totals from the same merge logic used by context state so totals are not double-counted after sync.
- Add regression tests for reducer merge, offline queue id remap, vertical offline→sync→fetch flow, and Recent Expenses post-flush fetch.

Fixes #230

## Repro (#230)

1. Open a trip while **offline** (airplane mode or dev force-offline).
2. **Add** an expense on Recent Expenses (or Manage Expense) and confirm it appears once locally.
3. Go **online** with a stable connection; open Recent Expenses or pull to refresh so the offline queue flushes and expenses fetch.
4. **Expected:** one ledger row per expense; trip total and split summary not double-counted.

## Test plan

- [x] `pnpm test` — `expenses-reducer-offline-sync.test.ts`, `offline-queue-sync.test.ts`, `offline-expense-sync-vertical.test.ts`, `recent-expenses-screen.test.ts`
- [ ] Manual repro above: offline create → online → sync/refresh → single ledger row
- [ ] Manual: trip total and split summary not double-counted after sync (code path uses `mergeExpenseLists` for totals; verify on device)
- [ ] Manual: ranged expenses still count once per period after sync
- [ ] Manual: online-only create/update/delete still work