### PR TITLE
i18n: align Split Summary copy with balance/settlement glossary (#222)

### DIFF
--- a/TravelCostApp/CONTEXT.md
+++ b/TravelCostApp/CONTEXT.md
@@ -115,9 +115,9 @@ Places where English UI copy or code identifiers still diverge from domain langu
 | ------- | ----------------------- | ----------- | ----- |
 | Trip setup (i18n) | ~~“Base Currency”~~ → home / Heimatwährung / domicile copy (#221) | **Trip currency** | Aligned in #221 for EN/DE/FR/RU trip-currency alerts, info modals, and TripForm change-currency confirm. |
 | Expense / trip models | `isPaid`, `isPaidTimestamp` | **Paid back**, **Settlement** (trip-wide) | `isPaid` is per-expense paid-back status; trip `isPaid` + timestamp drive trip-wide **Settlement**. |
-| Split Summary UI (i18n) | “open splits”, “Calculate open splits”, “No open splits” | **Balance** | Rolled-up amounts travellers owe each other, not “splits” as allocation mode. |
-| Split Summary UI (i18n) | “settle splits”, “Could not settle splits” | **Settlement** | Trip-wide clearing of balances, not settling split rows. |
-| Split Summary UI (i18n) | “simplify splits”, “Could not simplify splits” | **Balance simplification** | Fewer payment lines with the same net balances; no money has moved. |
+| Split Summary UI (i18n) | ~~“open splits”, “Calculate open splits”, “No open splits”~~ → balance copy (#222) | **Balance** | Aligned in #222 for EN/DE/FR/RU: balances wording, button helpers, Settlement vs Balance simplification labels. |
+| Split Summary UI (i18n) | ~~“settle splits”, “Could not settle splits”~~ → Settlement copy (#222) | **Settlement** | Aligned in #222; trip-wide settle actions and toasts use Settlement language. |
+| Split Summary UI (i18n) | ~~“simplify splits”, “Could not simplify splits”~~ → Balance simplification copy (#222) | **Balance simplification** | Aligned in #222; “Simplify splits” + helper clarifies no money has moved. |
 
 ## Example dialogue
 

--- a/TravelCostApp/__tests__/i18n/split-summary-copy.test.ts
+++ b/TravelCostApp/__tests__/i18n/split-summary-copy.test.ts
@@ -44,25 +44,45 @@ describe("split summary i18n (issue #222)", () => {
   });
 
   describe("German", () => {
+    it("helper copy clarifies no money moved vs paid back", () => {
+      expect(de.balanceSimplificationHelper).toMatch(/kein Geld bewegt/i);
+      expect(de.settlementHelper).toMatch(/zurückbekommen/i);
+    });
+
     it("balance touchpoints avoid Aufteilung open-split phrasing", () => {
       const copy = splitSummaryTouchpoints(de);
       expect(copy).not.toMatch(/offene Aufteilung/i);
       expect(copy).not.toMatch(/Aufteilungen vereinfachen/i);
+      expect(copy).toMatch(/Salden/i);
     });
   });
 
   describe("French", () => {
+    it("helper copy clarifies no money moved vs paid back", () => {
+      expect(fr.balanceSimplificationHelper).toMatch(
+        /n'a encore bougé|aucun argent/i
+      );
+      expect(fr.settlementHelper).toMatch(/remboursé/i);
+    });
+
     it("balance touchpoints avoid open partage / dépense ouverte phrasing", () => {
       const copy = splitSummaryTouchpoints(fr);
       expect(copy).not.toMatch(/dépense ouverte/i);
       expect(copy).not.toMatch(/partages ouverts/i);
+      expect(copy).toMatch(/soldes/i);
     });
   });
 
   describe("Russian", () => {
+    it("helper copy clarifies no money moved vs paid back", () => {
+      expect(ru.balanceSimplificationHelper).toMatch(/не переводились/i);
+      expect(ru.settlementHelper).toMatch(/вернули деньги/i);
+    });
+
     it("balance touchpoints avoid open раздел phrasing", () => {
       const copy = splitSummaryTouchpoints(ru);
       expect(copy).not.toMatch(/открыт\w* раздел/i);
+      expect(copy).toMatch(/баланс/i);
     });
   });
 

--- a/TravelCostApp/__tests__/i18n/split-summary-copy.test.ts
+++ b/TravelCostApp/__tests__/i18n/split-summary-copy.test.ts
@@ -1,0 +1,75 @@
+import { de, en, fr, ru } from "../../i18n/supportedLanguages";
+
+/** Split Summary / balance glossary copy (issue #222). */
+const splitSummaryTouchpoints = (locale: Record<string, string>) =>
+  [
+    locale.simplifySplits,
+    locale.settleSplits,
+    locale.balanceSimplificationHelper,
+    locale.settlementHelper,
+    locale.simplifySplitsLabel,
+    locale.calcOpenSplits,
+    locale.noOpenSplits,
+    locale.noOpenSplitsAllSettled,
+    locale.noSplitsToSimplify,
+    locale.couldNotSimplifySplits,
+    locale.sureSettleSplitsFullMessage,
+    locale.tripSettledAllExpensesPaid,
+    locale.toastSettleFailedMessage,
+    locale.toastSettleSuccessTitle,
+    locale.toastSettleSuccessMessage,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+describe("split summary i18n (issue #222)", () => {
+  describe("English", () => {
+    it("button labels distinguish Balance simplification from Settlement", () => {
+      expect(en.simplifySplits).toBe("Simplify splits");
+      expect(en.settleSplits).toBe("Settle splits");
+    });
+
+    it("helper copy clarifies no money moved vs paid back", () => {
+      expect(en.balanceSimplificationHelper).toMatch(/no money has moved/i);
+      expect(en.settlementHelper).toMatch(/paid back/i);
+    });
+
+    it("balance touchpoints avoid open splits wording", () => {
+      const copy = splitSummaryTouchpoints(en);
+      expect(copy).not.toMatch(/open splits/i);
+      expect(copy).not.toMatch(/simplify splits\?/i);
+      expect(copy).toMatch(/balance/i);
+      expect(copy).toMatch(/paid back/i);
+    });
+  });
+
+  describe("German", () => {
+    it("balance touchpoints avoid Aufteilung open-split phrasing", () => {
+      const copy = splitSummaryTouchpoints(de);
+      expect(copy).not.toMatch(/offene Aufteilung/i);
+      expect(copy).not.toMatch(/Aufteilungen vereinfachen/i);
+    });
+  });
+
+  describe("French", () => {
+    it("balance touchpoints avoid open partage / dépense ouverte phrasing", () => {
+      const copy = splitSummaryTouchpoints(fr);
+      expect(copy).not.toMatch(/dépense ouverte/i);
+      expect(copy).not.toMatch(/partages ouverts/i);
+    });
+  });
+
+  describe("Russian", () => {
+    it("balance touchpoints avoid open раздел phrasing", () => {
+      const copy = splitSummaryTouchpoints(ru);
+      expect(copy).not.toMatch(/открыт\w* раздел/i);
+    });
+  });
+
+  it("helper keys exist in every locale", () => {
+    for (const locale of [en, de, fr, ru]) {
+      expect(locale.balanceSimplificationHelper).toBeTruthy();
+      expect(locale.settlementHelper).toBeTruthy();
+    }
+  });
+});

--- a/TravelCostApp/__tests__/screens/financial-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/financial-screen.test.tsx
@@ -35,6 +35,6 @@ describe("Financial screen", () => {
     });
 
     expect(screen.getByText("Financial Overview")).toBeTruthy();
-    expect(screen.getByText("Open Splits Summary")).toBeTruthy();
+    expect(screen.getByText("Balance summary")).toBeTruthy();
   });
 });

--- a/TravelCostApp/__tests__/screens/split-summary-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/split-summary-screen.test.tsx
@@ -25,6 +25,7 @@ jest.mock("react-native-toast-message", () => ({
 }));
 
 import SplitSummaryScreen from "../../screens/SplitSummaryScreen";
+import * as splitUtil from "../../util/split";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
@@ -68,5 +69,57 @@ describe("Split Summary screen", () => {
       expect(screen.getByText("Bob")).toBeTruthy();
       expect(screen.getByText("Alice")).toBeTruthy();
     });
+  });
+
+  it("shows Balance simplification and Settlement helpers when balances can be simplified", async () => {
+    const openBalances = [
+      { userName: "Bob", whoPaid: "Alice", amount: 50 },
+      { userName: "Alice", whoPaid: "Bob", amount: 30 },
+    ];
+    const calcSpy = jest
+      .spyOn(splitUtil, "calcOpenSplitsTable")
+      .mockResolvedValue(openBalances);
+
+    const navigation = { navigate: jest.fn(), pop: jest.fn() };
+    const screen = renderWithAppProviders(
+      <SplitSummaryScreen navigation={navigation as any} />,
+      {
+        trip: {
+          tripid: "t1",
+          tripCurrency: "EUR",
+          isPaid: "notPaid",
+          isPaidTimestamp: 0,
+          fetchAndSettleCurrentTrip: jest.fn(async () => {}),
+        },
+        user: { userName: "Alice", freshlyCreated: false },
+        expenses: {
+          expenses: [
+            makeExpense({
+              whoPaid: "Alice",
+              amount: 100,
+              calcAmount: 100,
+              currency: "EUR",
+              splitList: [
+                { userName: "Alice", amount: 50 },
+                { userName: "Bob", amount: 50 },
+              ],
+            }),
+          ],
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Simplify splits")).toBeTruthy();
+      expect(
+        screen.getByText(/no money has moved/i, { exact: false })
+      ).toBeTruthy();
+      expect(screen.getByText("Settle splits")).toBeTruthy();
+      expect(
+        screen.getByText(/paid back/i, { exact: false })
+      ).toBeTruthy();
+    });
+
+    calcSpy.mockRestore();
   });
 });

