### PR TITLE
Add canonical expense aggregation module (expenseTotals)

### DIFF
--- a/TravelCostApp/__tests__/util/expense-totals.test.ts
+++ b/TravelCostApp/__tests__/util/expense-totals.test.ts
@@ -55,6 +55,14 @@ describe("sumByPeriod (period spend)", () => {
     expect(sumByPeriod(expenses)).toBe(250);
   });
 
+  it("excludes deleted expenses from period spend", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: 50, isDeleted: true, splitList: [] }),
+    ];
+    expect(sumByPeriod(expenses)).toBe(100);
+  });
+
   it("excludes special expenses when hideSpecial is true", () => {
     const expenses = [
       makeExpense({ id: "e1", calcAmount: 100, splitList: [] }),
@@ -83,6 +91,25 @@ describe("sumByTraveller (per-traveller attribution)", () => {
     ];
     expect(sumByTraveller(expenses, "Alice")).toBe(100);
     expect(sumByTraveller(expenses, "Bob")).toBe(50);
+  });
+
+  it("excludes deleted expenses from traveller attribution", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        amount: 100,
+        calcAmount: 100,
+        splitList: [{ userName: "Alice", amount: 100 }],
+      }),
+      makeExpense({
+        id: "e2",
+        amount: 100,
+        calcAmount: 100,
+        isDeleted: true,
+        splitList: [{ userName: "Alice", amount: 100 }],
+      }),
+    ];
+    expect(sumByTraveller(expenses, "Alice")).toBe(100);
   });
 
   it("uses each traveller's split amount from splitList", () => {

--- a/TravelCostApp/__tests__/util/expense-totals.test.ts
+++ b/TravelCostApp/__tests__/util/expense-totals.test.ts
@@ -1,0 +1,144 @@
+import { makeExpense } from "../fixtures/expense";
+import {
+  sumForTrip,
+  sumByPeriod,
+  sumByTraveller,
+} from "../../util/expenseTotals";
+
+// ─── sumForTrip ───────────────────────────────────────────────────────────────
+
+describe("sumForTrip (trip total spent)", () => {
+  it("sums non-ranged, non-deleted expenses", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 30, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: 20, splitList: [] }),
+    ];
+    expect(sumForTrip(expenses)).toBe(50);
+  });
+
+  it("excludes deleted expenses from trip total spent", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: 50, isDeleted: true, splitList: [] }),
+    ];
+    expect(sumForTrip(expenses)).toBe(100);
+  });
+
+  it("counts each ranged expense once regardless of how many days it spans", () => {
+    const expenses = [
+      makeExpense({ id: "e1", rangeId: "r1", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", rangeId: "r1", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e3", rangeId: "r2", calcAmount: 50, splitList: [] }),
+    ];
+    expect(sumForTrip(expenses)).toBe(150);
+  });
+
+  it("excludes deleted ranged expense instances before deduplication", () => {
+    const expenses = [
+      makeExpense({ id: "e1", rangeId: "r1", calcAmount: 100, isDeleted: true, splitList: [] }),
+      makeExpense({ id: "e2", rangeId: "r1", calcAmount: 100, splitList: [] }),
+    ];
+    // e1 is deleted; e2 is first surviving instance → counts once
+    expect(sumForTrip(expenses)).toBe(100);
+  });
+});
+
+// ─── sumByPeriod ──────────────────────────────────────────────────────────────
+
+describe("sumByPeriod (period spend)", () => {
+  it("counts all day-instances of a ranged expense separately", () => {
+    const expenses = [
+      makeExpense({ id: "e1", rangeId: "r1", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", rangeId: "r1", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e3", calcAmount: 50, splitList: [] }),
+    ];
+    expect(sumByPeriod(expenses)).toBe(250);
+  });
+
+  it("excludes special expenses when hideSpecial is true", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: 40, isSpecialExpense: true, splitList: [] }),
+    ];
+    expect(sumByPeriod(expenses, true)).toBe(100);
+  });
+
+  it("includes special expenses when hideSpecial is false (default)", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: 40, isSpecialExpense: true, splitList: [] }),
+    ];
+    expect(sumByPeriod(expenses)).toBe(140);
+    expect(sumByPeriod(expenses, false)).toBe(140);
+  });
+});
+
+// ─── sumByTraveller ───────────────────────────────────────────────────────────
+
+describe("sumByTraveller (per-traveller attribution)", () => {
+  it("sums expenses where the traveller was who-paid (no splits)", () => {
+    const expenses = [
+      makeExpense({ id: "e1", whoPaid: "Alice", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", whoPaid: "Bob", calcAmount: 50, splitList: [] }),
+    ];
+    expect(sumByTraveller(expenses, "Alice")).toBe(100);
+    expect(sumByTraveller(expenses, "Bob")).toBe(50);
+  });
+
+  it("uses each traveller's split amount from splitList", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        amount: 100,
+        calcAmount: 100,
+        splitList: [
+          { userName: "Alice", amount: 60 },
+          { userName: "Bob", amount: 40 },
+        ],
+      }),
+    ];
+    expect(sumByTraveller(expenses, "Alice")).toBe(60);
+    expect(sumByTraveller(expenses, "Bob")).toBe(40);
+  });
+
+  it("applies currency-conversion ratio to split amounts", () => {
+    // 100 expense currency = 120 trip currency; Alice's 60 share → 60/100 × 120 = 72
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        amount: 100,
+        calcAmount: 120,
+        splitList: [
+          { userName: "Alice", amount: 60 },
+          { userName: "Bob", amount: 40 },
+        ],
+      }),
+    ];
+    expect(sumByTraveller(expenses, "Alice")).toBeCloseTo(72);
+    expect(sumByTraveller(expenses, "Bob")).toBeCloseTo(48);
+  });
+
+  it("returns 0 for a traveller not on any expense", () => {
+    const expenses = [
+      makeExpense({ id: "e1", whoPaid: "Alice", calcAmount: 100, splitList: [] }),
+    ];
+    expect(sumByTraveller(expenses, "Charlie")).toBe(0);
+  });
+
+  it("deduplicates ranged expenses when isTotal is true", () => {
+    const expenses = [
+      makeExpense({ id: "e1", rangeId: "r1", whoPaid: "Alice", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", rangeId: "r1", whoPaid: "Alice", calcAmount: 100, splitList: [] }),
+    ];
+    expect(sumByTraveller(expenses, "Alice", true)).toBe(100);
+  });
+
+  it("counts all ranged instances when isTotal is false (default)", () => {
+    const expenses = [
+      makeExpense({ id: "e1", rangeId: "r1", whoPaid: "Alice", calcAmount: 100, splitList: [] }),
+      makeExpense({ id: "e2", rangeId: "r1", whoPaid: "Alice", calcAmount: 100, splitList: [] }),
+    ];
+    expect(sumByTraveller(expenses, "Alice")).toBe(200);
+    expect(sumByTraveller(expenses, "Alice", false)).toBe(200);
+  });
+});

