### PR TITLE
feat: trip total spent hook

### DIFF
--- a/TravelCostApp/App.tsx
+++ b/TravelCostApp/App.tsx
@@ -826,11 +826,11 @@ export default function App() {
           <StatusBar style="auto" />
           <AuthContextProvider>
             <NetworkContextProvider>
-              <TripContextProvider>
-                <UserContextProvider>
-                  <SettingsProvider>
-                    <NetworkProvider>
-                      <ExpensesContextProvider>
+              <ExpensesContextProvider>
+                <TripContextProvider>
+                  <UserContextProvider>
+                    <SettingsProvider>
+                      <NetworkProvider>
                         <OrientationContextProvider>
                           <GestureHandlerRootView style={{ flex: 1 }}>
                             <TourGuideProvider
@@ -868,11 +868,11 @@ export default function App() {
                             </TourGuideProvider>
                           </GestureHandlerRootView>
                         </OrientationContextProvider>
-                      </ExpensesContextProvider>
-                    </NetworkProvider>
-                  </SettingsProvider>
-                </UserContextProvider>
-              </TripContextProvider>
+                      </NetworkProvider>
+                    </SettingsProvider>
+                  </UserContextProvider>
+                </TripContextProvider>
+              </ExpensesContextProvider>
             </NetworkContextProvider>
           </AuthContextProvider>
         </SafeAreaWrapper>

--- a/TravelCostApp/__tests__/hooks/use-trip-total-spent.test.tsx
+++ b/TravelCostApp/__tests__/hooks/use-trip-total-spent.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Text } from "react-native";
+import { render } from "@testing-library/react-native";
+
+import { ExpensesContext } from "../../store/expenses-context";
+import { sumForTrip } from "../../util/expenseTotals";
+import { useTripTotalSpent } from "../../hooks/useTripTotalSpent";
+import { makeExpense } from "../fixtures/expense";
+
+function TotalSpent() {
+  const total = useTripTotalSpent();
+  return <Text testID="total">{String(total)}</Text>;
+}
+
+describe("useTripTotalSpent", () => {
+  it("returns sumForTrip(expenses)", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 30, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: 20, splitList: [] }),
+    ];
+
+    const screen = render(
+      <ExpensesContext.Provider value={{ expenses } as any}>
+        <TotalSpent />
+      </ExpensesContext.Provider>
+    );
+
+    expect(screen.getByTestId("total").props.children).toBe(
+      String(sumForTrip(expenses))
+    );
+  });
+
+  it("updates when expenses change", () => {
+    const initial = [makeExpense({ id: "e1", calcAmount: 10, splitList: [] })];
+    const updated = [
+      makeExpense({ id: "e1", calcAmount: 10, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: 25, splitList: [] }),
+    ];
+
+    const screen = render(
+      <ExpensesContext.Provider value={{ expenses: initial } as any}>
+        <TotalSpent />
+      </ExpensesContext.Provider>
+    );
+
+    expect(screen.getByTestId("total").props.children).toBe(
+      String(sumForTrip(initial))
+    );
+
+    screen.rerender(
+      <ExpensesContext.Provider value={{ expenses: updated } as any}>
+        <TotalSpent />
+      </ExpensesContext.Provider>
+    );
+
+    expect(screen.getByTestId("total").props.children).toBe(
+      String(sumForTrip(updated))
+    );
+  });
+
+  it("excludes deleted expenses", () => {
+    const expenses = [
+      makeExpense({ id: "e1", calcAmount: 100, isDeleted: true, splitList: [] }),
+      makeExpense({ id: "e2", calcAmount: 40, splitList: [] }),
+    ];
+
+    const screen = render(
+      <ExpensesContext.Provider value={{ expenses } as any}>
+        <TotalSpent />
+      </ExpensesContext.Provider>
+    );
+
+    expect(screen.getByTestId("total").props.children).toBe(
+      String(sumForTrip(expenses))
+    );
+  });
+});
+

