### PR TITLE
feat: roll up open balances synchronously

### DIFF
--- a/TravelCostApp/__tests__/screens/split-summary-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/split-summary-screen.test.tsx
@@ -30,7 +30,7 @@ import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
 describe("Split Summary screen", () => {
-  it("lists an open Balance from fixture expenses via calcOpenSplitsTable", async () => {
+  it("lists an open Balance from fixture expenses via rollupOpenBalances", async () => {
     const navigation = { navigate: jest.fn(), pop: jest.fn() };
     const screen = renderWithAppProviders(
       <SplitSummaryScreen navigation={navigation as any} />,
@@ -77,8 +77,8 @@ describe("Split Summary screen", () => {
       { userName: "Alice", whoPaid: "Bob", amount: 30 },
     ];
     const calcSpy = jest
-      .spyOn(splitUtil, "calcOpenSplitsTable")
-      .mockResolvedValue(openBalances);
+      .spyOn(splitUtil, "rollupOpenBalances")
+      .mockReturnValue(openBalances as any);
 
     const navigation = { navigate: jest.fn(), pop: jest.fn() };
     const screen = renderWithAppProviders(

--- a/TravelCostApp/__tests__/util/open-balance-rollup.test.ts
+++ b/TravelCostApp/__tests__/util/open-balance-rollup.test.ts
@@ -1,8 +1,8 @@
-import { calcOpenSplitsTable } from "../../util/split";
+import { rollupOpenBalances } from "../../util/split";
 import { makeExpense } from "../fixtures/expense";
 
-describe("Open Balance rollup (calcOpenSplitsTable)", () => {
-  it("rolls up open Balances from fixture expenses with splitList in trip currency", async () => {
+describe("Open Balance rollup (rollupOpenBalances)", () => {
+  it("rolls up open Balances from fixture expenses with splitList in trip currency", () => {
     const expenses = [
       makeExpense({
         whoPaid: "Alice",
@@ -16,7 +16,63 @@ describe("Open Balance rollup (calcOpenSplitsTable)", () => {
       }),
     ];
 
-    const openBalances = await calcOpenSplitsTable("t1", "EUR", expenses, 0);
+    const openBalances = rollupOpenBalances(expenses, "EUR", 0);
+
+    expect(openBalances).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userName: "Bob",
+          whoPaid: "Alice",
+          amount: 50,
+        }),
+      ])
+    );
+  });
+
+  it("converts split amounts to trip currency when expense currency differs", () => {
+    const expenses = [
+      makeExpense({
+        whoPaid: "Alice",
+        // 110 USD total equals 100 EUR calcAmount -> rate 1.1 USD/EUR
+        amount: 110,
+        calcAmount: 100,
+        currency: "USD",
+        splitList: [
+          { userName: "Alice", amount: 55 },
+          { userName: "Bob", amount: 55 },
+        ],
+      }),
+    ];
+
+    const openBalances = rollupOpenBalances(expenses, "EUR", 0);
+
+    expect(openBalances).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userName: "Bob",
+          whoPaid: "Alice",
+          amount: 50,
+        }),
+      ])
+    );
+  });
+
+  it("keeps an expense open when edited after the settlement timestamp", () => {
+    const expenses = [
+      makeExpense({
+        whoPaid: "Alice",
+        amount: 100,
+        calcAmount: 100,
+        currency: "EUR",
+        editedTimestamp: 2000,
+        splitList: [
+          { userName: "Alice", amount: 50 },
+          { userName: "Bob", amount: 50 },
+        ],
+      }),
+    ];
+
+    const openBalances = rollupOpenBalances(expenses, "EUR", 1000);
 
     expect(openBalances).toEqual(
       expect.arrayContaining([

--- a/TravelCostApp/screens/SplitSummaryScreen.tsx
+++ b/TravelCostApp/screens/SplitSummaryScreen.tsx
@@ -95,7 +95,7 @@ const SplitSummaryScreen = ({ navigation }) => {
     totalPayBackTextOriginal
   );
 
-  const getOpenSplits = useCallback(async () => {
+  const getOpenSplits = useCallback(() => {
     if (!tripid || expenses?.length === 0) return;
     setIsFetching(true);
     try {
@@ -338,7 +338,7 @@ const SplitSummaryScreen = ({ navigation }) => {
               trackEvent(VexoEvents.SPLIT_SUMMARY_BACK_PRESSED);
               navigation.goBack();
             } else {
-              await getOpenSplits();
+              getOpenSplits();
               setShowSimplify(true);
               setTitleText(titleTextOriginal);
             }

--- a/TravelCostApp/screens/SplitSummaryScreen.tsx
+++ b/TravelCostApp/screens/SplitSummaryScreen.tsx
@@ -24,7 +24,7 @@ import { GlobalStyles } from "../constants/styles";
 import { TripContext } from "../store/trip-context";
 import {
   areSplitListsEqual,
-  calcOpenSplitsTable,
+  rollupOpenBalances,
   simplifySplits,
 } from "../util/split";
 import PropTypes from "prop-types";
@@ -99,12 +99,7 @@ const SplitSummaryScreen = ({ navigation }) => {
     if (!tripid || expenses?.length === 0) return;
     setIsFetching(true);
     try {
-      const response = await calcOpenSplitsTable(
-        tripid,
-        tripCurrency,
-        expenses,
-        isPaidTimestamp
-      );
+      const response = rollupOpenBalances(expenses, tripCurrency, isPaidTimestamp);
       const formattedSplits = [];
       let userGetsBack = 0;
       let userHasToPay = 0;

--- a/TravelCostApp/util/split.ts
+++ b/TravelCostApp/util/split.ts
@@ -9,7 +9,6 @@ import {
 import { Traveller } from "./traveler";
 import { DateOrDateTime } from "./date";
 
-import { getAllExpenses } from "./http";
 import safeLogError from "./error";
 import { safelyParseJSON } from "./jsonParse";
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -351,71 +350,77 @@ export function travellerToDropdown(
   return [...listOfLabelValues];
 }
 
-export async function calcOpenSplitsTable(
+/**
+ * @deprecated Use `rollupOpenBalances(expenses, tripCurrency, tripIsPaidTimestamp?)`.
+ *
+ * Kept for backwards compatibility with older callers. This is now synchronous and
+ * no longer fetches expenses over HTTP when none are provided.
+ */
+export function calcOpenSplitsTable(
   tripid: string,
   tripCurrency: string,
   givenExpenses?: ExpenseData[],
   tripIsPaidTimestamp?: number
 ) {
-  let expenses = [];
-  const rates = {};
-  rates[tripCurrency] = 1;
-  if (givenExpenses && givenExpenses?.length > 0) {
-    expenses = [...givenExpenses];
-  } else {
-    try {
-      expenses = await getAllExpenses(tripid);
-    } catch (error) {
-      safeLogError(error);
-    }
-    if (!expenses || expenses?.length < 1) {
-      return [];
-    }
-  }
-  let openSplits = [];
-  const asyncSplitList = async () => {
-    for (const exp of expenses) {
-      const expense: ExpenseData = exp;
+  return rollupOpenBalances(givenExpenses ?? [], tripCurrency, tripIsPaidTimestamp);
+}
 
-      // Skip expense if:
-      // 1. Expense type is SELF
-      // 2. Expense has no split list
-      // 3. Expense has effective isPaid status of "paid" (checked via timestamp override logic)
-      if (
-        expense.splitType === "SELF" ||
-        !expense.splitList ||
-        getEffectiveIsPaid(expense, tripIsPaidTimestamp) === isPaidString.paid
-      ) {
+export function rollupOpenBalances(
+  expenses: ExpenseData[],
+  tripCurrency: string,
+  tripIsPaidTimestamp?: number
+): Split[] {
+  const rates: Record<string, number> = {};
+  rates[tripCurrency] = 1;
+
+  let openSplits: Split[] = [];
+  for (const exp of expenses) {
+    const expense: ExpenseData = exp;
+
+    // Skip expense if:
+    // 1. Expense type is SELF
+    // 2. Expense has no split list
+    // 3. Expense has effective isPaid status of "paid" (checked via timestamp override logic)
+    if (
+      expense.splitType === "SELF" ||
+      !expense.splitList ||
+      getEffectiveIsPaid(expense, tripIsPaidTimestamp) === isPaidString.paid
+    ) {
+      continue;
+    }
+
+    for (const split of expense.splitList) {
+      if (split.userName === expense.whoPaid) {
         continue;
       }
-      for (const split of expense.splitList) {
-        if (split.userName !== expense.whoPaid) {
-          // Create a copy of the split object to avoid mutating the original
-          const splitCopy = { ...split };
 
-          // check if rate is already in rates
-          if (!rates[expense.currency]) {
-            // get rate
-            try {
-              const rate = expense.amount / expense.calcAmount;
-              rates[expense.currency] = rate;
-              splitCopy.amount = splitCopy.amount / rate;
-            } catch (error) {
-              safeLogError(error);
-            }
-          } else {
-            splitCopy.amount = splitCopy.amount / rates[expense.currency];
-          }
-          splitCopy.whoPaid = expense.whoPaid;
-          openSplits.push(splitCopy);
+      // Create a copy of the split object to avoid mutating the original
+      const splitCopy: Split = { ...split };
+
+      // check if rate is already in rates
+      if (!rates[expense.currency]) {
+        try {
+          const rate = expense.amount / expense.calcAmount;
+          rates[expense.currency] = rate;
+          splitCopy.amount = Number((splitCopy.amount / rate).toFixed(2));
+        } catch (error) {
+          safeLogError(error);
         }
+      } else {
+        splitCopy.amount = Number(
+          (splitCopy.amount / rates[expense.currency]).toFixed(2)
+        );
       }
+
+      splitCopy.whoPaid = expense.whoPaid;
+      openSplits.push(splitCopy);
     }
-  };
-  await asyncSplitList();
+  }
+
   if (openSplits?.length < 1) {
     return openSplits;
   }
+
   openSplits = sumUpSamePairs(openSplits);
   openSplits = cancelDifferences(openSplits);
 

--- a/TravelCostApp/util/split.ts
+++ b/TravelCostApp/util/split.ts
@@ -376,6 +376,7 @@ export function rollupOpenBalances(
   let openSplits: Split[] = [];
   for (const exp of expenses) {
     const expense: ExpenseData = exp;
+    const expenseCurrency = expense.currency || tripCurrency;
 
     // Skip expense if:
     // 1. Expense type is SELF
@@ -398,17 +399,43 @@ export function rollupOpenBalances(
       const splitCopy: Split = { ...split };
 
       // check if rate is already in rates
-      if (!rates[expense.currency]) {
+      if (!rates[expenseCurrency]) {
         try {
-          const rate = expense.amount / expense.calcAmount;
-          rates[expense.currency] = rate;
-          splitCopy.amount = Number((splitCopy.amount / rate).toFixed(2));
+          // When expense currency differs from trip currency, we convert split amounts into trip currency.
+          // The conversion factor comes from the expense's original amount vs its already-converted calcAmount.
+          const calcAmount = Number(expense.calcAmount);
+          const amount = Number(expense.amount);
+          if (
+            expenseCurrency === tripCurrency ||
+            !calcAmount ||
+            Number.isNaN(calcAmount) ||
+            !amount ||
+            Number.isNaN(amount)
+          ) {
+            // Either already trip currency, or conversion inputs are invalid (avoid Infinity/NaN).
+            rates[expenseCurrency] = 1;
+            splitCopy.amount = Number(Number(splitCopy.amount).toFixed(2));
+          } else {
+            const rate = amount / calcAmount;
+            if (!rate || Number.isNaN(rate) || !Number.isFinite(rate)) {
+              safeLogError(
+                new Error(
+                  `Invalid currency conversion rate for ${expenseCurrency}→${tripCurrency}`
+                )
+              );
+              rates[expenseCurrency] = 1;
+              splitCopy.amount = Number(Number(splitCopy.amount).toFixed(2));
+            } else {
+              rates[expenseCurrency] = rate;
+              splitCopy.amount = Number((splitCopy.amount / rate).toFixed(2));
+            }
+          }
         } catch (error) {
           safeLogError(error);
         }
       } else {
         splitCopy.amount = Number(
-          (splitCopy.amount / rates[expense.currency]).toFixed(2)
+          (splitCopy.amount / rates[expenseCurrency]).toFixed(2)
         );
       }
 


### PR DESCRIPTION
## Summary
- Extract `rollupOpenBalances(expenses, tripCurrency, tripIsPaidTimestamp?)` as a pure synchronous open-balance rollup.
- Keep `calcOpenSplitsTable` as a deprecated synchronous alias (no HTTP fallback).
- Update `SplitSummaryScreen` and tests; add coverage for currency conversion and post-settlement edits staying open.

## Test plan
- `pnpm test`

Fixes #245