### PR TITLE
Wire useTripTotalSpent into TripContext

### DIFF
--- a/TravelCostApp/__tests__/util/budget.test.ts
+++ b/TravelCostApp/__tests__/util/budget.test.ts
@@ -103,6 +103,12 @@ describe("util/budget", () => {
     });
   });
 
+  describe("getBudgetColor (non-traffic light)", () => {
+    it("returns red when over budget", () => {
+      expect(getBudgetColor(110, 100, 0, 0, false)).toBe(GlobalStyles.colors.error300);
+    });
+  });
+
   describe("calculateDailyAverage", () => {
     it('computes "total" as trip total spent divided by days since trip start', () => {
       const expenses = [
@@ -292,6 +298,84 @@ describe("util/budget", () => {
           true
         )
       ).toBeCloseTo(50 / 5, 6);
+    });
+
+    it('computes "total" as trip total spent divided by days since trip start (up to target date)', () => {
+      const expenses = [
+        makeExpense({ calcAmount: 100, date: new Date("2026-01-15T12:00:00Z") }),
+        makeExpense({
+          id: "e2",
+          calcAmount: 50,
+          date: new Date("2026-01-14T12:00:00Z"),
+        }),
+      ];
+
+      expect(
+        calculateAverageUpToDate(
+          "total",
+          new Date("2026-01-15T12:00:00.000Z"),
+          expenses,
+          { startDate: "2026-01-10T00:00:00.000Z" },
+          false
+        )
+      ).toBeCloseTo(150 / 5, 6);
+    });
+
+    it('computes "week" as average daily spend per week (up to target date)', () => {
+      const expenses = [
+        makeExpense({
+          calcAmount: 70,
+          date: new Date("2026-01-12T12:00:00Z"), // Mon
+        }),
+      ];
+
+      expect(
+        calculateAverageUpToDate(
+          "week",
+          new Date("2026-01-18T12:00:00.000Z"), // Sun, week is complete
+          expenses,
+          { startDate: "2026-01-10T00:00:00.000Z" },
+          false
+        )
+      ).toBeCloseTo(10, 6); // 70/7
+    });
+
+    it('computes "month" as average daily spend per month (up to target date)', () => {
+      const expenses = [
+        makeExpense({
+          calcAmount: 300,
+          date: new Date("2026-01-02T12:00:00Z"),
+        }),
+      ];
+
+      expect(
+        calculateAverageUpToDate(
+          "month",
+          new Date("2026-01-31T12:00:00.000Z"),
+          expenses,
+          { startDate: "2026-01-01T00:00:00.000Z" },
+          false
+        )
+      ).toBeCloseTo(10, 6); // 300/30
+    });
+
+    it('computes "year" as average daily spend per year (up to target date)', () => {
+      const expenses = [
+        makeExpense({
+          calcAmount: 3650,
+          date: new Date("2025-06-01T12:00:00Z"),
+        }),
+      ];
+
+      expect(
+        calculateAverageUpToDate(
+          "year",
+          new Date("2025-12-31T12:00:00.000Z"),
+          expenses,
+          { startDate: "2025-01-01T00:00:00.000Z" },
+          false
+        )
+      ).toBeCloseTo(10, 6); // 3650/365
     });
   });
 });

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import React, { createContext, useEffect, useState } from "react";
 import { fetchTrip, fetchUser, getTravellers, updateTrip } from "../util/http";
 import { asyncStoreGetObject, asyncStoreSetObject } from "./async-storage";
 import { MAX_JS_NUMBER } from "../confAppConstants";
@@ -12,11 +12,10 @@ import { useInterval } from "../components/Hooks/useInterval";
 import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "./mmkv";
 import { Category } from "../util/category";
 import safeLogError from "../util/error";
-import { ExpensesContext } from "./expenses-context";
-import { sumForTrip } from "../util/expenseTotals";
 import { computeDynamicDailyBudget } from "../util/budget";
 import type { TripData } from "../types/trip";
 import { settleTrip } from "../util/settlement";
+import { useTripTotalSpent } from "../hooks/useTripTotalSpent";
 
 export type { TripData };
 
@@ -105,7 +104,6 @@ export const TripContext = createContext<TripContextType>({
 });
 
 function TripContextProvider({ children }: React.PropsWithChildren) {
-  const expensesCtx = useContext(ExpensesContext);
   const [travellers, setTravellers] = useState([]);
   const [tripid, setTripid] = useState("");
   const [tripName, setTripName] = useState("");
@@ -125,10 +123,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   const [isLoading, setIsLoading] = useState(false);
   const [isDynamicDailyBudget, setIsDynamicDailyBudget] = useState(false);
 
-  const tripTotalSpent = useMemo(() => {
-    const expenses = expensesCtx?.expenses ?? [];
-    return sumForTrip(expenses);
-  }, [expensesCtx?.expenses]);
+  const tripTotalSpent = useTripTotalSpent();
 
   async function loadTripidFetchTrip() {
     const stored_tripid = await secureStoreGetItem("currentTripId");

--- a/TravelCostApp/util/budget.ts
+++ b/TravelCostApp/util/budget.ts
@@ -102,7 +102,7 @@ export function calculateDailyAverage(
   currentDate: Date,
   expenses: ExpenseData[],
   tripMeta: TripBudgetMeta,
-  hideSpecial: boolean = false
+  hideSpecial = false
 ): number {
   const today = currentDate;
   const eligible = (Array.isArray(expenses) ? expenses : []).filter((exp) =>
@@ -277,11 +277,11 @@ export function calculateDailyAverage(
  * This calculates average only up to that point (no future data).
  */
 export function calculateAverageUpToDate(
-  periodName: PeriodName,
+  periodName: PeriodNameWithTotal,
   targetDate: Date,
   expenses: ExpenseData[],
   tripMeta: TripBudgetMeta,
-  hideSpecial: boolean = false
+  hideSpecial = false
 ): number {
   // Some date helpers (e.g. getPreviousMondayDate) mutate the Date passed in.
   // Avoid mutating caller-owned Date instances.
@@ -290,6 +290,19 @@ export function calculateAverageUpToDate(
     isEligibleExpense(exp, { hideSpecial, maxDate: safeTargetDate })
   );
   switch (periodName) {
+    case "total": {
+      const startDate = new Date(tripMeta.startDate);
+      const daysFromStartToTarget = Math.max(
+        1,
+        Math.floor(
+          (safeTargetDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
+        )
+      );
+
+      const totalSum = sumByPeriod(asPeriodSlice(eligible), hideSpecial);
+      return totalSum / daysFromStartToTarget;
+    }
+
     case "day": {
       const thisWeekMonday = getPreviousMondayDate(new Date(safeTargetDate)) as Date;
       const lastWeekMonday = getDateMinusDays(thisWeekMonday, 7) as Date;


### PR DESCRIPTION
## Summary
- Use `useTripTotalSpent()` in `TripContext` to avoid duplicating trip total aggregation logic.
- Add missing `budget` util coverage for non-traffic-light color path and `calculateAverageUpToDate` across periods (day/week/month/year/total).

## Test plan
- [x] `pnpm test`

Closes #256.