### PR TITLE
feat: redirect legacy expense aggregators to expenseTotals

### DIFF
--- a/TravelCostApp/__tests__/util/expense-range.test.ts
+++ b/TravelCostApp/__tests__/util/expense-range.test.ts
@@ -34,6 +34,8 @@ function makeExpense(params: {
   whoPaid: string;
   amount: number;
   calcAmount: number;
+  isDeleted?: boolean;
+  duplOrSplit?: number;
 }): ExpenseData {
   return {
     id: params.id,
@@ -49,10 +51,11 @@ function makeExpense(params: {
     currency: "EUR",
     whoPaid: params.whoPaid,
     calcAmount: params.calcAmount,
-    duplOrSplit: undefined,
+    duplOrSplit: params.duplOrSplit,
     splitList: [],
     rangeId: params.rangeId,
     isSpecialExpense: false,
+    isDeleted: params.isDeleted,
   } as ExpenseData;
 }
 
@@ -117,6 +120,90 @@ describe("Ranged expense deduplication", () => {
     ];
 
     expect(getExpensesSumPeriod(expenses)).toBe(250);
+  });
+});
+
+describe("getExpensesSumTotal — delegates to sumForTrip", () => {
+  it("excludes deleted expenses from the total", () => {
+    const expenses: ExpenseData[] = [
+      makeExpense({
+        id: "e1",
+        rangeId: "",
+        description: "active",
+        whoPaid: "Alice",
+        amount: 100,
+        calcAmount: 100,
+      }),
+      makeExpense({
+        id: "e2",
+        rangeId: "",
+        description: "deleted",
+        whoPaid: "Bob",
+        amount: 50,
+        calcAmount: 50,
+        isDeleted: true,
+      }),
+    ];
+    expect(getExpensesSumTotal(expenses)).toBe(100);
+  });
+
+  it("reconstructs full cost for ranged-split expenses (duplOrSplit=2)", () => {
+    // €300 total split into 3 daily instances of €100 each
+    const expenses: ExpenseData[] = [
+      makeExpense({
+        id: "e1",
+        rangeId: "r1",
+        description: "day1",
+        whoPaid: "Alice",
+        amount: 100,
+        calcAmount: 100,
+        duplOrSplit: 2,
+      }),
+      makeExpense({
+        id: "e2",
+        rangeId: "r1",
+        description: "day2",
+        whoPaid: "Alice",
+        amount: 100,
+        calcAmount: 100,
+        duplOrSplit: 2,
+      }),
+      makeExpense({
+        id: "e3",
+        rangeId: "r1",
+        description: "day3",
+        whoPaid: "Alice",
+        amount: 100,
+        calcAmount: 100,
+        duplOrSplit: 2,
+      }),
+    ];
+    expect(getExpensesSumTotal(expenses)).toBe(300);
+  });
+});
+
+describe("getExpensesSumPeriod — delegates to sumByPeriod", () => {
+  it("excludes deleted expenses from the period sum", () => {
+    const expenses: ExpenseData[] = [
+      makeExpense({
+        id: "e1",
+        rangeId: "",
+        description: "active",
+        whoPaid: "Alice",
+        amount: 100,
+        calcAmount: 100,
+      }),
+      makeExpense({
+        id: "e2",
+        rangeId: "",
+        description: "deleted",
+        whoPaid: "Bob",
+        amount: 50,
+        calcAmount: 50,
+        isDeleted: true,
+      }),
+    ];
+    expect(getExpensesSumPeriod(expenses)).toBe(100);
   });
 });
 

--- a/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseTravellers.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseTravellers.tsx
@@ -14,8 +14,8 @@ import PropTypes from "prop-types";
 import {
   ExpenseData,
   getExpensesSum,
-  getTravellerSum,
 } from "../../../util/expense";
+import { sumByTraveller } from "../../../util/expenseTotals";
 import { TripContext } from "../../../store/trip-context";
 import BlurPremium from "../../Premium/BlurPremium";
 import { processTitleStringFilteredPiecharts } from "../../../util/string";