--- a/TravelCostApp/__tests__/screens/financial-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/financial-screen.test.tsx
@@ -27,7 +27,6 @@ describe("Financial screen", () => {
         startDate: pastDate.toISOString(),
         endDate: new Date("2026-02-01T12:00:00.000Z").toISOString(),
         travellers: ["Alice", "Bob"],
-        setTotalSum: jest.fn(),
       },
       expenses: {
         expenses: [makeExpense({ date: pastDate, calcAmount: 40 })],

--- a/TravelCostApp/__tests__/store/dynamic-daily-budget-from-expenses.test.tsx
+++ b/TravelCostApp/__tests__/store/dynamic-daily-budget-from-expenses.test.tsx
@@ -1,0 +1,116 @@
+import React, { useContext, useEffect, useRef } from "react";
+import { Text } from "react-native";
+import { render, waitFor } from "@testing-library/react-native";
+
+import TripContextProvider, { TripContext } from "../../store/trip-context";
+import { ExpensesContext } from "../../store/expenses-context";
+import { makeExpense } from "../fixtures/expense";
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => null),
+}));
+
+function BudgetProbe() {
+  const tripCtx = useContext(TripContext);
+  const didInit = useRef(false);
+
+  useEffect(() => {
+    if (didInit.current) return;
+    didInit.current = true;
+    (async () => {
+      await tripCtx.setCurrentTrip("trip-1", {
+        tripName: "Test Trip",
+        totalBudget: "100",
+        dailyBudget: "0",
+        tripCurrency: "EUR",
+        startDate: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+        endDate: new Date("2026-01-11T00:00:00.000Z").toISOString(),
+        travellers: [],
+        isDynamicDailyBudget: true,
+        totalSum: 0,
+      });
+    })();
+  }, [tripCtx.setCurrentTrip]);
+
+  return <Text testID="dailyBudget">{String(tripCtx.dailyBudget)}</Text>;
+}
+
+describe("TripContext dynamic daily budget", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("recomputes from expenses-derived trip total spent", async () => {
+    const initialExpenses = [
+      makeExpense({ id: "e1", calcAmount: 20, splitList: [] }),
+      makeExpense({ id: "e_deleted", calcAmount: 999, isDeleted: true, splitList: [] }),
+    ];
+    const updatedExpenses = [
+      ...initialExpenses,
+      makeExpense({ id: "e2", calcAmount: 30, splitList: [] }),
+    ];
+
+    const baseExpensesCtx = {
+      isSyncing: false,
+      addExpense: jest.fn(),
+      setExpenses: jest.fn(),
+      mergeExpenses: jest.fn(),
+      deleteExpense: jest.fn(),
+      updateExpense: jest.fn(),
+      updateExpenseId: jest.fn(),
+      getRecentExpenses: jest.fn(() => []),
+      getYearlyExpenses: jest.fn(() => ({
+        firstDay: new Date(),
+        lastDay: new Date(),
+        yearlyExpenses: [],
+      })),
+      getMonthlyExpenses: jest.fn(() => ({
+        firstDay: new Date(),
+        lastDay: new Date(),
+        monthlyExpenses: [],
+      })),
+      getWeeklyExpenses: jest.fn(() => ({
+        firstDay: new Date(),
+        lastDay: new Date(),
+        weeklyExpenses: [],
+      })),
+      getDailyExpenses: jest.fn(() => []),
+      getSpecificDayExpenses: jest.fn(() => []),
+      getSpecificWeekExpenses: jest.fn(() => []),
+      getSpecificMonthExpenses: jest.fn(() => []),
+      getSpecificYearExpenses: jest.fn(() => []),
+      loadExpensesFromStorage: jest.fn(async () => true),
+      setIsSyncing: jest.fn(),
+    };
+
+    const screen = render(
+      <ExpensesContext.Provider value={{ ...baseExpensesCtx, expenses: initialExpenses } as any}>
+        <TripContextProvider>
+          <BudgetProbe />
+        </TripContextProvider>
+      </ExpensesContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dailyBudget").props.children).toBe("8.00");
+    });
+
+    screen.rerender(
+      <ExpensesContext.Provider value={{ ...baseExpensesCtx, expenses: updatedExpenses } as any}>
+        <TripContextProvider>
+          <BudgetProbe />
+        </TripContextProvider>
+      </ExpensesContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dailyBudget").props.children).toBe("5.00");
+    });
+  });
+});
+

