### PR TITLE
Fix Hermes crash in Highcharts WebView chart payload

### DIFF
--- a/TravelCostApp/__tests__/components/chart-helpers.test.ts
+++ b/TravelCostApp/__tests__/components/chart-helpers.test.ts
@@ -1,5 +1,6 @@
 import {
   createBarChartData,
+  createPieChartData,
   formatDataForHighcharts,
 } from "../../components/charts/chartHelpers";
 
@@ -57,5 +58,35 @@ describe("Highcharts column point payload", () => {
     expect(point.color).toBe("#00aa00");
     expect(point).not.toHaveProperty("originalData");
     expect(Object.keys(point).sort()).toEqual(["color", "x", "y"]);
+  });
+});
+
+describe("Highcharts pie point payload", () => {
+  it("createPieChartData omits originalData and only serializes name, y, and color", () => {
+    const chartData = [
+      {
+        x: "Food 42 EUR",
+        y: 42,
+        color: "#ff0000",
+        originalData: {
+          categoryId: "food",
+          expensesSum: 42,
+        },
+      },
+    ];
+
+    const series = createPieChartData(chartData) as Array<{
+      data: Array<Record<string, unknown>>;
+    }>;
+
+    const point = series[0].data[0];
+
+    expect(point).toEqual({
+      name: 'Food<br/><span style="white-space: nowrap;">42 EUR</span>',
+      y: 42,
+      color: "#ff0000",
+    });
+    expect(point).not.toHaveProperty("originalData");
+    expect(Object.keys(point).sort()).toEqual(["color", "name", "y"]);
   });
 });

--- a/TravelCostApp/__tests__/components/chart-helpers.test.ts
+++ b/TravelCostApp/__tests__/components/chart-helpers.test.ts
@@ -1,0 +1,61 @@
+import {
+  createBarChartData,
+  formatDataForHighcharts,
+} from "../../components/charts/chartHelpers";
+
+describe("Highcharts column point payload", () => {
+  it("createBarChartData omits originalData from points sent to the WebView", () => {
+    const chartData = [
+      {
+        x: "2026-01-15",
+        y: 42,
+        color: "#00aa00",
+        label: "15 Jan",
+        originalData: {
+          day: "2026-01-15",
+          expensesSum: 42,
+          dailyBudget: 50,
+        },
+      },
+    ];
+
+    const series = createBarChartData(chartData, {
+      primary: "#111",
+      error: "#f00",
+      budget: "#999",
+    }) as Array<{ data: Array<Record<string, unknown>> }>;
+
+    const point = series[0].data[0];
+
+    expect(point).toEqual({
+      x: "2026-01-15",
+      y: 42,
+      color: "#00aa00",
+      label: "15 Jan",
+    });
+    expect(point).not.toHaveProperty("originalData");
+  });
+
+  it("formatDataForHighcharts omits originalData and converts x when dateFormat is enabled", () => {
+    const chartData = [
+      {
+        x: "2026-01-15",
+        y: 10,
+        color: "#00aa00",
+        originalData: { expensesSum: 10 },
+      },
+    ];
+
+    const series = formatDataForHighcharts(chartData, {
+      dateFormat: true,
+    }) as Array<{ data: Array<Record<string, unknown>> }>;
+
+    const point = series[0].data[0];
+
+    expect(point.x).toBe(new Date("2026-01-15").getTime());
+    expect(point.y).toBe(10);
+    expect(point.color).toBe("#00aa00");
+    expect(point).not.toHaveProperty("originalData");
+    expect(Object.keys(point).sort()).toEqual(["color", "x", "y"]);
+  });
+});

--- a/TravelCostApp/components/charts/chartHelpers.ts
+++ b/TravelCostApp/components/charts/chartHelpers.ts
@@ -222,6 +222,28 @@ export const generateHTMLTemplate = (
   `;
 };
 
+const toColumnPoint = (
+  item: ChartData,
+  color?: string
+): { x: string | number; y: number; color?: string; label?: string } => {
+  const point: {
+    x: string | number;
+    y: number;
+    color?: string;
+    label?: string;
+  } = {
+    x: item.x,
+    y: item.y,
+    color: color ?? item.color,
+  };
+
+  if (item.label != null) {
+    point.label = item.label;
+  }
+
+  return point;
+};
+
 export const formatDataForHighcharts = (
   data: ChartData[],
   options: ChartOptions = {}
@@ -247,12 +269,17 @@ export const formatDataForHighcharts = (
   return [
     {
       name: "Series 1",
-      data: data.map((item) => ({
-        x: options.dateFormat ? new Date(item.x).getTime() : item.x,
-        y: item.y,
-        color: item.color,
-        ...item,
-      })),
+      data: data.map((item) =>
+        toColumnPoint(
+          {
+            x: options.dateFormat ? new Date(item.x).getTime() : item.x,
+            y: item.y,
+            color: item.color,
+            label: item.label,
+          },
+          item.color
+        )
+      ),
       color: options.colors?.[0],
     },
   ];
@@ -267,12 +294,9 @@ export const createBarChartData = (
   series.push({
     name: "Expenses",
     type: "column",
-    data: data.map((item) => ({
-      x: item.x,
-      y: item.y,
-      color: item.color || colors?.primary,
-      ...item,
-    })),
+    data: data.map((item) =>
+      toColumnPoint(item, item.color || colors?.primary)
+    ),
     animation: {
       duration: 1000,
     },

--- a/TravelCostApp/components/charts/chartHelpers.ts
+++ b/TravelCostApp/components/charts/chartHelpers.ts
@@ -244,6 +244,7 @@ const toColumnPoint = (
   return point;
 };
 
+/** Generic formatter; not used by production callers today. Overview column charts use createBarChartData. */
 export const formatDataForHighcharts = (
   data: ChartData[],
   options: ChartOptions = {}
@@ -285,6 +286,7 @@ export const formatDataForHighcharts = (
   ];
 };
 
+/** Overview expense column chart path (ExpenseChart). Prefer this over formatDataForHighcharts for column data. */
 export const createBarChartData = (
   data: ChartData[],
   colors?: { primary: string; error: string; budget: string }


### PR DESCRIPTION
## Summary

- Fixes [#228](https://github.com/HaDuve/TravelCostNative/issues/228): Hermes crash `Property storage exceeds 196607 properties` when opening the Overview expense graph.
- Replaces `...item` spreading in column/bar Highcharts point shaping with explicit `{ x, y, color, label? }` via `toColumnPoint()`.
- Adds unit tests ensuring `originalData` and other extra fields are not included in the WebView series payload.

## Root cause

`ChartController` attaches `originalData` to each `ChartData` item. `createBarChartData` and `formatDataForHighcharts` spread the full item into Highcharts points, copying large nested objects into the WebView payload and risking Hermes' property limit.

## Test plan

- [x] `pnpm test __tests__/components/chart-helpers.test.ts`
- [x] Full Jest suite passes
- [ ] Manual: open Overview graph on Hermes (device/simulator)
- [ ] Toggle day / week / month / year — bars render, no crash
- [ ] Category pie chart still renders