--- a/TravelCostApp/__tests__/util/expense-totals.test.ts
+++ b/TravelCostApp/__tests__/util/expense-totals.test.ts
@@ -5,6 +5,15 @@ import {
   sumByTraveller,
 } from "../../util/expenseTotals";
 
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2026-01-15T12:00:00.000Z"));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
 // ─── sumForTrip ───────────────────────────────────────────────────────────────
 
 describe("sumForTrip (trip total spent)", () => {
@@ -41,6 +50,14 @@ describe("sumForTrip (trip total spent)", () => {
     // e1 is deleted; e2 is first surviving instance → counts once
     expect(sumForTrip(expenses)).toBe(100);
   });
+
+  it("ignores non-finite calcAmount values", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 10, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: Number.POSITIVE_INFINITY, splitList: [] }),
+    ];
+    expect(sumForTrip(expenses)).toBe(10);
+  });
 });
 
 // ─── sumByPeriod ──────────────────────────────────────────────────────────────
@@ -61,6 +78,14 @@ describe("sumByPeriod (period spend)", () => {
       makeExpense({ id: "e2", calcAmount: 50, isDeleted: true, splitList: [] }),
     ];
     expect(sumByPeriod(expenses)).toBe(100);
+  });
+
+  it("ignores non-finite calcAmount values", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 10, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: Number.NEGATIVE_INFINITY, splitList: [] }),
+    ];
+    expect(sumByPeriod(expenses)).toBe(10);
   });
 
   it("excludes special expenses when hideSpecial is true", () => {
@@ -106,6 +131,24 @@ describe("sumByTraveller (per-traveller attribution)", () => {
         amount: 100,
         calcAmount: 100,
         isDeleted: true,
+        splitList: [{ userName: "Alice", amount: 100 }],
+      }),
+    ];
+    expect(sumByTraveller(expenses, "Alice")).toBe(100);
+  });
+
+  it("ignores expenses with non-finite calcAmount values", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        amount: 100,
+        calcAmount: 100,
+        splitList: [{ userName: "Alice", amount: 100 }],
+      }),
+      makeExpense({
+        id: "e2",
+        amount: 100,
+        calcAmount: Number.POSITIVE_INFINITY,
         splitList: [{ userName: "Alice", amount: 100 }],
       }),
     ];

