### PR TITLE
Settlement: pure settleTrip + Balances=0 invariant

### DIFF
--- a/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
+++ b/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
@@ -1,0 +1,60 @@
+import React, { useContext, useEffect } from "react";
+import { render, waitFor } from "@testing-library/react-native";
+
+import TripContextProvider, { TripContext } from "../../store/trip-context";
+import { ExpensesContext } from "../../store/expenses-context";
+
+jest.mock("../../components/Hooks/useInterval", () => ({
+  useInterval: () => {},
+}));
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: {
+    CURRENT_TRIP: "current_trip",
+  },
+  getMMKVObject: jest.fn(() => null),
+  setMMKVObject: jest.fn(),
+}));
+
+const mockAsyncStoreGetObject = jest.fn(async () => null);
+jest.mock("../../store/async-storage", () => ({
+  asyncStoreGetObject: (...args: any[]) => mockAsyncStoreGetObject(...args),
+  asyncStoreSetObject: jest.fn(),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => null),
+}));
+
+function LoadTravellersProbe({
+  onResult,
+}: {
+  onResult: (travellers: unknown) => void;
+}) {
+  const ctx = useContext(TripContext);
+  useEffect(() => {
+    ctx.loadTravellersFromStorage().then(onResult);
+  }, [ctx, onResult]);
+  return null;
+}
+
+describe("TripContext storage contracts", () => {
+  it("loadTravellersFromStorage resolves to [] when storage is empty", async () => {
+    mockAsyncStoreGetObject.mockResolvedValueOnce(null);
+
+    const results: unknown[] = [];
+    render(
+      <ExpensesContext.Provider value={{ expenses: [] } as any}>
+        <TripContextProvider>
+          <LoadTravellersProbe onResult={(r) => results.push(r)} />
+        </TripContextProvider>
+      </ExpensesContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(results.length).toBeGreaterThan(0);
+    });
+    expect(results[0]).toEqual([]);
+  });
+});
+

