### PR TITLE
docs: wire CONTEXT.md into project guidance (#220)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# TravelCostNative
+
+Monorepo root; application code lives in [`TravelCostApp/`](TravelCostApp/).
+
+Use domain terms from the glossary in [TravelCostApp/CONTEXT.md](TravelCostApp/CONTEXT.md) when naming, documenting, or discussing trip expenses, splits, balances, and settlements.

--- a/TravelCostApp/.gitignore
+++ b/TravelCostApp/.gitignore
@@ -14,9 +14,6 @@ web-build/
 .env*
 settings.json
 
-# claude
-CLAUDE.md
-
 # credentials
 credentials.json
 database-overview.md

--- a/TravelCostApp/CLAUDE.md
+++ b/TravelCostApp/CLAUDE.md
@@ -1,0 +1,12 @@
+# TravelCostApp
+
+App code for Budget For Nomads (React Native / Expo). Run commands from this directory (`pnpm install`, `pnpm test`).
+
+## Domain language
+
+Use domain terms from the glossary in [CONTEXT.md](./CONTEXT.md) in code comments, tests, PR text, and user-facing copy when you touch those concepts.
+
+## Further reading
+
+- [docs/testing.md](./docs/testing.md) — Jest playbook (also points at CONTEXT.md)
+- [docs/package-manager.md](./docs/package-manager.md) — pnpm only

--- a/TravelCostApp/CONTEXT.md
+++ b/TravelCostApp/CONTEXT.md
@@ -4,9 +4,7 @@ Shared travel expense tracking for groups: one trip holds expenses, budgets, tra
 
 ## Language
 
-**Trip**:
-The shared container where a group tracks travel spending together — expenses, travellers, budgets, and splits all belong to one trip.
-_Avoid_: Trip budget (as a noun for the container), journey, group ledger
+### People
 
 **User**:
 A person with a signed-in app account (authentication identity). Users can create trips, join trips, and hold trip history — but merely having an account does not put them on any trip roster.
@@ -16,6 +14,12 @@ _Avoid_: Account (in domain speech), member
 A User who appears on a specific trip’s roster. Every Traveller is a User; joining or creating a trip is what makes someone a Traveller for that trip. A User who has not completed onboarding or has not joined a trip is not a Traveller.
 _Avoid_: Member, participant, user (when you mean someone on the trip roster)
 
+### Trips
+
+**Trip**:
+The shared container where a group tracks travel spending together — expenses, travellers, budgets, and splits all belong to one trip.
+_Avoid_: Trip budget (as a noun for the container), journey, group ledger
+
 **Active trip**:
 The trip a User has selected for day-to-day use — adding expenses, viewing the ledger, and seeing trip-level summaries. A User may belong to many trips but only one is active at a time.
 _Avoid_: Current trip (implementation alias only), open trip
@@ -23,6 +27,8 @@ _Avoid_: Current trip (implementation alias only), open trip
 **Trip history**:
 All trips a User can open (shown as “My Trips”) — not only past trips; includes current and future-dated trips. One is the **Active trip**.
 _Avoid_: History (alone — implies completed trips only)
+
+### Expenses
 
 **Expense**:
 A recorded cost on a trip — amount, when it applies, category, who paid, and how it is shared among travellers.
@@ -35,6 +41,12 @@ _Avoid_: Long-term expense (UI copy only), grouped expenses (implementation grou
 **Deleted expense**:
 An expense removed from the trip — it no longer appears in the ledger, budgets, splits, or summaries. Users treat it as gone; it is not shown again unless restored (if that capability is added later).
 _Avoid_: Removed expense, archived expense
+
+**Special expense**:
+An expense flagged to stay off budget charts and spending summaries when the viewer hides special expenses. It is still a normal **Expense** for **Splits** and **Balances** — included in split calculations and visible on split summaries like any other expense.
+_Avoid_: Private expense, excluded expense
+
+### Money flow
 
 **Split**:
 How an expense’s cost is divided among travellers on that expense (equal, exact amount, percent, or self).
@@ -68,6 +80,8 @@ _Avoid_: Split up (UI copy)
 Repeating a **Ranged expense**’s full amount on each day in its date span (multiply per day), as opposed to **Ranged split**.
 _Avoid_: Duplicate (alone — ambiguous), multiply (UI copy)
 
+### Budget
+
 **Budget**:
 A spending target on a trip. Qualifiers name the shape: **total budget** (whole trip), **daily budget** (per calendar day), and **dynamic daily budget** (recalculated daily target — see below).
 _Avoid_: Spending limit, trip budget (as the trip container)
@@ -83,9 +97,7 @@ The spending target for a single calendar day. The day is **over daily budget** 
 A mode where the daily budget target is recalculated from remaining total budget and remaining trip days (e.g. after €1,200 spent with €1,800 left over 20 days, the target becomes ~€90/day). When enabled, “over daily budget” uses the current recalculated target, not necessarily the original figure entered at trip setup.
 _Avoid_: Automatic budget (vague)
 
-**Special expense**:
-An expense flagged to stay off budget charts and spending summaries when the viewer hides special expenses. It is still a normal **Expense** for **Splits** and **Balances** — included in split calculations and visible on split summaries like any other expense.
-_Avoid_: Private expense, excluded expense
+### Currency
 
 **Trip currency**:
 The currency a traveller lives with at home — where their money comes from — used as the trip’s reference for budgets, totals, and balances. It is **not** the currency of the country being visited; expenses abroad may be logged in other currencies and understood in trip currency for rollups.
@@ -94,6 +106,18 @@ _Avoid_: Base currency (ambiguous), local currency, destination currency
 **Expense currency**:
 The currency in which an expense was entered (e.g. cash spent in Japan). May differ from **Trip currency**; the app converts for trip-level totals.
 _Avoid_: Foreign currency (implies trip currency is always “foreign”)
+
+## Flagged ambiguities
+
+Places where English UI copy or code identifiers still diverge from domain language above. Prefer domain terms in new work; align i18n and labels incrementally.
+
+| Surface | Current wording / field | Domain term | Notes |
+| ------- | ----------------------- | ----------- | ----- |
+| Trip setup (i18n) | “Base Currency” (`selectCurrencyAlert`, related strings) | **Trip currency** | “Base” suggests destination or accounting base; domain term is the traveller’s home reference currency for the trip. |
+| Expense / trip models | `isPaid`, `isPaidTimestamp` | **Paid back**, **Settlement** (trip-wide) | `isPaid` is per-expense paid-back status; trip `isPaid` + timestamp drive trip-wide **Settlement**. |
+| Split Summary UI (i18n) | “open splits”, “Calculate open splits”, “No open splits” | **Balance** | Rolled-up amounts travellers owe each other, not “splits” as allocation mode. |
+| Split Summary UI (i18n) | “settle splits”, “Could not settle splits” | **Settlement** | Trip-wide clearing of balances, not settling split rows. |
+| Split Summary UI (i18n) | “simplify splits”, “Could not simplify splits” | **Balance simplification** | Fewer payment lines with the same net balances; no money has moved. |
 
 ## Example dialogue
 

--- a/TravelCostApp/__tests__/docs/project-guidance.test.ts
+++ b/TravelCostApp/__tests__/docs/project-guidance.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const appRoot = join(__dirname, "../..");
+
+describe("project guidance (issue #220)", () => {
+  it("CLAUDE.md links to CONTEXT.md and instructs use of domain terms", () => {
+    const claude = readFileSync(join(appRoot, "CLAUDE.md"), "utf8");
+
+    expect(claude).toMatch(/CONTEXT\.md/);
+    expect(claude).toMatch(/domain term/i);
+  });
+
+  it("CONTEXT.md lists flagged UI vs domain language mismatches", () => {
+    const context = readFileSync(join(appRoot, "CONTEXT.md"), "utf8");
+
+    expect(context).toMatch(/## Flagged ambiguities/);
+    expect(context).toMatch(/Base Currency/i);
+    expect(context).toMatch(/\*\*Trip currency\*\*/);
+    expect(context).toMatch(/`isPaid`/);
+    expect(context).toMatch(/\*\*Paid back\*\*/);
+    expect(context).toMatch(/open splits/i);
+    expect(context).toMatch(/settle splits/i);
+    expect(context).toMatch(/simplify splits/i);
+    expect(context).toMatch(/\*\*Balance\*\*/);
+    expect(context).toMatch(/\*\*Settlement\*\*/);
+    expect(context).toMatch(/\*\*Balance simplification\*\*/);
+  });
+
+  it("groups Language glossary terms under skimmable subheadings", () => {
+    const context = readFileSync(join(appRoot, "CONTEXT.md"), "utf8");
+
+    expect(context).toMatch(/### People/);
+    expect(context).toMatch(/### Trips/);
+    expect(context).toMatch(/### Expenses/);
+    expect(context).toMatch(/### Money flow/);
+    expect(context).toMatch(/### Budget/);
+    expect(context).toMatch(/### Currency/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `TravelCostApp/CLAUDE.md` and repo-root `CLAUDE.md` linking to `TravelCostApp/CONTEXT.md` with a one-line instruction to use domain terms from the glossary.
- Extend `CONTEXT.md` with a **Flagged ambiguities** table (Base Currency vs Trip currency, `isPaid` vs Paid back/Settlement, Split Summary i18n vs Balance/Settlement/Balance simplification) and group **Language** under skimmable subheadings.
- Stop ignoring `TravelCostApp/CLAUDE.md` in `.gitignore` so guidance is versioned.
- Add `__tests__/docs/project-guidance.test.ts` as a small contract suite so wiring and required sections stay in CI.

Closes #220.

## Test plan

- [x] `cd TravelCostApp && pnpm test`
- [x] `pnpm test -- __tests__/docs/project-guidance.test.ts`
- [ ] Confirm `TravelCostApp/CLAUDE.md` and root `CLAUDE.md` render links correctly on GitHub
- [ ] Spot-check **Flagged ambiguities** table against current i18n strings in `i18n/supportedLanguages.tsx`