@@ -72,7 +72,7 @@ const ExpenseTravellers = ({
     const catSumCat = Array.from(travellerMap.entries()).map(
       ([traveller, catExpenses]) => ({
         cat: traveller,
-        sumCat: Number(getTravellerSum(catExpenses, traveller)),
+        sumCat: Number(sumByTraveller(catExpenses, traveller)),
         color: "",
         catExpenses,
       })

--- a/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
@@ -18,8 +18,8 @@ import { SettingsContext } from "../../store/settings-context";
 import {
   ExpenseData,
   getExpensesSumPeriod,
-  getTravellerSum,
 } from "../../util/expense";
+import { sumByTraveller } from "../../util/expenseTotals";
 import { ExpensesContext, RangeString } from "../../store/expenses-context";
 import { constantScale, dynamicScale } from "../../util/scalingUtil";
 import { CurrencyTicker } from "../UI/AnimatedNumber";
@@ -136,7 +136,7 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
       break;
   }
   const travellerSplitExpenseSums = travellerNames.map((travellerName) => {
-    return getTravellerSum(
+    return sumByTraveller(
       periodExpenses,
       travellerName || "",
       periodName === "total",

--- a/TravelCostApp/util/budget.ts
+++ b/TravelCostApp/util/budget.ts
@@ -1,6 +1,6 @@
 import { GlobalStyles } from "../constants/styles";
 import type { ExpenseData } from "./expense";
-import { getExpensesSumPeriod } from "./expense";
+import { asPeriodSlice, sumByPeriod } from "./expenseTotals";
 import { DateTime } from "luxon";
 import {
   getDateMinusDays,
@@ -117,7 +117,7 @@ export function calculateDailyAverage(
         Math.floor((today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
       );
 
-      const totalSum = getExpensesSumPeriod(eligible, hideSpecial);
+      const totalSum = sumByPeriod(asPeriodSlice(eligible), hideSpecial);
       return totalSum / daysFromStartToToday;
     }
 
@@ -135,7 +135,7 @@ export function calculateDailyAverage(
         const dayExpenses = eligible.filter((exp) =>
           isSameDay(toJsDate(exp.date), day)
         );
-        const daySum = getExpensesSumPeriod(dayExpenses, hideSpecial);
+        const daySum = sumByPeriod(asPeriodSlice(dayExpenses), hideSpecial);
         if (daySum > 0) {
           totalSum += daySum;
           daysWithExpenses++;
@@ -184,7 +184,7 @@ export function calculateDailyAverage(
           if (d < weekStartDay || d > weekEndDay) return false;
           return true;
         });
-        const weekSum = getExpensesSumPeriod(weekExpenses, hideSpecial);
+        const weekSum = sumByPeriod(asPeriodSlice(weekExpenses), hideSpecial);
         if (weekSum > 0) {
           totalSum += weekSum / 7;
           weeksWithExpenses++;
@@ -224,7 +224,7 @@ export function calculateDailyAverage(
           if (d < start || d > end) return false;
           return true;
         });
-        const monthSum = getExpensesSumPeriod(monthExpenses, hideSpecial);
+        const monthSum = sumByPeriod(asPeriodSlice(monthExpenses), hideSpecial);
         if (monthSum > 0) {
           totalSum += monthSum / 30;
           monthsWithExpenses++;
@@ -257,7 +257,7 @@ export function calculateDailyAverage(
           if (d < start || d > end) return false;
           return true;
         });
-        const yearSum = getExpensesSumPeriod(yearExpenses, hideSpecial);
+        const yearSum = sumByPeriod(asPeriodSlice(yearExpenses), hideSpecial);
         if (yearSum > 0) {
           totalSum += yearSum / 365;
           yearsWithExpenses++;
@@ -307,7 +307,7 @@ export function calculateAverageUpToDate(
         const dayExpenses = eligible.filter((exp) =>
           isSameDay(toJsDate(exp.date), day)
         );
-        const daySum = getExpensesSumPeriod(dayExpenses, hideSpecial);
+        const daySum = sumByPeriod(asPeriodSlice(dayExpenses), hideSpecial);
         if (daySum > 0) {
           totalSum += daySum;
           daysWithExpenses++;
@@ -354,7 +354,7 @@ export function calculateAverageUpToDate(
           if (d < weekStartDay || d > weekEndDay) return false;
           return true;
         });
-        const weekSum = getExpensesSumPeriod(weekExpenses, hideSpecial);
+        const weekSum = sumByPeriod(asPeriodSlice(weekExpenses), hideSpecial);
         if (weekSum > 0) {
           totalSum += weekSum / 7;
           weeksWithExpenses++;
@@ -392,7 +392,7 @@ export function calculateAverageUpToDate(
           if (d < start || d > end) return false;
           return true;
         });
-        const monthSum = getExpensesSumPeriod(monthExpenses, hideSpecial);
+        const monthSum = sumByPeriod(asPeriodSlice(monthExpenses), hideSpecial);
         if (monthSum > 0) {
           totalSum += monthSum / 30;
           monthsWithExpenses++;
@@ -425,7 +425,7 @@ export function calculateAverageUpToDate(
           if (d < start || d > end) return false;
           return true;
         });
-        const yearSum = getExpensesSumPeriod(yearExpenses, hideSpecial);
+        const yearSum = sumByPeriod(asPeriodSlice(yearExpenses), hideSpecial);
         if (yearSum > 0) {
           totalSum += yearSum / 365;
           yearsWithExpenses++;

--- a/TravelCostApp/util/expense.ts
+++ b/TravelCostApp/util/expense.ts
@@ -12,6 +12,7 @@ import {
   OfflineQueueManageExpenseItem,
 } from "./offline-queue";
 import { splitType } from "./split";
+import { asPeriodSlice, sumByPeriod, sumForTrip } from "./expenseTotals";
 
 // expense interface
 export interface Expense {
@@ -187,24 +188,29 @@ export function deduplicateRangeExpenses(
 /**
  * Calculate total expenses sum with deduplication for range expenses.
  * Use this for total/overall calculations where each range should be counted once.
+ *
+ * Delegates to {@link sumForTrip}: excludes deleted expenses and uses
+ * consolidateRangedExpenses (reconstructs full cost for ranged-split expenses).
  */
 export function getExpensesSumTotal(
   expenses: ExpenseData[],
-  hideSpecial = false
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _hideSpecial = false
 ) {
-  const deduplicatedExpenses = deduplicateRangeExpenses(expenses);
-  return calculateExpensesSum(deduplicatedExpenses, hideSpecial);
+  return sumForTrip(expenses);
 }
 
 /**
  * Calculate expenses sum for a specific time period, counting all days of range expenses.
  * Use this for daily/weekly/monthly/yearly calculations where each day should be counted.
+ *
+ * Delegates to {@link sumByPeriod}: excludes deleted expenses.
  */
 export function getExpensesSumPeriod(
   expenses: ExpenseData[],
   hideSpecial = false
 ) {
-  return calculateExpensesSum(expenses, hideSpecial);
+  return sumByPeriod(asPeriodSlice(expenses), hideSpecial);
 }
 
 /**
@@ -227,6 +233,10 @@ export function getExpensesSum(expenses: ExpenseData[], hideSpecial = false) {
   return getExpensesSumPeriod(expenses, hideSpecial);
 }
 
+/**
+ * @deprecated Use {@link sumByTraveller} from `./expenseTotals` instead.
+ * `sumByTraveller` correctly excludes deleted expenses.
+ */
 export function getTravellerSum(
   expenses: ExpenseData[],
   traveller: string,


### PR DESCRIPTION
## Summary

Closes #255.

- **`getExpensesSumTotal`** now delegates to `sumForTrip` — gains deleted-expense exclusion and `consolidateRangedExpenses` (reconstructs full cost for ranged-split expenses) instead of the first-day-only `deduplicateRangeExpenses`.
- **`getExpensesSumPeriod`** now delegates to `sumByPeriod` — gains deleted-expense exclusion; `hideSpecial` is preserved.
- **`util/budget.ts`** imports `sumByPeriod` / `asPeriodSlice` from `./expenseTotals` at all 9 call sites (previously imported `getExpensesSumPeriod` from `./expense`).
- **`getTravellerSum`** marked `@deprecated` with a pointer to `sumByTraveller`.
- **`ExpensesSummary`** and **`ExpenseTravellers`** migrated to `sumByTraveller` from `util/expenseTotals`.

## Test plan

- [ ] Three new regression tests added to `__tests__/util/expense-range.test.ts` (RED→GREEN via TDD):
  - `getExpensesSumTotal` excludes deleted expenses
  - `getExpensesSumTotal` reconstructs full cost for ranged-split (duplOrSplit=2) expenses
  - `getExpensesSumPeriod` excludes deleted expenses
- [ ] `pnpm test` — 117 tests pass, 0 failures