### PR TITLE
fix: lazy bottom tabs to reduce WebView memory on large trips

### DIFF
--- a/TravelCostApp/App.tsx
+++ b/TravelCostApp/App.tsx
@@ -8,7 +8,11 @@ import {
 import Purchases from "react-native-purchases";
 
 import { StatusBar } from "expo-status-bar";
-import { NavigationContainer, useNavigation } from "@react-navigation/native";
+import {
+  NavigationContainer,
+  useIsFocused,
+  useNavigation,
+} from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as SplashScreen from "expo-splash-screen";
@@ -110,6 +114,15 @@ const AuthStack = createNativeStackNavigator();
 const BottomTabs = createBottomTabNavigator();
 
 const IconSize = constantScale(24, 0.1);
+
+/** Tear down tab content when blurred (RN7 replacement for removed unmountOnBlur). */
+function UnmountOnBlur({ children }: { children: React.ReactNode }) {
+  const isFocused = useIsFocused();
+  if (!isFocused) {
+    return null;
+  }
+  return <>{children}</>;
+}
 
 const prefix = Linking.createURL("/");
 
@@ -405,8 +418,8 @@ function Home() {
       safeAreaInsets={{ bottom: 0 }}
       screenOptions={{
         headerShown: false,
-          lazy: true,
-          tabBarStyle: {
+        lazy: true,
+        tabBarStyle: {
           backgroundColor: GlobalStyles.colors.gray500,
           borderTopWidth: dynamicScale(1, false, 0.5),
           borderTopColor: GlobalStyles.colors.gray600,
@@ -431,6 +444,7 @@ function Home() {
       <BottomTabs.Screen
         name="Overview"
         component={OverviewScreen}
+        layout={({ children }) => <UnmountOnBlur>{children}</UnmountOnBlur>}
         options={{
           tabBarShowLabel: false,
           title: i18n.t("overviewTab"),

--- a/TravelCostApp/App.tsx
+++ b/TravelCostApp/App.tsx
@@ -10,7 +10,7 @@ import Purchases from "react-native-purchases";
 import { StatusBar } from "expo-status-bar";
 import { NavigationContainer, useNavigation } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as SplashScreen from "expo-splash-screen";
 import { shouldShowOnboarding } from "./components/Rating/firstStartUtil";
 
@@ -102,13 +102,12 @@ import {
   VexoUserContext,
 } from "./util/vexo-tracking";
 import { VexoEvents } from "./util/vexo-constants";
-
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
 
 const Stack = createNativeStackNavigator();
 const AuthStack = createNativeStackNavigator();
-const BottomTabs = createMaterialTopTabNavigator();
+const BottomTabs = createBottomTabNavigator();
 
 const IconSize = constantScale(24, 0.1);
 
@@ -394,27 +393,28 @@ function Home() {
     (exp: ExpenseData) => exp.splitList?.length > 0
   );
   const validSplitSummary = hasExp && hasExpensesWithSplit;
+
+  // SafeAreaWrapper paints bottom inset via BottomInset — don't pad tab bar again.
+  const homeTabBarHeight = dynamicScale(48, false, 0.5);
+
   return (
     <BottomTabs.Navigator
       initialRouteName={FirstScreen}
       backBehavior={"history"}
-      tabBarPosition={"bottom"}
-      screenOptions={() => ({
-        headerStyle: { backgroundColor: GlobalStyles.colors.primary500 },
-        headerTintColor: GlobalStyles.colors.backgroundColor,
-        tabBarStyle: {
+      detachInactiveScreens={true}
+      safeAreaInsets={{ bottom: 0 }}
+      screenOptions={{
+        headerShown: false,
+          lazy: true,
+          tabBarStyle: {
           backgroundColor: GlobalStyles.colors.gray500,
           borderTopWidth: dynamicScale(1, false, 0.5),
           borderTopColor: GlobalStyles.colors.gray600,
+          height: homeTabBarHeight,
+          paddingBottom: 0,
         },
         tabBarActiveTintColor: GlobalStyles.colors.primary500,
-        tabBarIndicatorStyle: {
-          backgroundColor: GlobalStyles.colors.primary500,
-          borderWidth: dynamicScale(1, true, 0.5),
-          borderColor: GlobalStyles.colors.primary500,
-        },
-        tabBarBounces: true,
-      })}
+      }}
     >
       <BottomTabs.Screen
         name="RecentExpenses"
@@ -427,20 +427,6 @@ function Home() {
           ),
         }}
       />
-      {/* DEBUG for push notifications */}
-      {/* <BottomTabs.Screen
-        name="Push"
-        component={PushScreen}
-        options={{
-          // headerShown: false,
-          tabBarShowLabel: false,
-          title: i18n.t("overviewTab"),
-          tabBarLabel: "Push",
-          tabBarIcon: ({ color }) => (
-            <Ionicons name={"push"} size={IconSize} color={color} />
-          ),
-        }}
-      ></BottomTabs.Screen> */}
 
       <BottomTabs.Screen
         name="Overview"
@@ -465,7 +451,6 @@ function Home() {
           options={{
             title: i18n.t("settingsTab"),
             tabBarShowLabel: false,
-
             tabBarLabel: i18n.t("finderTab"),
             tabBarIcon: ({ color }) => (
               <Ionicons name="search-outline" size={IconSize} color={color} />
@@ -480,7 +465,6 @@ function Home() {
           options={{
             title: i18n.t("settingsTab"),
             tabBarShowLabel: false,
-
             tabBarLabel: i18n.t("financialTab"),
             tabBarIcon: ({ color }) => (
               <Ionicons name="cash-outline" size={IconSize} color={color} />
@@ -494,7 +478,6 @@ function Home() {
         options={{
           title: i18n.t("profileTab"),
           tabBarShowLabel: false,
-
           tabBarLabel: i18n.t("myTrips"),
           tabBarIcon: ({ color }) => (
             <View>

--- a/TravelCostApp/components/ExpensesOutput/ExpensesOverview.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesOverview.tsx
@@ -1,5 +1,5 @@
-import { Platform, StyleSheet, Text, View } from "react-native";
-import React, { useContext, useRef, useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import React, { useCallback, useContext, useRef, useState } from "react";
 import ExpenseCategories from "./ExpenseStatistics/ExpenseCategories";
 import ExpenseGraph from "./ExpenseStatistics/ExpenseGraph";
 import { GlobalStyles } from "../../constants/styles";
@@ -11,36 +11,59 @@ import PropTypes from "prop-types";
 import ExpenseCountries from "./ExpenseStatistics/ExpenseCountries";
 import ExpenseTravellers from "./ExpenseStatistics/ExpenseTravellers";
 import ExpenseCurrencies from "./ExpenseStatistics/ExpenseCurrencies";
-import Animated, { FadeInUp, FadeOutDown } from "react-native-reanimated";
-import { MAX_PERIOD_RANGE } from "../../confAppConstants";
-import { BlurView } from "expo-blur";
+import Animated, {
+  FadeInLeft,
+  FadeInRight,
+  FadeInUp,
+  FadeOutDown,
+  FadeOutLeft,
+  FadeOutRight,
+} from "react-native-reanimated";
 import { TripContext } from "../../store/trip-context";
-import { constantScale, dynamicScale } from "../../util/scalingUtil";
-import { OrientationContext } from "../../store/orientation-context";
+import { dynamicScale } from "../../util/scalingUtil";
 import { useSwipe } from "../Hooks/useSwipe";
+import IconButton from "../UI/IconButton";
+
+const PIE_CHART_TYPE_COUNT = 4;
 
 const ExpensesOverview = ({ navigation, expenses, periodName }) => {
   const tripCtx = useContext(TripContext);
-  const { isPortrait } = useContext(OrientationContext);
-  // const periodRangeNumber = useRef(7);
-  // periodRangeNumber useState is used to rerender the component when the periodRangeNumber changes
+  const pieChartTitles = [
+    i18n.t("categories"),
+    i18n.t("travellers"),
+    i18n.t("countries"),
+    i18n.t("currencies"),
+  ];
   const realPeriodNumber = useRef(7);
-  const [periodRangeNumber, setPeriodRangeNumber] = useState(
-    realPeriodNumber.current
-  );
-
-  const { onTouchStart, onTouchEnd } = useSwipe(onSwipeLeft, onSwipeRight, 6);
-
-  function onSwipeLeft() {}
-
-  function onSwipeRight() {}
+  const [periodRangeNumber] = useState(realPeriodNumber.current);
 
   const userCtx = useContext(UserContext);
   const isGraphNotPie = userCtx.isShowingGraph;
-  // enum =>  0 = categories, 1 = traveller, 2 = country, 3 = currency
   const [toggleGraphEnum, setToggleGraphEnum] = useState(0);
-  const [longerPeriodNum, setLongerPeriodNum] = useState(0);
-  const [startingPoint, setStartingPoint] = useState(0);
+  const [longerPeriodNum] = useState(0);
+  const [startingPoint] = useState(0);
+
+  const contentsMaxIndex = PIE_CHART_TYPE_COUNT - 1;
+
+  const nextPieChartType = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setToggleGraphEnum((current) =>
+      current === contentsMaxIndex ? 0 : current + 1
+    );
+  }, [contentsMaxIndex]);
+
+  const previousPieChartType = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setToggleGraphEnum((current) =>
+      current === 0 ? contentsMaxIndex : current - 1
+    );
+  }, [contentsMaxIndex]);
+
+  const { onTouchStart, onTouchEnd } = useSwipe(
+    nextPieChartType,
+    previousPieChartType,
+    6
+  );
 
   let titleString = "";
   switch (periodName) {
@@ -54,38 +77,47 @@ const ExpensesOverview = ({ navigation, expenses, periodName }) => {
       break;
   }
 
-  const titleContainerJSX = (
-    <View style={styles.titleContainerBlur}>
-      {isGraphNotPie && (
-        <Animated.View
-          style={styles.titleContainer}
-          entering={FadeInUp}
-          exiting={FadeOutDown}
-        >
-          <Text style={styles.titleText}> {titleString} </Text>
-        </Animated.View>
-      )}
-
-      {!isGraphNotPie && toggleGraphEnum == 0 && (
-        <Animated.View entering={FadeInUp} exiting={FadeOutDown}>
-          <Text style={styles.titleText}> {i18n.t("categories")} </Text>
-        </Animated.View>
-      )}
-      {!isGraphNotPie && toggleGraphEnum == 1 && (
-        <Animated.View entering={FadeInUp} exiting={FadeOutDown}>
-          <Text style={styles.titleText}> {i18n.t("travellers")} </Text>
-        </Animated.View>
-      )}
-      {!isGraphNotPie && toggleGraphEnum == 2 && (
-        <Animated.View entering={FadeInUp} exiting={FadeOutDown}>
-          <Text style={styles.titleText}> {i18n.t("countries")} </Text>
-        </Animated.View>
-      )}
-      {!isGraphNotPie && toggleGraphEnum == 3 && (
-        <Animated.View entering={FadeInUp} exiting={FadeOutDown}>
-          <Text style={styles.titleText}> {i18n.t("currencies")} </Text>
-        </Animated.View>
-      )}
+  const chartTitleHeader = isGraphNotPie ? (
+    <View style={styles.chartTitleHeader}>
+      <Animated.View
+        style={styles.titleContainer}
+        entering={FadeInUp}
+        exiting={FadeOutDown}
+      >
+        <Text style={styles.titleText}>{titleString}</Text>
+      </Animated.View>
+    </View>
+  ) : (
+    <View style={styles.chartTitleHeader}>
+      <Animated.View
+        entering={FadeInLeft}
+        exiting={FadeOutLeft}
+        style={styles.chevronContainer}
+      >
+        <IconButton
+          icon={"chevron-back-outline"}
+          size={24}
+          onPress={previousPieChartType}
+          color={GlobalStyles.colors.primaryGrayed}
+        />
+      </Animated.View>
+      <Animated.View entering={FadeInUp} exiting={FadeOutDown}>
+        <Text style={styles.titleText}>
+          {pieChartTitles[toggleGraphEnum]}
+        </Text>
+      </Animated.View>
+      <Animated.View
+        entering={FadeInRight}
+        exiting={FadeOutRight}
+        style={styles.chevronContainer}
+      >
+        <IconButton
+          icon={"chevron-forward-outline"}
+          size={24}
+          onPress={nextPieChartType}
+          color={GlobalStyles.colors.primaryGrayed}
+        />
+      </Animated.View>
     </View>
   );
 
@@ -95,44 +127,46 @@ const ExpensesOverview = ({ navigation, expenses, periodName }) => {
       onTouchEnd={onTouchEnd}
       style={styles.container}
     >
-      {isGraphNotPie && (
-        <ExpenseGraph
-          navigation={navigation}
-          periodName={periodName}
-          tripCtx={tripCtx}
-          longerPeriodNum={longerPeriodNum}
-          startingPoint={startingPoint}
-        />
-      )}
-      {!isGraphNotPie && toggleGraphEnum == 0 && (
-        <ExpenseCategories
-          expenses={expenses}
-          periodName={periodName}
-          navigation={navigation}
-        />
-      )}
-      {!isGraphNotPie && toggleGraphEnum == 1 && (
-        <ExpenseTravellers
-          expenses={expenses}
-          periodName={periodName}
-          navigation={navigation}
-        ></ExpenseTravellers>
-      )}
-      {!isGraphNotPie && toggleGraphEnum == 2 && (
-        <ExpenseCountries
-          expenses={expenses}
-          periodName={periodName}
-          navigation={navigation}
-        ></ExpenseCountries>
-      )}
-      {!isGraphNotPie && toggleGraphEnum == 3 && (
-        <ExpenseCurrencies
-          expenses={expenses}
-          periodName={periodName}
-          navigation={navigation}
-        ></ExpenseCurrencies>
-      )}
-      {titleContainerJSX}
+      {chartTitleHeader}
+      <View style={styles.chartBody}>
+        {isGraphNotPie && (
+          <ExpenseGraph
+            navigation={navigation}
+            periodName={periodName}
+            tripCtx={tripCtx}
+            longerPeriodNum={longerPeriodNum}
+            startingPoint={startingPoint}
+          />
+        )}
+        {!isGraphNotPie && toggleGraphEnum == 0 && (
+          <ExpenseCategories
+            expenses={expenses}
+            periodName={periodName}
+            navigation={navigation}
+          />
+        )}
+        {!isGraphNotPie && toggleGraphEnum == 1 && (
+          <ExpenseTravellers
+            expenses={expenses}
+            periodName={periodName}
+            navigation={navigation}
+          />
+        )}
+        {!isGraphNotPie && toggleGraphEnum == 2 && (
+          <ExpenseCountries
+            expenses={expenses}
+            periodName={periodName}
+            navigation={navigation}
+          />
+        )}
+        {!isGraphNotPie && toggleGraphEnum == 3 && (
+          <ExpenseCurrencies
+            expenses={expenses}
+            periodName={periodName}
+            navigation={navigation}
+          />
+        )}
+      </View>
     </View>
   );
 };
@@ -160,19 +194,29 @@ const styles = StyleSheet.create({
     flex: 1,
     overflow: "visible",
   },
-  titleContainerBlur: {
-    marginTop: dynamicScale(8, true, 0.5),
-    alignSelf: "center",
-    position: "absolute",
-    width: "50%",
+  chartTitleHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 10,
+    elevation: 10,
+    backgroundColor: GlobalStyles.colors.backgroundColor,
+    paddingTop: dynamicScale(4, true),
+    paddingBottom: dynamicScale(4, true),
+  },
+  chartBody: {
+    flex: 1,
   },
   titleContainer: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
   },
+  chevronContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
   titleText: {
-    marginTop: dynamicScale(6, true),
     minWidth: dynamicScale(200),
     maxWidth: dynamicScale(200),
     textAlign: "center",
@@ -180,6 +224,6 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
     fontStyle: "italic",
     color: GlobalStyles.colors.gray700,
-    marginLeft: dynamicScale(6),
+    marginHorizontal: dynamicScale(6),
   },
 });

--- a/TravelCostApp/package.json
+++ b/TravelCostApp/package.json
@@ -55,7 +55,6 @@
     "@react-navigation/bottom-tabs": "^7.0.14",
     "@react-navigation/core": "6.4.10",
     "@react-navigation/elements": "2.0.4",
-    "@react-navigation/material-top-tabs": "^7.0.18",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.0.4",
     "axios": "^0.27.2",

--- a/TravelCostApp/pnpm-lock.yaml
+++ b/TravelCostApp/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       '@react-navigation/elements':
         specifier: 2.0.4
         version: 2.0.4(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@react-navigation/material-top-tabs':
-        specifier: ^7.0.18
-        version: 7.3.7(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-pager-view@6.7.1(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@react-navigation/native':
         specifier: ^7.1.17
         version: 7.1.17(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -1575,15 +1572,6 @@ packages:
     peerDependenciesMeta:
       '@react-native-masked-view/masked-view':
         optional: true
-
-  '@react-navigation/material-top-tabs@7.3.7':
-    resolution: {integrity: sha512-lVgcJON9kqCETE628/E5da0jbSB1QxHdYaKetxAIEFCgcANebcg1wU80P2B3PBFp2qRrLfrPS9oHTUfaUIjLSA==}
-    peerDependencies:
-      '@react-navigation/native': ^7.1.17
-      react: '>= 18.2.0'
-      react-native: '*'
-      react-native-pager-view: '>= 6.0.0'
-      react-native-safe-area-context: '>= 4.0.0'
 
   '@react-navigation/native-stack@7.3.26':
     resolution: {integrity: sha512-EjaBWzLZ76HJGOOcWCFf+h/M+Zg7M1RalYioDOb6ZdXHz7AwYNidruT3OUAQgSzg3gVLqvu5OYO0jFsNDPCZxQ==}
@@ -4951,13 +4939,6 @@ packages:
       react-native: '*'
       react-native-pager-view: '*'
 
-  react-native-tab-view@4.1.3:
-    resolution: {integrity: sha512-COj2HBeM4IqKCAadUdZAUWrFyO8++wlgObsgOt6xrwqdEnu9HX/74uesC0MGlgwIalFffXqTh5F3CC3pUjFPug==}
-    peerDependencies:
-      react: '>= 18.2.0'
-      react-native: '*'
-      react-native-pager-view: '>= 6.0.0'
-
   react-native-toast-message@2.3.3:
     resolution: {integrity: sha512-4IIUHwUPvKHu4gjD0Vj2aGQzqPATiblL1ey8tOqsxOWRPGGu52iIbL8M/mCz4uyqecvPdIcMY38AfwRuUADfQQ==}
     peerDependencies:
@@ -8060,19 +8041,6 @@ snapshots:
       react-native-safe-area-context: 5.4.0(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       use-latest-callback: 0.2.4(react@19.0.0)
       use-sync-external-store: 1.5.0(react@19.0.0)
-
-  '@react-navigation/material-top-tabs@7.3.7(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-pager-view@6.7.1(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@react-navigation/elements': 2.6.4(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@react-navigation/native': 7.1.17(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      color: 4.2.3
-      react: 19.0.0
-      react-native: 0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0)
-      react-native-pager-view: 6.7.1(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.4.0(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native-tab-view: 4.1.3(react-native-pager-view@6.7.1(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - '@react-native-masked-view/masked-view'
 
   '@react-navigation/native-stack@7.3.26(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-screens@4.11.1(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -12237,13 +12205,6 @@ snapshots:
       react-native: 0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0)
       react-native-pager-view: 6.7.1(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       use-latest-callback: 0.1.11(react@19.0.0)
-
-  react-native-tab-view@4.1.3(react-native-pager-view@6.7.1(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
-    dependencies:
-      react: 19.0.0
-      react-native: 0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0)
-      react-native-pager-view: 6.7.1(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      use-latest-callback: 0.2.4(react@19.0.0)
 
   react-native-toast-message@2.3.3(react-native@0.79.5(@babel/core@7.28.4)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
## Summary

- Replaces `createMaterialTopTabNavigator` with `@react-navigation/bottom-tabs` using `lazy: true` and `detachInactiveScreens={true}` so Highcharts WebViews on Overview are not mounted until the user opens that tab
- Restores pie-chart navigation header (chevrons + swipe) in `ExpensesOverview` so chart controls stay above WebViews after faster mount
- Prototype validated: large trips went from ~4fps / ~1.2GB RAM to >50fps / <400MB

Closes #233

## Test plan

- [x] Launch app on a large trip — stay on Recent Expenses; confirm smooth FPS and RAM stays low before visiting Overview
- [x] Open Overview (pie and bar chart modes); confirm charts render and pie chevrons/swipe cycle categories → travellers → countries → currencies
- [x] Leave Overview and return to Recent Expenses; confirm performance remains acceptable
- [x] Verify bottom tab bar height and safe-area inset (icons + gray strip) match expectations
- [x] Smoke-test Finder, Financial (if splits exist), and Profile tabs