--- a/TravelCostApp/__tests__/util/settlement.test.ts
+++ b/TravelCostApp/__tests__/util/settlement.test.ts
@@ -1,0 +1,111 @@
+import { settleTrip } from "../../util/settlement";
+import { makeExpense } from "../fixtures/expense";
+import { rollupOpenBalances } from "../../util/split";
+import { getEffectiveIsPaid, isPaidString } from "../../util/expense";
+
+describe("Settlement (settleTrip)", () => {
+  it("sets isPaid, isPaidTimestamp, isPaidDate and preserves all other trip fields", () => {
+    const now = Date.UTC(2026, 0, 15, 12, 0, 0);
+    const trip = {
+      tripid: "t1",
+      tripName: "Japan",
+      tripCurrency: "EUR",
+      isPaid: isPaidString.notPaid,
+      isPaidTimestamp: 0,
+      isPaidDate: "",
+      travellers: [{ uid: "u1", userName: "Alice", touched: true }],
+      expenses: [makeExpense()],
+      totalBudget: "1000",
+      dailyBudget: "50",
+      startDate: "2026-01-01T00:00:00.000Z",
+      endDate: "2026-02-01T00:00:00.000Z",
+      isDynamicDailyBudget: false,
+    };
+
+    const settled = settleTrip(trip, now);
+
+    expect(settled).toEqual({
+      ...trip,
+      isPaid: isPaidString.paid,
+      isPaidTimestamp: now,
+      isPaidDate: new Date(now).toISOString(),
+    });
+    expect(settled).not.toBe(trip);
+  });
+
+  it("satisfies the invariant: after settlement, open Balances roll up to []", () => {
+    const now = 1000;
+    const trip = {
+      tripCurrency: "EUR",
+      expenses: [
+        makeExpense({
+          whoPaid: "Alice",
+          editedTimestamp: 0,
+          splitList: [
+            { userName: "Alice", amount: 50 },
+            { userName: "Bob", amount: 50 },
+          ],
+        }),
+        makeExpense({
+          id: "e2",
+          whoPaid: "Bob",
+          editedTimestamp: 0,
+          splitList: [
+            { userName: "Alice", amount: 20 },
+            { userName: "Bob", amount: 80 },
+          ],
+        }),
+      ],
+    };
+
+    const openBefore = rollupOpenBalances(trip.expenses, trip.tripCurrency, 0);
+    expect(openBefore.length).toBeGreaterThan(0);
+
+    const settledTrip = settleTrip(trip, now);
+
+    // Per-expense paid-back is derived by getEffectiveIsPaid with trip settlement timestamp.
+    for (const exp of trip.expenses) {
+      expect(getEffectiveIsPaid(exp, settledTrip.isPaidTimestamp)).toBe(
+        isPaidString.paid
+      );
+    }
+
+    const openAfter = rollupOpenBalances(
+      trip.expenses,
+      trip.tripCurrency,
+      settledTrip.isPaidTimestamp
+    );
+    expect(openAfter).toEqual([]);
+  });
+
+  it("keeps an expense open when edited after settlement timestamp", () => {
+    const settledAt = 1000;
+    const trip = {
+      tripCurrency: "EUR",
+      expenses: [
+        makeExpense({
+          whoPaid: "Alice",
+          editedTimestamp: settledAt + 1,
+          splitList: [
+            { userName: "Alice", amount: 50 },
+            { userName: "Bob", amount: 50 },
+          ],
+        }),
+      ],
+    };
+
+    const settledTrip = settleTrip(trip, settledAt);
+
+    expect(
+      getEffectiveIsPaid(trip.expenses[0], settledTrip.isPaidTimestamp)
+    ).toBe(isPaidString.notPaid);
+
+    const openBalances = rollupOpenBalances(
+      trip.expenses,
+      trip.tripCurrency,
+      settledTrip.isPaidTimestamp
+    );
+    expect(openBalances.length).toBeGreaterThan(0);
+  });
+});
+