--- a/TravelCostApp/__tests__/screens/split-summary-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/split-summary-screen.test.tsx
@@ -61,6 +61,10 @@ describe("Split Summary screen", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Split Summary")).toBeTruthy();
+      expect(screen.getByText("Settle splits")).toBeTruthy();
+      expect(
+        screen.getByText(/paid back/i, { exact: false })
+      ).toBeTruthy();
       expect(screen.getByText("Bob")).toBeTruthy();
       expect(screen.getByText("Alice")).toBeTruthy();
     });

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -44,7 +44,7 @@ const en = {
   chooseAction: "Please choose action:",
   inviteTravellers: "Invite other travellers",
   setActiveTrip: "Set as active Trip",
-  calcOpenSplits: "Calculate open splits",
+  calcOpenSplits: "Calculate balances",
   daily: "Daily",
 
   // today - yesterday etc.
@@ -139,7 +139,7 @@ const en = {
   // Settings Labels
   logoutLabel: "Logout",
   joinTripLabel: "Join Trip",
-  simplifySplitsLabel: "Open Splits Summary",
+  simplifySplitsLabel: "Balance summary",
   resetAppIntroductionLabel: "Reset App Introduction",
   visitFoodForNomadsLabel: "Visit Food For Nomads",
   supportFeedbackLabel: "Feedback?",
@@ -324,15 +324,19 @@ const en = {
   yourMoneyBack: "Your money back",
   youStillOwe: "You still owe",
   error: "Error",
-  errorSplits: "Could not fetch splits!",
-  alertNoSplits: "No Splits to Simplify",
+  errorSplits: "Could not fetch balances!",
+  alertNoSplits: "Nothing to simplify",
   XowesYtoZ1: "owes",
   XowesYtoZ2: "to",
-  simplifySplits: "Simplify Splits",
-  settleSplits: "Settle Splits",
+  simplifySplits: "Simplify splits",
+  settleSplits: "Settle splits",
+  balanceSimplificationHelper:
+    "See fewer payments between travellers. No money has moved yet.",
+  settlementHelper:
+    "Mark the trip as settled when everyone has been paid back.",
   confirmSettle: "Settle",
   sureSettleSplits:
-    "Are you sure you want to settle all splits? Has everyone gotten their money back?",
+    "Are you sure you want to settle the trip? Has everyone been paid back?",
   sureDeleteAccount:
     "This will unreversibly delete your Budget for Nomads Account!",
   premiumNomad: "Premium Nomad",
@@ -443,10 +447,10 @@ const en = {
   toastSyncFailed: "Failed to sync, please try again later",
   toastSyncSuccessTitle: "Sync Successful",
   toastSyncFailedTitle: "Sync Failed",
-  toastSettleSuccessTitle: "All Splits Settled!",
-  toastSettleSuccessMessage: "Yay! All splits are settled!",
-  toastSettleFailedTitle: "Settlement Failed",
-  toastSettleFailedMessage: "Could not settle splits. Please try again.",
+  toastSettleSuccessTitle: "Trip settled!",
+  toastSettleSuccessMessage: "Everyone is paid back for this trip.",
+  toastSettleFailedTitle: "Settlement failed",
+  toastSettleFailedMessage: "Could not settle the trip. Please try again.",
 
   // rate modal
   rateModalTitle: "Enjoying Budget for Nomads?",
@@ -538,8 +542,8 @@ const en = {
   neverAskAgain: "Never ask again",
   enterTotalBudgetNumber: "Please enter a total Budget number!",
   chatGPTError: "Chat GPT Error",
-  noSplitsToSimplify: "No Splits to Simplify",
-  couldNotSimplifySplits: "Could not simplify splits",
+  noSplitsToSimplify: "Nothing to simplify",
+  couldNotSimplifySplits: "Could not simplify balances",
   mustUsePhysicalDevice: "Must use physical device for Push Notifications",
   pressToSendNotification: "Press to Send Notification",
   hideSpecialExpenses: "Hide special expenses",
@@ -567,10 +571,12 @@ const en = {
   youStillOweWithColon: "You still owe: ",
   somethingWentWrongSorry: "Something must have gone wrong, sorry!",
   sureSettleSplitsFullMessage:
-    "Are you sure you want to settle all splits? Has everyone gotten their money back? This will mark ALL expenses as paid, regardless of their date.",
-  tripSettledAllExpensesPaid: "Trip Settled - All expenses marked as paid",
-  noOpenSplitsAllSettled: "No open splits - All expenses are settled",
-  noOpenSplits: "No open splits",
+    "Are you sure you want to settle the trip? Has everyone been paid back? This will mark ALL expenses as paid back, regardless of their date.",
+  tripSettledAllExpensesPaid:
+    "Trip settled — all expenses marked as paid back",
+  noOpenSplitsAllSettled:
+    "No open balances — all expenses are paid back",
+  noOpenSplits: "No open balances",
 };
 const de = {
   // special expense strings
@@ -619,7 +625,7 @@ const de = {
   chooseAction: "Bitte wähle eine Aktion aus:",
   inviteTravellers: "Andere Reisende einladen",
   setActiveTrip: "Als aktive Reise markieren",
-  calcOpenSplits: "Berechne offene Schulden",
+  calcOpenSplits: "Salden berechnen",
   daily: "Täglich",
 
   // today - yesterday etc.
@@ -717,7 +723,7 @@ const de = {
   // Settings Labels
   logoutLabel: "Ausloggen",
   joinTripLabel: "Reise beitreten",
-  simplifySplitsLabel: "Offene Schulden Übersicht",
+  simplifySplitsLabel: "Saldenübersicht",
   resetAppIntroductionLabel: "App Einführung wiederholen",
   visitFoodForNomadsLabel: "Food For Nomads besuchen",
   supportFeedbackLabel: "Feedback?",
@@ -914,15 +920,19 @@ const de = {
   yourMoneyBack: "Dein Geld zurück",
   youStillOwe: "Du schuldest noch",
   error: "Fehler",
-  errorSplits: "Aufteilungen konnten nicht abgerufen werden!",
-  alertNoSplits: "Keine Aufteilungen zum Vereinfachen",
+  errorSplits: "Salden konnten nicht abgerufen werden!",
+  alertNoSplits: "Nichts zu vereinfachen",
   XowesYtoZ1: "schuldet",
   XowesYtoZ2: "zu",
-  simplifySplits: "Aufteilungen vereinfachen",
-  settleSplits: "Aufteilungen begleichen",
+  simplifySplits: "Salden vereinfachen",
+  settleSplits: "Reise begleichen",
+  balanceSimplificationHelper:
+    "Weniger Zahlungen zwischen Reisenden — es wurde noch kein Geld bewegt.",
+  settlementHelper:
+    "Reise begleichen, wenn alle ihr Geld zurückbekommen haben.",
   confirmSettle: "Begleichen",
   sureSettleSplits:
-    "Sind Sie sicher, dass Sie alle Schulden begleichen möchten? Hat jeder sein Geld zurückbekommen?",
+    "Reise wirklich begleichen? Hat jeder sein Geld zurückbekommen?",
   sureDeleteAccount:
     "Dies löscht deinen Budget for Nomads Account unwiderruflich!",
   premiumNomad: "Premium-Nomade",
@@ -1043,11 +1053,12 @@ const de = {
     "Synchronisation fehlgeschlagen, bitte versuche es später erneut",
   toastSyncSuccessTitle: "Synchronisation erfolgreich",
   toastSyncFailedTitle: "Synchronisation fehlgeschlagen",
-  toastSettleSuccessTitle: "Alle Aufteilungen beglichen!",
-  toastSettleSuccessMessage: "Yay! Alle Aufteilungen sind beglichen!",
+  toastSettleSuccessTitle: "Reise beglichen!",
+  toastSettleSuccessMessage:
+    "Alle Reisenden haben ihr Geld für diese Reise zurück.",
   toastSettleFailedTitle: "Begleichung fehlgeschlagen",
   toastSettleFailedMessage:
-    "Aufteilungen konnten nicht beglichen werden. Bitte versuche es erneut.",
+    "Reise konnte nicht beglichen werden. Bitte versuche es erneut.",
   // rate modal
   rateModalTitle: "Gefällt dir Budget for Nomads?",
   rateModalSubTitle:
@@ -1141,8 +1152,8 @@ const de = {
   neverAskAgain: "Nie wieder fragen",
   enterTotalBudgetNumber: "Bitte geben Sie eine Gesamtbudgetzahl ein!",
   chatGPTError: "Chat GPT Fehler",
-  noSplitsToSimplify: "Keine Aufteilungen zu vereinfachen",
-  couldNotSimplifySplits: "Aufteilungen konnten nicht vereinfacht werden",
+  noSplitsToSimplify: "Nichts zu vereinfachen",
+  couldNotSimplifySplits: "Salden konnten nicht vereinfacht werden",
   mustUsePhysicalDevice:
     "Muss physisches Gerät für Push-Benachrichtigungen verwenden",
   pressToSendNotification: "Drücken Sie, um Benachrichtigung zu senden",
@@ -1171,12 +1182,12 @@ const de = {
   youStillOweWithColon: "Du schuldest noch: ",
   somethingWentWrongSorry: "Etwas muss schief gelaufen sein, entschuldige!",
   sureSettleSplitsFullMessage:
-    "Sind Sie sicher, dass Sie alle Schulden begleichen möchten? Hat jeder sein Geld zurückbekommen? Dies markiert ALLE Ausgaben als bezahlt, unabhängig von ihrem Datum.",
+    "Reise wirklich begleichen? Hat jeder sein Geld zurückbekommen? Alle Ausgaben werden als zurückgezahlt markiert, unabhängig vom Datum.",
   tripSettledAllExpensesPaid:
-    "Reise abgerechnet - Alle Ausgaben als bezahlt markiert",
+    "Reise beglichen — alle Ausgaben als zurückgezahlt markiert",
   noOpenSplitsAllSettled:
-    "Keine offenen Aufteilungen - Alle Ausgaben abgerechnet",
-  noOpenSplits: "Keine offenen Aufteilungen",
+    "Keine offenen Salden — alle Ausgaben sind zurückgezahlt",
+  noOpenSplits: "Keine offenen Salden",
 };
 const fr = {
   // special expense strings
@@ -1224,7 +1235,7 @@ const fr = {
   chooseAction: "Veuillez choisir une action :",
   inviteTravellers: "Inviter d'autres voyageurs",
   setActiveTrip: "Définir comme voyage actif",
-  calcOpenSplits: "Calculer les dépenses partagées ouvertes",
+  calcOpenSplits: "Calculer les soldes",
   daily: "Quotidien",
 
   // today - yesterday etc.
@@ -1321,7 +1332,7 @@ const fr = {
   // Settings Labels
   logoutLabel: "Déconnexion",
   joinTripLabel: "Rejoindre un voyage",
-  simplifySplitsLabel: "Résumé des dettes",
+  simplifySplitsLabel: "Résumé des soldes",
   resetAppIntroductionLabel: "Réinitialiser l'introduction de l'application",
   visitFoodForNomadsLabel: "Visitez Food For Nomads",
   supportFeedbackLabel: "Commentaires?",
@@ -1517,15 +1528,19 @@ const fr = {
   yourMoneyBack: "Votre argent est de retour",
   youStillOwe: "Vous devez toujours",
   error: "Erreur",
-  errorSplits: "Impossible de récupérer les dépenses partagées !",
-  alertNoSplits: "Aucune dépense à simplifier",
+  errorSplits: "Impossible de récupérer les soldes !",
+  alertNoSplits: "Rien à simplifier",
   XowesYtoZ1: "doit",
   XowesYtoZ2: "à",
-  simplifySplits: "Simplifier les dépenses",
-  settleSplits: "Régler les dépenses",
+  simplifySplits: "Simplifier les soldes",
+  settleSplits: "Régler le voyage",
+  balanceSimplificationHelper:
+    "Moins de paiements entre voyageurs. Aucun argent n'a encore bougé.",
+  settlementHelper:
+    "Marquer le voyage comme réglé quand tout le monde a été remboursé.",
   confirmSettle: "Régler",
   sureSettleSplits:
-    "Êtes-vous sûr de vouloir régler toutes les dépenses ? Tout le monde a-t-il récupéré son argent ?",
+    "Régler le voyage ? Tout le monde a-t-il été remboursé ?",
   sureDeleteAccount:
     "Cela supprimera définitivement votre compte Budget for Nomads !",
   premiumNomad: "Nomade Premium",
@@ -1644,11 +1659,12 @@ const fr = {
   toastSyncFailed: "Échec de la synchronisation, veuillez réessayer plus tard",
   toastSyncSuccessTitle: "Synchronisation réussie",
   toastSyncFailedTitle: "Échec de la synchronisation",
-  toastSettleSuccessTitle: "Tous les partages réglés !",
-  toastSettleSuccessMessage: "Yay ! Tous les partages sont réglés !",
+  toastSettleSuccessTitle: "Voyage réglé !",
+  toastSettleSuccessMessage:
+    "Tout le monde a été remboursé pour ce voyage.",
   toastSettleFailedTitle: "Échec du règlement",
   toastSettleFailedMessage:
-    "Impossible de régler les partages. Veuillez réessayer.",
+    "Impossible de régler le voyage. Veuillez réessayer.",
   // rate modal
   rateModalTitle: "Vous appréciez Budget for Nomads ?",
   rateModalSubTitle:
@@ -1744,8 +1760,8 @@ const fr = {
   neverAskAgain: "Ne plus jamais demander",
   enterTotalBudgetNumber: "Veuillez entrer un nombre de budget total!",
   chatGPTError: "Erreur Chat GPT",
-  noSplitsToSimplify: "Aucun partage à simplifier",
-  couldNotSimplifySplits: "Impossible de simplifier les partages",
+  noSplitsToSimplify: "Rien à simplifier",
+  couldNotSimplifySplits: "Impossible de simplifier les soldes",
   mustUsePhysicalDevice:
     "Doit utiliser un appareil physique pour les notifications push",
   pressToSendNotification: "Appuyez pour envoyer une notification",
@@ -1774,12 +1790,12 @@ const fr = {
   youStillOweWithColon: "Vous devez toujours : ",
   somethingWentWrongSorry: "Quelque chose a dû mal se passer, désolé !",
   sureSettleSplitsFullMessage:
-    "Êtes-vous sûr de vouloir régler toutes les dépenses ? Tout le monde a-t-il récupéré son argent ? Cela marquera TOUTES les dépenses comme payées, quelle que soit leur date.",
+    "Régler le voyage ? Tout le monde a-t-il été remboursé ? Toutes les dépenses seront marquées comme remboursées, quelle que soit leur date.",
   tripSettledAllExpensesPaid:
-    "Voyage réglé - Toutes les dépenses marquées comme payées",
+    "Voyage réglé — toutes les dépenses marquées comme remboursées",
   noOpenSplitsAllSettled:
-    "Aucune dépense ouverte - Toutes les dépenses sont réglées",
-  noOpenSplits: "Aucune dépense ouverte",
+    "Aucun solde ouvert — toutes les dépenses sont remboursées",
+  noOpenSplits: "Aucun solde ouvert",
 };
 const ru = {
   // special expense strings
@@ -1827,7 +1843,7 @@ const ru = {
   chooseAction: "Пожалуйста, выберите действие:",
   inviteTravellers: "Пригласить других путешественников",
   setActiveTrip: "Установить активную поездку",
-  calcOpenSplits: "Рассчитать открытые распределения",
+  calcOpenSplits: "Рассчитать балансы",
   daily: "Ежедневно",
 
   // today - yesterday etc.
@@ -1923,7 +1939,7 @@ const ru = {
   // Settings Labels
   logoutLabel: "Выйти",
   joinTripLabel: "Присоединиться к поездке",
-  simplifySplitsLabel: "Открыть сводку распределения",
+  simplifySplitsLabel: "Сводка балансов",
   resetAppIntroductionLabel: "Сбросить введение в приложение",
   visitFoodForNomadsLabel: "Посетить Food For Nomads",
   supportFeedbackLabel: "Отзыв?",
@@ -2110,15 +2126,19 @@ const ru = {
   yourMoneyBack: "Ваши деньги вернутся",
   youStillOwe: "Вы все еще должны",
   error: "Ошибка",
-  errorSplits: "Не удалось получить разделы!",
-  alertNoSplits: "Нет разделов для упрощения",
+  errorSplits: "Не удалось получить балансы!",
+  alertNoSplits: "Нечего упрощать",
   XowesYtoZ1: "должен",
   XowesYtoZ2: "для",
-  simplifySplits: "Упростить разделы",
-  settleSplits: "Расчет разделов",
-  confirmSettle: "Расчет",
+  simplifySplits: "Упростить балансы",
+  settleSplits: "Закрыть поездку",
+  balanceSimplificationHelper:
+    "Меньше платежей между путешественниками. Деньги ещё не переводились.",
+  settlementHelper:
+    "Отметить поездку закрытой, когда всем вернули деньги.",
+  confirmSettle: "Закрыть",
   sureSettleSplits:
-    "Вы уверены, что хотите рассчитать все разделы? Все ли получили свои деньги?",
+    "Закрыть поездку? Всем вернули деньги?",
   sureDeleteAccount: "Это безвозвратно удалит ваш аккаунт в Budget for Nomads!",
   premiumNomad: "Премиум-намбад",
   premiumNomadActiveNow: "Теперь вы являетесь премиум-намбадом!",
@@ -2248,11 +2268,11 @@ const ru = {
   toastSyncFailed: "Не удалось синхронизировать, попробуйте позже",
   toastSyncSuccessTitle: "Синхронизация успешна",
   toastSyncFailedTitle: "Ошибка синхронизации",
-  toastSettleSuccessTitle: "Все разделы урегулированы!",
-  toastSettleSuccessMessage: "Ура! Все разделы урегулированы!",
-  toastSettleFailedTitle: "Ошибка урегулирования",
+  toastSettleSuccessTitle: "Поездка закрыта!",
+  toastSettleSuccessMessage: "Всем вернули деньги по этой поездке.",
+  toastSettleFailedTitle: "Ошибка закрытия",
   toastSettleFailedMessage:
-    "Не удалось урегулировать разделы. Пожалуйста, попробуйте снова.",
+    "Не удалось закрыть поездку. Пожалуйста, попробуйте снова.",
   // rate modal
   rateModalTitle: "Нравится Budget for Nomads?",
   rateModalSubTitle:
@@ -2346,8 +2366,8 @@ const ru = {
   neverAskAgain: "Больше не спрашивать",
   enterTotalBudgetNumber: "Пожалуйста, введите общую сумму бюджета!",
   chatGPTError: "Ошибка Chat GPT",
-  noSplitsToSimplify: "Нет разделений для упрощения",
-  couldNotSimplifySplits: "Не удалось упростить разделения",
+  noSplitsToSimplify: "Нечего упрощать",
+  couldNotSimplifySplits: "Не удалось упростить балансы",
   mustUsePhysicalDevice:
     "Необходимо использовать физическое устройство для push-уведомлений",
   pressToSendNotification: "Нажмите, чтобы отправить уведомление",
@@ -2376,10 +2396,11 @@ const ru = {
   youStillOweWithColon: "Вы все еще должны: ",
   somethingWentWrongSorry: "Что-то пошло не так, извините!",
   sureSettleSplitsFullMessage:
-    "Вы уверены, что хотите рассчитать все разделы? Все ли получили свои деньги? Это отметит ВСЕ расходы как оплаченные, независимо от их даты.",
+    "Закрыть поездку? Всем вернули деньги? Все расходы будут отмечены как возмещённые, независимо от даты.",
   tripSettledAllExpensesPaid:
-    "Поездка урегулирована - Все расходы помечены как оплаченные",
-  noOpenSplitsAllSettled: "Нет открытых разделов - Все расходы урегулированы",
-  noOpenSplits: "Нет открытых разделов",
+    "Поездка закрыта — все расходы отмечены как возмещённые",
+  noOpenSplitsAllSettled:
+    "Нет открытых балансов — все расходы возмещены",
+  noOpenSplits: "Нет открытых балансов",
 };
 export { en, de, fr, ru };

--- a/TravelCostApp/screens/SplitSummaryScreen.tsx
+++ b/TravelCostApp/screens/SplitSummaryScreen.tsx
@@ -353,46 +353,56 @@ const SplitSummaryScreen = ({ navigation }) => {
         </FlatButton>
       )}
       {showSimplify && !noSimpleSplits && (
-        <GradientButton
-          buttonStyle={styles.button}
-          style={styles.button}
-          onPress={handleSimpflifySplits}
-        >
-          {i18n.t("simplifySplits")}
-        </GradientButton>
+        <View style={styles.actionWithHelper}>
+          <GradientButton
+            buttonStyle={styles.button}
+            style={styles.button}
+            onPress={handleSimpflifySplits}
+          >
+            {i18n.t("simplifySplits")}
+          </GradientButton>
+          <Text style={styles.buttonHelperText}>
+            {i18n.t("balanceSimplificationHelper")}
+          </Text>
+        </View>
       )}
       {hasOpenSplits && !isTripSettled && (
-        <GradientButton
-          style={styles.button}
-          colors={GlobalStyles.gradientColors}
-          darkText
-          buttonStyle={{
-            backgroundColor: GlobalStyles.colors.errorGrayed,
-          }}
-          onPress={async () => {
-            Alert.alert(
-              i18n.t("settleSplits"),
-              i18n.t("sureSettleSplitsFullMessage"),
-              [
-                {
-                  text: i18n.t("cancel"),
-                  style: "cancel",
-                },
-                {
-                  text: i18n.t("confirmSettle"),
-                  onPress: async () => {
-                    trackEvent(VexoEvents.SETTLE_ALL_PRESSED, {
-                      splitsCount: splits?.length || 0,
-                    });
-                    await settleSplitsHandler();
+        <View style={styles.actionWithHelper}>
+          <GradientButton
+            style={styles.button}
+            colors={GlobalStyles.gradientColors}
+            darkText
+            buttonStyle={{
+              backgroundColor: GlobalStyles.colors.errorGrayed,
+            }}
+            onPress={async () => {
+              Alert.alert(
+                i18n.t("settleSplits"),
+                i18n.t("sureSettleSplitsFullMessage"),
+                [
+                  {
+                    text: i18n.t("cancel"),
+                    style: "cancel",
                   },
-                },
-              ]
-            );
-          }}
-        >
-          {i18n.t("settleSplits")}
-        </GradientButton>
+                  {
+                    text: i18n.t("confirmSettle"),
+                    onPress: async () => {
+                      trackEvent(VexoEvents.SETTLE_ALL_PRESSED, {
+                        splitsCount: splits?.length || 0,
+                      });
+                      await settleSplitsHandler();
+                    },
+                  },
+                ]
+              );
+            }}
+          >
+            {i18n.t("settleSplits")}
+          </GradientButton>
+          <Text style={styles.buttonHelperText}>
+            {i18n.t("settlementHelper")}
+          </Text>
+        </View>
       )}
     </View>
   );
@@ -572,11 +582,24 @@ const styles = StyleSheet.create({
       },
     }),
   },
+  actionWithHelper: {
+    flex: 1,
+    maxWidth: "48%",
+    paddingHorizontal: dynamicScale(4, false, 0.5),
+  },
+  buttonHelperText: {
+    fontSize: dynamicScale(12, false, 0.5),
+    color: GlobalStyles.colors.gray700,
+    textAlign: "center",
+    marginTop: dynamicScale(6, false, 0.5),
+    paddingHorizontal: dynamicScale(4, false, 0.5),
+  },
   buttonContainer: {
     flexDirection: "row",
     alignSelf: "center",
-    alignItems: "center",
+    alignItems: "flex-start",
     justifyContent: "space-between",
+    flexWrap: "wrap",
     ...Platform.select({
       ios: { marginTop: 0 },
       android: {


### PR DESCRIPTION
## Summary

- Updates Split Summary and related i18n (EN/DE/FR/RU) to use **Balance**, **Balance simplification**, **Settlement**, and **Paid back** language from `TravelCostApp/CONTEXT.md` instead of ambiguous “open splits” / “settle splits” wording.
- Adds short helper text under **Simplify splits** and **Settle splits** on `SplitSummaryScreen` so users can tell planning (no money moved) from trip-wide settlement.
- Adds `__tests__/i18n/split-summary-copy.test.ts` and extends the Split Summary screen test; marks flagged ambiguities as aligned in `CONTEXT.md`.

Closes #222

## Test plan

- [x] `pnpm test -- __tests__/i18n/split-summary-copy.test.ts __tests__/screens/split-summary-screen.test.tsx __tests__/docs/project-guidance.test.ts`
- [ ] Open Split Summary on a trip with open balances — confirm button labels and helpers (EN)
- [ ] Spot-check DE/FR/RU locale if available
- [ ] Financial tab entry still shows updated “Balance summary” label