--- a/TravelCostApp/__tests__/util/offline-expense-sync-vertical.test.ts
+++ b/TravelCostApp/__tests__/util/offline-expense-sync-vertical.test.ts
@@ -103,7 +103,6 @@ describe("offline expense sync (#230)", () => {
     (getAllExpenses as jest.Mock).mockResolvedValue([serverExpense]);
 
     const mergeExpenses = jest.fn();
-    const tripCtx = { setTotalSum: jest.fn() };
 
     await fetchAndSetExpenses(
       false,
@@ -116,8 +115,7 @@ describe("offline expense sync (#230)", () => {
         setIsSyncing: jest.fn(),
       } as any,
       "trip-1",
-      "u1",
-      tripCtx as any
+      "u1"
     );
 
     expect(mergeExpenses).toHaveBeenCalledWith([serverExpense]);

--- a/TravelCostApp/components/ExpensesOutput/RecentExpensesUtil.ts
+++ b/TravelCostApp/components/ExpensesOutput/RecentExpensesUtil.ts
@@ -1,13 +1,6 @@
 import { getAllExpenses, unTouchTraveler } from "../../util/http";
 
-import { i18n } from "../../i18n/i18n";
-
-import { getExpensesSum } from "../../util/expense";
-import {
-  ExpenseContextType,
-  mergeExpenseLists,
-} from "../../store/expenses-context";
-import { TripContextType } from "../../store/trip-context";
+import { ExpenseContextType } from "../../store/expenses-context";
 import safeLogError from "../../util/error";
 
 export async function fetchAndSetExpenses(
@@ -17,8 +10,7 @@ export async function fetchAndSetExpenses(
   setRefreshing: (isRefreshing: boolean) => void,
   expensesCtx: ExpenseContextType,
   tripid: string,
-  uid: string,
-  tripCtx: TripContextType
+  uid: string
 ) {
   if (showRefIndicator && showAnyIndicator) setIsFetching(true);
   if (showAnyIndicator) setRefreshing(true);
@@ -40,10 +32,7 @@ export async function fetchAndSetExpenses(
     expenses = expenses.filter((expense) => !isNaN(Number(expense.calcAmount)));
 
     if (expenses && expenses?.length !== 0) {
-      const mergedForSum = mergeExpenseLists(expensesCtx.expenses, expenses);
       expensesCtx.mergeExpenses(expenses);
-      const expensesSum = getExpensesSum(mergedForSum);
-      tripCtx.setTotalSum(expensesSum);
 
       // Note: The merged expenses will be automatically saved to storage
       // via the useEffect in expenses-context.tsx that watches expensesState changes

--- a/TravelCostApp/hooks/useTripTotalSpent.ts
+++ b/TravelCostApp/hooks/useTripTotalSpent.ts
@@ -1,0 +1,10 @@
+import { useContext, useMemo } from "react";
+
+import { ExpensesContext } from "../store/expenses-context";
+import { sumForTrip } from "../util/expenseTotals";
+
+export function useTripTotalSpent(): number {
+  const { expenses } = useContext(ExpensesContext);
+  return useMemo(() => sumForTrip(expenses), [expenses]);
+}
+

--- a/TravelCostApp/screens/FinancialScreen.tsx
+++ b/TravelCostApp/screens/FinancialScreen.tsx
@@ -38,7 +38,6 @@ const FinancialScreen = () => {
 
   const restCash =
     Number(daysFromStartToToday) * Number(tripCtx.dailyBudget) - expensesSum;
-  tripCtx.setTotalSum(expensesSum);
   const multiTraveller =
     tripCtx.travellers && tripCtx.travellers.length > 1 ? true : false;
   // if (restCash < 0) restCash = 0;
@@ -52,6 +51,7 @@ const FinancialScreen = () => {
           totalCost={totalBudgetNum}
           catCost={restCash}
           iconOverride="fast-food-outline"
+          iconJSXOverride={undefined}
         />
       </View>
 
@@ -64,8 +64,9 @@ const FinancialScreen = () => {
           trackEvent(VexoEvents.OPEN_SPLITS_SUMMARY_PRESSED, {
             tripId: tripCtx.tripid,
           });
-          navigation.navigate("SplitSummary", { tripid: tripCtx.tripid });
+          (navigation as any).navigate("SplitSummary", { tripid: tripCtx.tripid });
         }}
+        buttonStyle={styles.button}
         style={styles.button}
       >
         {i18n.t("simplifySplitsLabel")}

--- a/TravelCostApp/screens/FinancialScreen.tsx
+++ b/TravelCostApp/screens/FinancialScreen.tsx
@@ -14,7 +14,7 @@ import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
 
 const FinancialScreen = () => {
-  const navigation = useNavigation();
+  const navigation = useNavigation<any>();
   const tripCtx = useContext(TripContext);
   const userCtx = useContext(UserContext);
   const expCtx = useContext(ExpensesContext);
@@ -51,7 +51,6 @@ const FinancialScreen = () => {
           totalCost={totalBudgetNum}
           catCost={restCash}
           iconOverride="fast-food-outline"
-          iconJSXOverride={undefined}
         />
       </View>
 
@@ -64,7 +63,7 @@ const FinancialScreen = () => {
           trackEvent(VexoEvents.OPEN_SPLITS_SUMMARY_PRESSED, {
             tripId: tripCtx.tripid,
           });
-          (navigation as any).navigate("SplitSummary", { tripid: tripCtx.tripid });
+          navigation.navigate("SplitSummary", { tripid: tripCtx.tripid });
         }}
         buttonStyle={styles.button}
         style={styles.button}

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -72,8 +72,7 @@ function RecentExpenses({ navigation }) {
       setRefreshing: (isRefreshing: boolean) => void,
       expensesCtx: ExpenseContextType,
       tripid: string,
-      uid: string,
-      tripCtx: TripContextType
+      uid: string
     ) => {
       await fetchAndSetExpenses(
         showRefIndicator,
@@ -82,8 +81,7 @@ function RecentExpenses({ navigation }) {
         setRefreshing,
         expensesCtx,
         tripid,
-        uid,
-        tripCtx
+        uid
       );
     },
     []
@@ -138,8 +136,7 @@ function RecentExpenses({ navigation }) {
         setRefreshing,
         expensesCtx,
         tripid,
-        uid,
-        tripCtx
+        uid
       );
     },
     [

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -192,12 +192,11 @@ function RecentExpenses({ navigation }) {
         expensesCtx,
         tripid,
         uid,
-        tripCtx,
       });
     } catch (error) {
       // Error handling is done in refreshWithToast
     }
-  }, [expensesCtx, tripid, uid, tripCtx, setIsFetching, setRefreshing]);
+  }, [expensesCtx, tripid, uid, setIsFetching, setRefreshing]);
 
   // strong connection state
   const [offlineString, setOfflineString] = useState("");

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -21,6 +21,7 @@ export interface TripData {
   tripCurrency?: string;
   travellers?: Traveller[];
   tripid?: string;
+  /** @deprecated derive trip total spent from expenses instead (see #247) */
   totalSum?: number;
   tripProgress?: number;
   startDate?: string;
@@ -41,6 +42,7 @@ export type TripContextType = {
   dailyBudget: string;
   setdailyBudget: (dailyBudget: string) => void;
   tripCurrency: string;
+  /** @deprecated derive trip total spent from expenses instead (see #247) */
   totalSum: number;
   tripProgress: number;
   startDate: string;
@@ -50,6 +52,7 @@ export type TripContextType = {
   setTripProgress: (percent: number) => void;
   travellers: Traveller[];
   fetchAndSetTravellers: (tripid: string) => Promise<boolean>;
+  /** @deprecated derive trip total spent from expenses instead (see #247) */
   setTotalSum: (amount: number) => void;
   setTripid: (tripid: string) => void;
   addTrip: ({ tripName, tripTotalBudget }) => void;
@@ -161,6 +164,7 @@ function TripContextProvider({ children }) {
   useEffect(() => {
     function calcDynamicDailyBudget() {
       if (isDynamicDailyBudget) {
+        // TODO: stop reading TripContext.totalSum; compute dynamic daily budget from expenses-derived totals.
         const daysLeft = Math.floor(
           (new Date(endDate).getTime() - new Date().getTime()) /
             (1000 * 3600 * 24)

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import React, { createContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { fetchTrip, fetchUser, getTravellers, updateTrip } from "../util/http";
 import { asyncStoreGetObject, asyncStoreSetObject } from "./async-storage";
 import { MAX_JS_NUMBER } from "../confAppConstants";
@@ -12,6 +12,9 @@ import { useInterval } from "../components/Hooks/useInterval";
 import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "./mmkv";
 import { Category } from "../util/category";
 import safeLogError from "../util/error";
+import { ExpensesContext } from "./expenses-context";
+import { sumForTrip } from "../util/expenseTotals";
+import { computeDynamicDailyBudget } from "../util/budget";
 
 export interface TripData {
   tripName?: string;
@@ -120,6 +123,7 @@ export const TripContext = createContext<TripContextType>({
 });
 
 function TripContextProvider({ children }) {
+  const expensesCtx = useContext(ExpensesContext);
   const [travellers, setTravellers] = useState([]);
   const [tripid, setTripid] = useState("");
   const [tripName, setTripName] = useState("");
@@ -138,6 +142,11 @@ function TripContextProvider({ children }) {
   );
   const [isLoading, setIsLoading] = useState(false);
   const [isDynamicDailyBudget, setIsDynamicDailyBudget] = useState(false);
+
+  const tripTotalSpent = useMemo(() => {
+    const expenses = expensesCtx?.expenses ?? [];
+    return sumForTrip(expenses);
+  }, [expensesCtx?.expenses]);
 
   async function loadTripidFetchTrip() {
     const stored_tripid = await secureStoreGetItem("currentTripId");
@@ -164,24 +173,23 @@ function TripContextProvider({ children }) {
   useEffect(() => {
     function calcDynamicDailyBudget() {
       if (isDynamicDailyBudget) {
-        // TODO: stop reading TripContext.totalSum; compute dynamic daily budget from expenses-derived totals.
-        const daysLeft = Math.floor(
-          (new Date(endDate).getTime() - new Date().getTime()) /
-            (1000 * 3600 * 24)
-        );
-        const totalBudgetLeft = Number(totalBudget) - Number(totalSum);
-        const dailyBudget = totalBudgetLeft / daysLeft;
+        const computed = computeDynamicDailyBudget({
+          totalBudget: Number(totalBudget),
+          tripTotalSpent,
+          endDate: new Date(endDate),
+          now: new Date(),
+        });
         // negative numbers are not allowed
-        if (isNaN(dailyBudget)) return;
-        if (dailyBudget < 0) {
+        if (isNaN(computed)) return;
+        if (computed < 0) {
           setdailyBudget("0.0001");
         } else {
-          setdailyBudget(dailyBudget.toFixed(2));
+          setdailyBudget(computed.toFixed(2));
         }
       }
     }
     calcDynamicDailyBudget();
-  }, [isDynamicDailyBudget, totalBudget, totalSum, endDate]);
+  }, [isDynamicDailyBudget, totalBudget, tripTotalSpent, endDate]);
 
   useInterval(
     () => {

--- a/TravelCostApp/util/refreshWithToast.ts
+++ b/TravelCostApp/util/refreshWithToast.ts
@@ -38,8 +38,7 @@ export async function refreshWithToast({
       setRefreshing,
       expensesCtx as ExpenseContextType,
       tripid,
-      uid,
-      tripCtx as TripContextType
+      uid
     );
 
     // Calculate how many new expenses were synced

--- a/TravelCostApp/util/refreshWithToast.ts
+++ b/TravelCostApp/util/refreshWithToast.ts
@@ -3,7 +3,6 @@ import { fetchAndSetExpenses } from "../components/ExpensesOutput/RecentExpenses
 
 import { i18n } from "../i18n/i18n";
 import { ExpenseContextType } from "../store/expenses-context";
-import { TripContextType } from "../store/trip-context";
 
 export interface RefreshWithToastParams {
   showRefIndicator: boolean;
@@ -13,7 +12,6 @@ export interface RefreshWithToastParams {
   expensesCtx: ExpenseContextType;
   tripid: string;
   uid: string;
-  tripCtx: TripContextType;
 }
 
 export async function refreshWithToast({
@@ -24,7 +22,6 @@ export async function refreshWithToast({
   expensesCtx,
   tripid,
   uid,
-  tripCtx,
 }: RefreshWithToastParams): Promise<void> {
   // Store the count of expenses before refresh
   const expensesCountBefore = expensesCtx.expenses.length;


### PR DESCRIPTION
## Summary
- Add `useTripTotalSpent()` hook derived from `ExpensesContext` via `sumForTrip`.
- Remove runtime `TripContext.setTotalSum` side effects (sync + render) and update callers/tests.
- Deprecate `TripContext.totalSum` / `setTotalSum` (kept for dynamic daily budget until follow-up).

## Test plan
- [x] `pnpm test`