--- a/TravelCostApp/__tests__/util/settlement.test.ts
+++ b/TravelCostApp/__tests__/util/settlement.test.ts
@@ -62,6 +62,9 @@ describe("Settlement (settleTrip)", () => {
     expect(openBefore.length).toBeGreaterThan(0);
 
     const settledTrip = settleTrip(trip, now);
+    expect(settledTrip.isPaid).toBe(isPaidString.paid);
+    expect(settledTrip.isPaidTimestamp).toBe(now);
+    expect(settledTrip.isPaidDate).toBe(new Date(now).toISOString());
 
     // Per-expense paid-back is derived by getEffectiveIsPaid with trip settlement timestamp.
     for (const exp of trip.expenses) {

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable react/prop-types */
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { fetchTrip, fetchUser, getTravellers, updateTrip } from "../util/http";
 import { asyncStoreGetObject, asyncStoreSetObject } from "./async-storage";
@@ -105,7 +104,7 @@ export const TripContext = createContext<TripContextType>({
   isDynamicDailyBudget: false,
 });
 
-function TripContextProvider({ children }) {
+function TripContextProvider({ children }: React.PropsWithChildren) {
   const expensesCtx = useContext(ExpensesContext);
   const [travellers, setTravellers] = useState([]);
   const [tripid, setTripid] = useState("");
@@ -458,7 +457,7 @@ function TripContextProvider({ children }) {
     if (travellers) {
       setTravellers(travellers);
     }
-    return travellers;
+    return travellers ?? [];
   }
 
   const value = {

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable react/prop-types */
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { fetchTrip, fetchUser, getTravellers, updateTrip } from "../util/http";
 import { asyncStoreGetObject, asyncStoreSetObject } from "./async-storage";
@@ -15,28 +16,10 @@ import safeLogError from "../util/error";
 import { ExpensesContext } from "./expenses-context";
 import { sumForTrip } from "../util/expenseTotals";
 import { computeDynamicDailyBudget } from "../util/budget";
+import type { TripData } from "../types/trip";
+import { settleTrip } from "../util/settlement";
 
-export interface TripData {
-  tripName?: string;
-  expenses?: ExpenseData[];
-  totalBudget?: string;
-  dailyBudget?: string;
-  tripCurrency?: string;
-  travellers?: Traveller[];
-  tripid?: string;
-  /** @deprecated derive trip total spent from expenses instead (see #247) */
-  totalSum?: number;
-  tripProgress?: number;
-  startDate?: string;
-  endDate?: string;
-  isPaidDate?: string;
-  isPaid?: isPaidString;
-  isPaidTimestamp?: number;
-  isDynamicDailyBudget?: boolean;
-  // online categories are stored as a JSON.stringified strings
-  // local categories are stored as Category arrays.
-  categories?: Category[] | string;
-}
+export type { TripData };
 
 export type TripContextType = {
   tripid: string;
@@ -66,7 +49,7 @@ export type TripContextType = {
   saveTripDataInStorage: (tripData: TripData) => Promise<void>;
   loadTripDataFromStorage: () => Promise<TripData>;
   saveTravellersInStorage: (travellers) => Promise<void>;
-  loadTravellersFromStorage: () => Promise<void>;
+  loadTravellersFromStorage: () => Promise<Traveller[]>;
   fetchAndSettleCurrentTrip: () => Promise<void>;
   setTripUnsettled: () => Promise<void>;
   isPaid: isPaidString;
@@ -111,7 +94,7 @@ export const TripContext = createContext<TripContextType>({
     return {} as TripData;
   },
   saveTravellersInStorage: async (travellers) => {},
-  loadTravellersFromStorage: async () => {},
+  loadTravellersFromStorage: async (): Promise<Traveller[]> => [],
   fetchAndSettleCurrentTrip: async () => {},
   setTripUnsettled: async () => {},
   isPaid: isPaidString.notPaid,
@@ -366,14 +349,10 @@ function TripContextProvider({ children }) {
   async function fetchAndSettleCurrentTrip() {
     try {
       const trip = await fetchTrip(tripid);
-      trip.isPaid = isPaidString.paid;
-      const now = Date.now();
-      trip.isPaidTimestamp = now;
-      const today = new Date();
-      trip.isPaidDate = today.toISOString();
-      await setCurrentTrip(tripid, trip);
-      await saveTripDataInStorage(trip);
-      await updateTrip(tripid, trip);
+      const settledTrip = settleTrip(trip);
+      await setCurrentTrip(tripid, settledTrip);
+      await saveTripDataInStorage(settledTrip);
+      await updateTrip(tripid, settledTrip);
     } catch (error) {
       safeLogError(error);
       throw error;

--- a/TravelCostApp/types/trip.ts
+++ b/TravelCostApp/types/trip.ts
@@ -1,0 +1,26 @@
+import type { ExpenseData, isPaidString } from "../util/expense";
+import type { Traveller } from "../util/traveler";
+import type { Category } from "../util/category";
+
+export interface TripData {
+  tripName?: string;
+  expenses?: ExpenseData[];
+  totalBudget?: string;
+  dailyBudget?: string;
+  tripCurrency?: string;
+  travellers?: Traveller[];
+  tripid?: string;
+  /** @deprecated derive trip total spent from expenses instead (see #247) */
+  totalSum?: number;
+  tripProgress?: number;
+  startDate?: string;
+  endDate?: string;
+  isPaidDate?: string;
+  isPaid?: isPaidString;
+  isPaidTimestamp?: number;
+  isDynamicDailyBudget?: boolean;
+  // online categories are stored as a JSON.stringified strings
+  // local categories are stored as Category arrays.
+  categories?: Category[] | string;
+}
+

--- a/TravelCostApp/util/http.tsx
+++ b/TravelCostApp/util/http.tsx
@@ -7,7 +7,8 @@ import {
 
 import { Category } from "./category";
 import type { TripData } from "../types/trip";
-import { ExpenseData, ExpenseDataOnline, isPaidString } from "./expense";
+import type { ExpenseData, ExpenseDataOnline } from "./expense";
+import { isPaidString } from "./expense";
 import { UserData } from "../store/user-context";
 
 import { i18n } from "../i18n/i18n";

--- a/TravelCostApp/util/http.tsx
+++ b/TravelCostApp/util/http.tsx
@@ -6,8 +6,8 @@ import {
 } from "../confAppConstants";
 
 import { Category } from "./category";
-import { TripData } from "../store/trip-context";
-import { ExpenseData, ExpenseDataOnline } from "./expense";
+import type { TripData } from "../types/trip";
+import { ExpenseData, ExpenseDataOnline, isPaidString } from "./expense";
 import { UserData } from "../store/user-context";
 
 import { i18n } from "../i18n/i18n";
@@ -27,6 +27,10 @@ import {
 
 const BACKEND_URL =
   "https://travelcostnative-default-rtdb.asia-southeast1.firebasedatabase.app";
+
+function normalizeIsPaid(value: unknown): isPaidString {
+  return value === isPaidString.paid ? isPaidString.paid : isPaidString.notPaid;
+}
 
 // Field name for server timestamp in expense data -- needs to be updated in .rules firebase backend
 export const SERVER_TIMESTAMP_FIELD = "serverTimestamp";
@@ -243,7 +247,7 @@ const processExpenseResponse = (data: any): ExpenseData[] => {
       categoryString: r.categoryString,
       duplOrSplit: r.duplOrSplit,
       rangeId: r.rangeId,
-      isPaid: r.isPaid,
+      isPaid: normalizeIsPaid(r.isPaid),
       isSpecialExpense: r.isSpecialExpense,
       editedTimestamp: editedTimestamp,
       isDeleted: r.isDeleted || false,
@@ -370,7 +374,7 @@ export async function fetchExpenses(
           categoryString: r.categoryString,
           duplOrSplit: r.duplOrSplit,
           rangeId: r.rangeId,
-          isPaid: r.isPaid,
+          isPaid: normalizeIsPaid(r.isPaid),
           isSpecialExpense: r.isSpecialExpense,
           editedTimestamp: editedTimestamp,
           isDeleted: r.isDeleted || false,

--- a/TravelCostApp/util/settlement.ts
+++ b/TravelCostApp/util/settlement.ts
@@ -1,0 +1,13 @@
+import type { TripData } from "../types/trip";
+import { isPaidString } from "./expense";
+
+export function settleTrip(trip: TripData, now?: number): TripData {
+  const ts = now ?? Date.now();
+  return {
+    ...trip,
+    isPaid: isPaidString.paid,
+    isPaidTimestamp: ts,
+    isPaidDate: new Date(ts).toISOString(),
+  };
+}
+

--- a/TravelCostApp/util/trip.ts
+++ b/TravelCostApp/util/trip.ts
@@ -5,7 +5,7 @@ import {
   setMMKVObject,
   setMMKVString,
 } from "../store/mmkv";
-import { TripData } from "../store/trip-context";
+import type { TripData } from "../types/trip";
 import { isToday } from "./date";
 import { fetchTrip } from "./http";
 


### PR DESCRIPTION
## Summary
- Extract trip settlement into pure `settleTrip(trip, now?)`.
- Update `TripContext.fetchAndSettleCurrentTrip` to use `fetchTrip → settleTrip → setCurrentTrip → saveTripDataInStorage → updateTrip`.
- Add end-to-end invariant coverage: after Settlement, open Balances roll up to `[]` (plus edited-after-settlement edge case).

## Test plan
- `pnpm test`

## Context
- Implements #248.