--- a/TravelCostApp/__tests__/util/expense-totals.test.ts
+++ b/TravelCostApp/__tests__/util/expense-totals.test.ts
@@ -1,5 +1,6 @@
 import { makeExpense } from "../fixtures/expense";
 import {
+  asPeriodSlice,
   sumForTrip,
   sumByPeriod,
   sumByTraveller,
@@ -42,6 +43,37 @@ describe("sumForTrip (trip total spent)", () => {
     expect(sumForTrip(expenses)).toBe(150);
   });
 
+  it("reconstructs full cost for ranged-split expenses (duplOrSplit=2)", () => {
+    // €600 rent stored as 3 daily instances of €200 each
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        rangeId: "r1",
+        duplOrSplit: 2,
+        amount: 200,
+        calcAmount: 200,
+        splitList: [],
+      }),
+      makeExpense({
+        id: "e2",
+        rangeId: "r1",
+        duplOrSplit: 2,
+        amount: 200,
+        calcAmount: 200,
+        splitList: [],
+      }),
+      makeExpense({
+        id: "e3",
+        rangeId: "r1",
+        duplOrSplit: 2,
+        amount: 200,
+        calcAmount: 200,
+        splitList: [],
+      }),
+    ];
+    expect(sumForTrip(expenses)).toBe(600);
+  });
+
   it("excludes deleted ranged expense instances before deduplication", () => {
     const expenses = [
       makeExpense({ id: "e1", rangeId: "r1", calcAmount: 100, isDeleted: true, splitList: [] }),
@@ -69,7 +101,7 @@ describe("sumByPeriod (period spend)", () => {
       makeExpense({ id: "e2", rangeId: "r1", calcAmount: 100, splitList: [] }),
       makeExpense({ id: "e3", calcAmount: 50, splitList: [] }),
     ];
-    expect(sumByPeriod(expenses)).toBe(250);
+    expect(sumByPeriod(asPeriodSlice(expenses))).toBe(250);
   });
 
   it("excludes deleted expenses from period spend", () => {
@@ -77,7 +109,7 @@ describe("sumByPeriod (period spend)", () => {
       makeExpense({ id: "e1", calcAmount: 100, splitList: [] }),
       makeExpense({ id: "e2", calcAmount: 50, isDeleted: true, splitList: [] }),
     ];
-    expect(sumByPeriod(expenses)).toBe(100);
+    expect(sumByPeriod(asPeriodSlice(expenses))).toBe(100);
   });
 
   it("ignores non-finite calcAmount values", () => {
@@ -85,7 +117,7 @@ describe("sumByPeriod (period spend)", () => {
       makeExpense({ id: "e1", calcAmount: 10, splitList: [] }),
       makeExpense({ id: "e2", calcAmount: Number.NEGATIVE_INFINITY, splitList: [] }),
     ];
-    expect(sumByPeriod(expenses)).toBe(10);
+    expect(sumByPeriod(asPeriodSlice(expenses))).toBe(10);
   });
 
   it("excludes special expenses when hideSpecial is true", () => {
@@ -93,7 +125,7 @@ describe("sumByPeriod (period spend)", () => {
       makeExpense({ id: "e1", calcAmount: 100, splitList: [] }),
       makeExpense({ id: "e2", calcAmount: 40, isSpecialExpense: true, splitList: [] }),
     ];
-    expect(sumByPeriod(expenses, true)).toBe(100);
+    expect(sumByPeriod(asPeriodSlice(expenses), true)).toBe(100);
   });
 
   it("includes special expenses when hideSpecial is false (default)", () => {
@@ -101,8 +133,8 @@ describe("sumByPeriod (period spend)", () => {
       makeExpense({ id: "e1", calcAmount: 100, splitList: [] }),
       makeExpense({ id: "e2", calcAmount: 40, isSpecialExpense: true, splitList: [] }),
     ];
-    expect(sumByPeriod(expenses)).toBe(140);
-    expect(sumByPeriod(expenses, false)).toBe(140);
+    expect(sumByPeriod(asPeriodSlice(expenses))).toBe(140);
+    expect(sumByPeriod(asPeriodSlice(expenses), false)).toBe(140);
   });
 });
 
@@ -201,6 +233,36 @@ describe("sumByTraveller (per-traveller attribution)", () => {
       makeExpense({ id: "e2", rangeId: "r1", whoPaid: "Alice", calcAmount: 100, splitList: [] }),
     ];
     expect(sumByTraveller(expenses, "Alice", true)).toBe(100);
+  });
+
+  it("reconstructs full cost for ranged-split expenses when isTotal is true", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        rangeId: "r1",
+        duplOrSplit: 2,
+        amount: 200,
+        calcAmount: 200,
+        splitList: [{ userName: "Alice", amount: 200 }],
+      }),
+      makeExpense({
+        id: "e2",
+        rangeId: "r1",
+        duplOrSplit: 2,
+        amount: 200,
+        calcAmount: 200,
+        splitList: [{ userName: "Alice", amount: 200 }],
+      }),
+      makeExpense({
+        id: "e3",
+        rangeId: "r1",
+        duplOrSplit: 2,
+        amount: 200,
+        calcAmount: 200,
+        splitList: [{ userName: "Alice", amount: 200 }],
+      }),
+    ];
+    expect(sumByTraveller(expenses, "Alice", true)).toBe(600);
   });
 
   it("counts all ranged instances when isTotal is false (default)", () => {

--- a/TravelCostApp/__tests__/util/expense-totals.test.ts
+++ b/TravelCostApp/__tests__/util/expense-totals.test.ts
@@ -150,6 +150,19 @@ describe("sumByTraveller (per-traveller attribution)", () => {
     expect(sumByTraveller(expenses, "Bob")).toBe(50);
   });
 
+  it("ignores non-finite fallback amounts when calcAmount is missing (no splits)", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        whoPaid: "Alice",
+        calcAmount: undefined as unknown as number,
+        amount: Number.POSITIVE_INFINITY,
+        splitList: [],
+      }),
+    ];
+    expect(sumByTraveller(expenses, "Alice")).toBe(0);
+  });
+
   it("excludes deleted expenses from traveller attribution", () => {
     const expenses = [
       makeExpense({

--- a/TravelCostApp/util/expense.ts
+++ b/TravelCostApp/util/expense.ts
@@ -341,10 +341,6 @@ export function findMostDuplicatedDescriptionExpenses(
   }
 }
 
-// Re-export canonical aggregation module so existing callers importing from
-// this file continue to work, and new code can import from expenseTotals directly.
-export { sumForTrip, sumByPeriod, sumByTraveller } from "./expenseTotals";
-
 export async function getAllExpensesData(tripid: string) {
   const lastCacheUpdateExpenses = getMMKVString(
     MMKV_KEY_PATTERNS.LAST_UPDATE_ISO_ALL_EXPENSES_TRIP(tripid)

--- a/TravelCostApp/util/expense.ts
+++ b/TravelCostApp/util/expense.ts
@@ -341,6 +341,10 @@ export function findMostDuplicatedDescriptionExpenses(
   }
 }
 
+// Re-export canonical aggregation module so existing callers importing from
+// this file continue to work, and new code can import from expenseTotals directly.
+export { sumForTrip, sumByPeriod, sumByTraveller } from "./expenseTotals";
+
 export async function getAllExpensesData(tripid: string) {
   const lastCacheUpdateExpenses = getMMKVString(
     MMKV_KEY_PATTERNS.LAST_UPDATE_ISO_ALL_EXPENSES_TRIP(tripid)

--- a/TravelCostApp/util/expenseTotals.ts
+++ b/TravelCostApp/util/expenseTotals.ts
@@ -1,0 +1,83 @@
+import type { ExpenseData } from "./expense";
+
+function deduplicateByRangeId(expenses: ExpenseData[]): ExpenseData[] {
+  const seen = new Set<string>();
+  return expenses.filter((e) => {
+    if (e.rangeId) {
+      if (seen.has(e.rangeId)) return false;
+      seen.add(e.rangeId);
+    }
+    return true;
+  });
+}
+
+/**
+ * Trip total spent: deduplicates ranged expenses by rangeId, excludes deleted.
+ * Use for trip-wide cumulative totals and dynamic daily budget recalculation.
+ * Each ranged expense counted once regardless of how many days it spans.
+ */
+export function sumForTrip(expenses: ExpenseData[]): number {
+  const active = expenses.filter((e) => !e.isDeleted);
+  const deduped = deduplicateByRangeId(active);
+  return deduped.reduce((sum, e) => {
+    if (isNaN(Number(e.calcAmount))) return sum;
+    return sum + Number(e.calcAmount);
+  }, 0);
+}
+
+/**
+ * Period spend: sums the supplied pre-filtered slice counting each day-instance
+ * of a ranged expense individually. Use for daily/weekly/monthly period views.
+ */
+export function sumByPeriod(
+  expenses: ExpenseData[],
+  hideSpecial = false
+): number {
+  return expenses.reduce((sum, e) => {
+    if (isNaN(Number(e.calcAmount)) || (hideSpecial && e.isSpecialExpense))
+      return sum;
+    return sum + Number(e.calcAmount);
+  }, 0);
+}
+
+/**
+ * Per-traveller attribution: sums what a traveller spent across the supplied
+ * expenses. Applies currency-conversion ratio for split expenses.
+ * Pass isTotal=true to deduplicate ranged expenses (trip total view).
+ */
+export function sumByTraveller(
+  expenses: ExpenseData[],
+  travellerId: string,
+  isTotal = false
+): number {
+  const working = isTotal ? deduplicateByRangeId(expenses) : expenses;
+  return working.reduce((sum, expense) => {
+    const hasSplits = expense.splitList && expense.splitList.length > 0;
+
+    if (!hasSplits) {
+      if (expense.whoPaid !== travellerId) return sum;
+      if (!expense.calcAmount) return sum + Number(expense.amount);
+      return sum + Number(expense.calcAmount);
+    }
+
+    const split = expense.splitList!.find((s) => s.userName === travellerId);
+    if (!split) return sum;
+
+    const splitAmount =
+      typeof split.amount === "string"
+        ? Number(String(split.amount).replace(/^0+/, ""))
+        : Number(split.amount);
+
+    if (isNaN(splitAmount) || !isFinite(splitAmount)) return sum;
+
+    if (!expense.calcAmount || !expense.amount) return sum + splitAmount;
+
+    if (expense.calcAmount === expense.amount) return sum + splitAmount;
+
+    const convertedAmount = expense.calcAmount * (splitAmount / expense.amount);
+    if (isNaN(convertedAmount) || !isFinite(convertedAmount))
+      return sum + splitAmount;
+
+    return sum + convertedAmount;
+  }, 0);
+}

--- a/TravelCostApp/util/expenseTotals.ts
+++ b/TravelCostApp/util/expenseTotals.ts
@@ -34,6 +34,7 @@ export function sumByPeriod(
   hideSpecial = false
 ): number {
   return expenses.reduce((sum, e) => {
+    if (e.isDeleted) return sum;
     if (isNaN(Number(e.calcAmount)) || (hideSpecial && e.isSpecialExpense))
       return sum;
     return sum + Number(e.calcAmount);
@@ -50,7 +51,8 @@ export function sumByTraveller(
   travellerId: string,
   isTotal = false
 ): number {
-  const working = isTotal ? deduplicateByRangeId(expenses) : expenses;
+  const active = expenses.filter((e) => !e.isDeleted);
+  const working = isTotal ? deduplicateByRangeId(active) : active;
   return working.reduce((sum, expense) => {
     const hasSplits = expense.splitList && expense.splitList.length > 0;
 

--- a/TravelCostApp/util/expenseTotals.ts
+++ b/TravelCostApp/util/expenseTotals.ts
@@ -20,8 +20,9 @@ export function sumForTrip(expenses: ExpenseData[]): number {
   const active = expenses.filter((e) => !e.isDeleted);
   const deduped = deduplicateByRangeId(active);
   return deduped.reduce((sum, e) => {
-    if (isNaN(Number(e.calcAmount))) return sum;
-    return sum + Number(e.calcAmount);
+    const value = Number(e.calcAmount);
+    if (!Number.isFinite(value)) return sum;
+    return sum + value;
   }, 0);
 }
 
@@ -35,9 +36,10 @@ export function sumByPeriod(
 ): number {
   return expenses.reduce((sum, e) => {
     if (e.isDeleted) return sum;
-    if (isNaN(Number(e.calcAmount)) || (hideSpecial && e.isSpecialExpense))
+    const value = Number(e.calcAmount);
+    if (!Number.isFinite(value) || (hideSpecial && e.isSpecialExpense))
       return sum;
-    return sum + Number(e.calcAmount);
+    return sum + value;
   }, 0);
 }
 
@@ -58,8 +60,10 @@ export function sumByTraveller(
 
     if (!hasSplits) {
       if (expense.whoPaid !== travellerId) return sum;
-      if (!expense.calcAmount) return sum + Number(expense.amount);
-      return sum + Number(expense.calcAmount);
+      if (expense.calcAmount == null) return sum + Number(expense.amount);
+      const value = Number(expense.calcAmount);
+      if (!Number.isFinite(value)) return sum;
+      return sum + value;
     }
 
     const split = expense.splitList!.find((s) => s.userName === travellerId);
@@ -70,14 +74,20 @@ export function sumByTraveller(
         ? Number(String(split.amount).replace(/^0+/, ""))
         : Number(split.amount);
 
-    if (isNaN(splitAmount) || !isFinite(splitAmount)) return sum;
+    if (!Number.isFinite(splitAmount)) return sum;
 
-    if (!expense.calcAmount || !expense.amount) return sum + splitAmount;
+    if (expense.calcAmount == null || expense.amount == null)
+      return sum + splitAmount;
 
-    if (expense.calcAmount === expense.amount) return sum + splitAmount;
+    const amountValue = Number(expense.amount);
+    const calcValue = Number(expense.calcAmount);
 
-    const convertedAmount = expense.calcAmount * (splitAmount / expense.amount);
-    if (isNaN(convertedAmount) || !isFinite(convertedAmount))
+    if (!Number.isFinite(amountValue) || !Number.isFinite(calcValue)) return sum;
+    if (amountValue === 0) return sum + splitAmount;
+    if (calcValue === amountValue) return sum + splitAmount;
+
+    const convertedAmount = calcValue * (splitAmount / amountValue);
+    if (!Number.isFinite(convertedAmount))
       return sum + splitAmount;
 
     return sum + convertedAmount;

--- a/TravelCostApp/util/expenseTotals.ts
+++ b/TravelCostApp/util/expenseTotals.ts
@@ -12,12 +12,14 @@ function deduplicateByRangeId(expenses: ExpenseData[]): ExpenseData[] {
 }
 
 /**
- * Trip total spent — counts each ranged expense ONCE (deduped by rangeId).
+ * Trip total spent — deduplicates ranged expenses by rangeId, excludes deleted.
  *
- * Use for: trip-wide cumulative totals, dynamic daily budget recalculation.
- * Pass the full, unfiltered expense list; dedup and deleted exclusion happen here.
- *
- * Do NOT use for period views — sumByPeriod counts every day-instance intentionally.
+ * ⚠ Known limitation: only correct for ranged-duplicate expenses (duplOrSplit=1),
+ * where each day-instance stores the full calcAmount. For ranged-split expenses
+ * (duplOrSplit=2) each instance stores calcAmount/days, so dedup returns just one
+ * day's share — not the full cost. Pre-existing behaviour inherited from
+ * getExpensesSumTotal. Use sumByPeriod over the full unfiltered list as a
+ * workaround for ranged-split trip totals.
  */
 export function sumForTrip(expenses: ExpenseData[]): number {
   const active = expenses.filter((e) => !e.isDeleted);
@@ -30,15 +32,12 @@ export function sumForTrip(expenses: ExpenseData[]): number {
 }
 
 /**
- * Period spend — counts every day-instance of a ranged expense (no dedup).
+ * Period spend — sums every day-instance of a ranged expense (no dedup).
  *
- * Use for: daily / weekly / monthly / yearly period views.
- * The CALLER must pre-filter the list to the window first. Each instance already
- * carries only its proportional calcAmount (ranged split), so summing all of them
- * gives the correct period total. Deduplicating here would silently discard
- * all-but-one day, making the period total up to N× too small.
- *
- * Do NOT use for trip-wide totals — use sumForTrip instead.
+ * The CALLER must pre-filter the list to the window first.
+ * For ranged-split expenses each instance stores calcAmount/days, so summing
+ * only the window's instances gives the correct proportional period cost.
+ * Deduplicating here would discard all-but-one day, making the total N× too small.
  */
 export function sumByPeriod(
   expenses: ExpenseData[],
@@ -54,12 +53,11 @@ export function sumByPeriod(
 }
 
 /**
- * Per-traveller attribution — sums what a traveller spent across the supplied expenses.
+ * Per-traveller attribution — same dedup contract as sumForTrip / sumByPeriod.
  *
- * isTotal=false (default): counts every day-instance — use for period views where
- *   the caller has pre-filtered the list to the window (same contract as sumByPeriod).
- * isTotal=true: deduplicates ranged expenses by rangeId — use for trip total views
- *   (same contract as sumForTrip).
+ * isTotal=false (default): no dedup — caller pre-filters to window (period view).
+ * isTotal=true: deduplicates by rangeId — carries the same ranged-split caveat
+ *   as sumForTrip (returns one day's share, not the full cost, for duplOrSplit=2).
  *
  * Applies expense-currency → trip-currency conversion ratio for split expenses.
  */

--- a/TravelCostApp/util/expenseTotals.ts
+++ b/TravelCostApp/util/expenseTotals.ts
@@ -12,9 +12,12 @@ function deduplicateByRangeId(expenses: ExpenseData[]): ExpenseData[] {
 }
 
 /**
- * Trip total spent: deduplicates ranged expenses by rangeId, excludes deleted.
- * Use for trip-wide cumulative totals and dynamic daily budget recalculation.
- * Each ranged expense counted once regardless of how many days it spans.
+ * Trip total spent — counts each ranged expense ONCE (deduped by rangeId).
+ *
+ * Use for: trip-wide cumulative totals, dynamic daily budget recalculation.
+ * Pass the full, unfiltered expense list; dedup and deleted exclusion happen here.
+ *
+ * Do NOT use for period views — sumByPeriod counts every day-instance intentionally.
  */
 export function sumForTrip(expenses: ExpenseData[]): number {
   const active = expenses.filter((e) => !e.isDeleted);
@@ -27,8 +30,15 @@ export function sumForTrip(expenses: ExpenseData[]): number {
 }
 
 /**
- * Period spend: sums the supplied pre-filtered slice counting each day-instance
- * of a ranged expense individually. Use for daily/weekly/monthly period views.
+ * Period spend — counts every day-instance of a ranged expense (no dedup).
+ *
+ * Use for: daily / weekly / monthly / yearly period views.
+ * The CALLER must pre-filter the list to the window first. Each instance already
+ * carries only its proportional calcAmount (ranged split), so summing all of them
+ * gives the correct period total. Deduplicating here would silently discard
+ * all-but-one day, making the period total up to N× too small.
+ *
+ * Do NOT use for trip-wide totals — use sumForTrip instead.
  */
 export function sumByPeriod(
   expenses: ExpenseData[],
@@ -44,9 +54,14 @@ export function sumByPeriod(
 }
 
 /**
- * Per-traveller attribution: sums what a traveller spent across the supplied
- * expenses. Applies currency-conversion ratio for split expenses.
- * Pass isTotal=true to deduplicate ranged expenses (trip total view).
+ * Per-traveller attribution — sums what a traveller spent across the supplied expenses.
+ *
+ * isTotal=false (default): counts every day-instance — use for period views where
+ *   the caller has pre-filtered the list to the window (same contract as sumByPeriod).
+ * isTotal=true: deduplicates ranged expenses by rangeId — use for trip total views
+ *   (same contract as sumForTrip).
+ *
+ * Applies expense-currency → trip-currency conversion ratio for split expenses.
  */
 export function sumByTraveller(
   expenses: ExpenseData[],

--- a/TravelCostApp/util/expenseTotals.ts
+++ b/TravelCostApp/util/expenseTotals.ts
@@ -78,8 +78,8 @@ export function sumByPeriod(
  * Per-traveller attribution — same dedup contract as sumForTrip / sumByPeriod.
  *
  * isTotal=false (default): no dedup — caller pre-filters to window (period view).
- * isTotal=true: deduplicates by rangeId — carries the same ranged-split caveat
- *   as sumForTrip (returns one day's share, not the full cost, for duplOrSplit=2).
+ * isTotal=true: deduplicates by rangeId — for ranged-split (duplOrSplit=2),
+ * consolidation reconstructs full cost by summing instances in the input slice.
  *
  * Applies expense-currency → trip-currency conversion ratio for split expenses.
  */
@@ -95,7 +95,11 @@ export function sumByTraveller(
 
     if (!hasSplits) {
       if (expense.whoPaid !== travellerId) return sum;
-      if (expense.calcAmount == null) return sum + Number(expense.amount);
+      if (expense.calcAmount == null) {
+        const amountValue = Number(expense.amount);
+        if (!Number.isFinite(amountValue)) return sum;
+        return sum + amountValue;
+      }
       const value = Number(expense.calcAmount);
       if (!Number.isFinite(value)) return sum;
       return sum + value;

--- a/TravelCostApp/util/expenseTotals.ts
+++ b/TravelCostApp/util/expenseTotals.ts
@@ -1,30 +1,52 @@
-import type { ExpenseData } from "./expense";
+import { DuplicateOption, type ExpenseData } from "./expense";
 
-function deduplicateByRangeId(expenses: ExpenseData[]): ExpenseData[] {
-  const seen = new Set<string>();
-  return expenses.filter((e) => {
-    if (e.rangeId) {
-      if (seen.has(e.rangeId)) return false;
-      seen.add(e.rangeId);
+declare const __periodBrand: unique symbol;
+export type PeriodSlice = ExpenseData[] & { readonly [__periodBrand]: void };
+export function asPeriodSlice(expenses: ExpenseData[]): PeriodSlice {
+  return expenses as PeriodSlice;
+}
+
+function consolidateRangedExpenses(expenses: ExpenseData[]): ExpenseData[] {
+  const byRangeId = new Map<string, ExpenseData[]>();
+  const out: ExpenseData[] = [];
+
+  for (const e of expenses) {
+    if (!e.rangeId) {
+      out.push(e);
+      continue;
     }
-    return true;
-  });
+    const existing = byRangeId.get(e.rangeId);
+    if (existing) {
+      existing.push(e);
+    } else {
+      byRangeId.set(e.rangeId, [e]);
+    }
+  }
+
+  for (const instances of byRangeId.values()) {
+    const first = instances[0];
+    if (first.duplOrSplit === DuplicateOption.split) {
+      const totalCalc = instances.reduce((sum, e) => {
+        const value = Number(e.calcAmount);
+        if (!Number.isFinite(value)) return sum;
+        return sum + value;
+      }, 0);
+      out.push({ ...first, calcAmount: totalCalc });
+    } else {
+      out.push(first);
+    }
+  }
+
+  return out;
 }
 
 /**
  * Trip total spent — deduplicates ranged expenses by rangeId, excludes deleted.
- *
- * ⚠ Known limitation: only correct for ranged-duplicate expenses (duplOrSplit=1),
- * where each day-instance stores the full calcAmount. For ranged-split expenses
- * (duplOrSplit=2) each instance stores calcAmount/days, so dedup returns just one
- * day's share — not the full cost. Pre-existing behaviour inherited from
- * getExpensesSumTotal. Use sumByPeriod over the full unfiltered list as a
- * workaround for ranged-split trip totals.
  */
 export function sumForTrip(expenses: ExpenseData[]): number {
   const active = expenses.filter((e) => !e.isDeleted);
-  const deduped = deduplicateByRangeId(active);
-  return deduped.reduce((sum, e) => {
+  const consolidated = consolidateRangedExpenses(active);
+  return consolidated.reduce((sum, e) => {
     const value = Number(e.calcAmount);
     if (!Number.isFinite(value)) return sum;
     return sum + value;
@@ -40,7 +62,7 @@ export function sumForTrip(expenses: ExpenseData[]): number {
  * Deduplicating here would discard all-but-one day, making the total N× too small.
  */
 export function sumByPeriod(
-  expenses: ExpenseData[],
+  expenses: PeriodSlice,
   hideSpecial = false
 ): number {
   return expenses.reduce((sum, e) => {
@@ -67,7 +89,7 @@ export function sumByTraveller(
   isTotal = false
 ): number {
   const active = expenses.filter((e) => !e.isDeleted);
-  const working = isTotal ? deduplicateByRangeId(active) : active;
+  const working = isTotal ? consolidateRangedExpenses(active) : active;
   return working.reduce((sum, expense) => {
     const hasSplits = expense.splitList && expense.splitList.length > 0;
 
@@ -79,7 +101,7 @@ export function sumByTraveller(
       return sum + value;
     }
 
-    const split = expense.splitList!.find((s) => s.userName === travellerId);
+    const split = expense.splitList?.find((s) => s.userName === travellerId);
     if (!split) return sum;
 
     const splitAmount =


### PR DESCRIPTION
## Summary
- Add `util/expenseTotals.ts` as the canonical home for expense sum calculations.
- Implement `sumForTrip`, `sumByPeriod`, and `sumByTraveller` (ranged-expense handling, deleted exclusion, hide-special, and currency conversion).
- Keep existing callers stable by re-exporting from `util/expense.ts`.

Closes #243.

## Test plan
- [x] `pnpm test`