### PR TITLE
refactor: remove deprecated TripContext totalSum

### DIFF
--- a/TravelCostApp/__tests__/store/dynamic-daily-budget-from-expenses.test.tsx
+++ b/TravelCostApp/__tests__/store/dynamic-daily-budget-from-expenses.test.tsx
@@ -27,7 +27,6 @@ function BudgetProbe() {
         endDate: new Date("2026-01-11T00:00:00.000Z").toISOString(),
         travellers: [],
         isDynamicDailyBudget: true,
-        totalSum: 0,
       });
     })();
   }, [tripCtx.setCurrentTrip]);

--- a/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
+++ b/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
@@ -1,7 +1,5 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import { render, waitFor } from "@testing-library/react-native";
-
-import TripContextProvider, { TripContext } from "../../store/trip-context";
 import { ExpensesContext } from "../../store/expenses-context";
 
 jest.mock("../../components/Hooks/useInterval", () => ({
@@ -31,9 +29,39 @@ function LoadTravellersProbe({
 }: {
   onResult: (travellers: unknown) => void;
 }) {
+  const { TripContext } = require("../../store/trip-context");
   const ctx = useContext(TripContext);
+  const didInit = useRef(false);
   useEffect(() => {
+    if (didInit.current) return;
+    didInit.current = true;
     ctx.loadTravellersFromStorage().then(onResult);
+  }, [ctx, onResult]);
+  return null;
+}
+
+function LoadTripProbe({ onResult }: { onResult: (trip: unknown) => void }) {
+  const { TripContext } = require("../../store/trip-context");
+  const ctx = useContext(TripContext);
+  const didInit = useRef(false);
+  useEffect(() => {
+    if (didInit.current) return;
+    didInit.current = true;
+    ctx.setCurrentTrip("trip-1", {
+      tripid: "trip-1",
+      tripName: "Trip",
+      totalBudget: "100",
+      dailyBudget: "10",
+      tripCurrency: "EUR",
+      travellers: [],
+      startDate: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+      endDate: new Date("2026-01-11T00:00:00.000Z").toISOString(),
+      isPaidDate: "",
+      isPaidTimestamp: undefined,
+      isDynamicDailyBudget: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      totalSum: 123 as any,
+    } as any).then(() => onResult(ctx.getcurrentTrip()));
   }, [ctx, onResult]);
   return null;
 }
@@ -43,6 +71,7 @@ describe("TripContext storage contracts", () => {
     mockAsyncStoreGetObject.mockResolvedValueOnce(null);
 
     const results: unknown[] = [];
+    const TripContextProvider = require("../../store/trip-context").default;
     render(
       <ExpensesContext.Provider value={{ expenses: [] } as any}>
         <TripContextProvider>
@@ -55,6 +84,25 @@ describe("TripContext storage contracts", () => {
       expect(results.length).toBeGreaterThan(0);
     });
     expect(results[0]).toEqual([]);
+  });
+
+  it("setCurrentTrip drops deprecated totalSum field when present", async () => {
+    const results: unknown[] = [];
+    const TripContextProvider = require("../../store/trip-context").default;
+    render(
+      <ExpensesContext.Provider value={{ expenses: [] } as any}>
+        <TripContextProvider>
+          <LoadTripProbe onResult={(r) => results.push(r)} />
+        </TripContextProvider>
+      </ExpensesContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    expect(results[0]).toBeTruthy();
+    expect("totalSum" in (results[0] as any)).toBe(false);
   });
 });
 

--- a/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
+++ b/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
@@ -79,24 +79,33 @@ function LoadTripProbe({
 }
 
 describe("TripContext storage contracts", () => {
-  it("loadTravellersFromStorage resolves to [] when storage is empty", async () => {
+  beforeEach(() => {
+    // Defend against other suites leaking fake timers into this file in CI.
+    jest.useRealTimers();
+  });
+
+  it(
+    "loadTravellersFromStorage resolves to [] when storage is empty",
+    async () => {
     mockAsyncStoreGetObject.mockResolvedValueOnce(null);
 
-    const results: unknown[] = [];
+    let resolveResult: (travellers: unknown) => void;
+    const resultPromise = new Promise<unknown>((resolve) => {
+      resolveResult = resolve;
+    });
     const TripContextProvider = require("../../store/trip-context").default;
     render(
       <ExpensesContext.Provider value={{ expenses: [] } as any}>
         <TripContextProvider>
-          <LoadTravellersProbe onResult={(r) => results.push(r)} />
+          <LoadTravellersProbe onResult={(r) => resolveResult(r)} />
         </TripContextProvider>
       </ExpensesContext.Provider>
     );
 
-    await waitFor(() => {
-      expect(results.length).toBeGreaterThan(0);
-    });
-    expect(results[0]).toEqual([]);
-  });
+    await expect(resultPromise).resolves.toEqual([]);
+    },
+    15000
+  );
 
   it("setCurrentTrip drops deprecated totalSum field when present", async () => {
     const results: Array<{

--- a/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
+++ b/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
@@ -40,14 +40,19 @@ function LoadTravellersProbe({
   return null;
 }
 
-function LoadTripProbe({ onResult }: { onResult: (trip: unknown) => void }) {
+function LoadTripProbe({
+  onResult,
+}: {
+  onResult: (result: { storedTrip: unknown; inputTripHasTotalSum: boolean }) => void;
+}) {
   const { TripContext } = require("../../store/trip-context");
   const ctx = useContext(TripContext);
   const didInit = useRef(false);
   useEffect(() => {
     if (didInit.current) return;
     didInit.current = true;
-    ctx.setCurrentTrip("trip-1", {
+    // Intentionally include a legacy persisted field to verify migration behavior.
+    const inputTrip = {
       tripid: "trip-1",
       tripName: "Trip",
       totalBudget: "100",
@@ -61,7 +66,14 @@ function LoadTripProbe({ onResult }: { onResult: (trip: unknown) => void }) {
       isDynamicDailyBudget: false,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       totalSum: 123 as any,
-    } as any).then(() => onResult(ctx.getcurrentTrip()));
+    } as any;
+
+    ctx.setCurrentTrip("trip-1", inputTrip).then(() =>
+      onResult({
+        storedTrip: ctx.getcurrentTrip(),
+        inputTripHasTotalSum: "totalSum" in inputTrip,
+      })
+    );
   }, [ctx, onResult]);
   return null;
 }
@@ -87,7 +99,10 @@ describe("TripContext storage contracts", () => {
   });
 
   it("setCurrentTrip drops deprecated totalSum field when present", async () => {
-    const results: unknown[] = [];
+    const results: Array<{
+      storedTrip: unknown;
+      inputTripHasTotalSum: boolean;
+    }> = [];
     const TripContextProvider = require("../../store/trip-context").default;
     render(
       <ExpensesContext.Provider value={{ expenses: [] } as any}>
@@ -102,7 +117,8 @@ describe("TripContext storage contracts", () => {
     });
 
     expect(results[0]).toBeTruthy();
-    expect("totalSum" in (results[0] as any)).toBe(false);
+    expect(results[0].inputTripHasTotalSum).toBe(true);
+    expect("totalSum" in (results[0].storedTrip as any)).toBe(false);
   });
 });
 

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -232,11 +232,14 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   function dropDeprecatedTripFields(trip: TripData): TripData {
     // `totalSum` was a persisted trip-level total-spent number. We now derive totals
     // from expenses (see #247) and drop this field on load to avoid stale state.
-    if (trip && "totalSum" in trip) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (trip as any).totalSum;
-    }
-    return trip;
+    //
+    // Important: don't mutate the input object; callers may retain the reference.
+    if (!trip) return trip;
+    if (!("totalSum" in trip)) return trip;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { totalSum: _deprecatedTotalSum, ...rest } = trip as any;
+    return rest as TripData;
   }
 
   async function fetchAndSetTravellers(tripid: string): Promise<boolean> {
@@ -404,6 +407,10 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   async function loadTripDataFromStorage() {
     const tripData: TripData = getMMKVObject(MMKV_KEYS.CURRENT_TRIP);
     if (tripData) {
+      // `totalSum` might still exist in persisted data from older app versions.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const hadDeprecatedTotalSum = "totalSum" in (tripData as any);
+
       // Migrate trip data from old settlement system
       const migratedTrip = dropDeprecatedTripFields(
         migrateTripSettlementData(tripData)
@@ -430,12 +437,13 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       }
       setIsLoading(false);
 
-      // If migration occurred, save migrated trip back to storage
-      if (
+      // If migration occurred, save migrated trip back to storage.
+      // Also persist the cleanup of deprecated fields (e.g. legacy `totalSum`).
+      const didMigrateSettlementData =
         tripData.isPaidDate &&
         !tripData.isPaidTimestamp &&
-        migratedTrip.isPaidTimestamp
-      ) {
+        migratedTrip.isPaidTimestamp;
+      if (didMigrateSettlementData || hadDeprecatedTotalSum) {
         await saveTripDataInStorage(migratedTrip);
       }
 

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -27,8 +27,6 @@ export type TripContextType = {
   dailyBudget: string;
   setdailyBudget: (dailyBudget: string) => void;
   tripCurrency: string;
-  /** @deprecated derive trip total spent from expenses instead (see #247) */
-  totalSum: number;
   tripProgress: number;
   startDate: string;
   endDate: string;
@@ -37,8 +35,6 @@ export type TripContextType = {
   setTripProgress: (percent: number) => void;
   travellers: Traveller[];
   fetchAndSetTravellers: (tripid: string) => Promise<boolean>;
-  /** @deprecated derive trip total spent from expenses instead (see #247) */
-  setTotalSum: (amount: number) => void;
   setTripid: (tripid: string) => void;
   addTrip: ({ tripName, tripTotalBudget }) => void;
   deleteTrip: (tripid: string) => void;
@@ -66,7 +62,6 @@ export const TripContext = createContext<TripContextType>({
   dailyBudget: "",
   setdailyBudget: (dailyBudget: string) => {},
   tripCurrency: "",
-  totalSum: 0,
   tripProgress: 0,
   startDate: "",
   endDate: "",
@@ -75,7 +70,6 @@ export const TripContext = createContext<TripContextType>({
   setTripProgress: (percent: number) => {},
   travellers: [],
   fetchAndSetTravellers: async (tripid: string) => false,
-  setTotalSum: (amount: number) => {},
   setTripid: (tripid: string) => {},
 
   addTrip: ({ tripName, tripTotalBudget }) => {},
@@ -112,7 +106,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   const [totalBudget, setTotalBudget] = useState("");
   const [tripCurrency, setTripCurrency] = useState("");
   const [dailyBudget, setdailyBudget] = useState("");
-  const [totalSum, setTotalSumTrip] = useState(0);
   const [progress, setProgress] = useState(0);
   const [refreshState, setRefreshState] = useState(false);
   const [startDate, setStartDate] = useState("");
@@ -236,6 +229,16 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     return trip;
   }
 
+  function dropDeprecatedTripFields(trip: TripData): TripData {
+    // `totalSum` was a persisted trip-level total-spent number. We now derive totals
+    // from expenses (see #247) and drop this field on load to avoid stale state.
+    if (trip && "totalSum" in trip) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (trip as any).totalSum;
+    }
+    return trip;
+  }
+
   async function fetchAndSetTravellers(tripid: string): Promise<boolean> {
     await loadTravellersFromStorage();
     const { isFastEnough } = await isConnectionFastEnough();
@@ -266,13 +269,12 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       setIsPaid(isPaidString.notPaid);
       setIsPaidDate("");
       setIsPaidTimestamp(undefined);
-      setTotalSumTrip(0);
       setIsLoading(false);
       return;
     }
 
     // Migrate trip data from old settlement system
-    const migratedTrip = migrateTripSettlementData(trip);
+    const migratedTrip = dropDeprecatedTripFields(migrateTripSettlementData(trip));
 
     _setTripid(tripid);
     setTripName(migratedTrip.tripName);
@@ -293,7 +295,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     setIsPaid(migratedTrip.isPaid ?? isPaidString.notPaid);
     setIsPaidDate(migratedTrip.isPaidDate);
     setIsPaidTimestamp(migratedTrip.isPaidTimestamp);
-    setTotalSumTrip(migratedTrip.totalSum);
     setIsLoading(false);
     setIsDynamicDailyBudget(migratedTrip.isDynamicDailyBudget);
     if (typeof trip.travellers[1] === "string") {
@@ -310,10 +311,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     }
   }
 
-  function setTotalSum(amount: number) {
-    setTotalSumTrip(amount);
-  }
-
   async function fetchAndSetCurrentTrip(tripid: string) {
     if (!tripid) return;
     const { isFastEnough } = await isConnectionFastEnough();
@@ -324,7 +321,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       trip.tripid = tripid;
 
       // Migrate trip data from old settlement system
-      const migratedTrip = migrateTripSettlementData(trip);
+      const migratedTrip = dropDeprecatedTripFields(migrateTripSettlementData(trip));
 
       await setCurrentTrip(tripid, migratedTrip);
 
@@ -379,7 +376,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       totalBudget: totalBudget,
       dailyBudget: dailyBudget,
       tripCurrency: tripCurrency,
-      totalSum: totalSum,
       isPaid: isPaid,
       isPaidDate: isPaidDate,
       isPaidTimestamp: isPaidTimestamp,
@@ -409,7 +405,9 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     const tripData: TripData = getMMKVObject(MMKV_KEYS.CURRENT_TRIP);
     if (tripData) {
       // Migrate trip data from old settlement system
-      const migratedTrip = migrateTripSettlementData(tripData);
+      const migratedTrip = dropDeprecatedTripFields(
+        migrateTripSettlementData(tripData)
+      );
 
       setTripName(migratedTrip.tripName);
       setTotalBudget(
@@ -423,7 +421,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       setIsPaid(migratedTrip.isPaid ?? isPaidString.notPaid);
       setIsPaidDate(migratedTrip.isPaidDate ?? "");
       setIsPaidTimestamp(migratedTrip.isPaidTimestamp);
-      setTotalSumTrip(migratedTrip.totalSum ?? 0);
       setStartDate(migratedTrip.startDate ?? "");
       setEndDate(migratedTrip.endDate ?? "");
       try {
@@ -467,7 +464,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     dailyBudget: dailyBudget,
     setdailyBudget: setdailyBudget,
     tripCurrency: tripCurrency,
-    totalSum: totalSum,
     tripProgress: progress,
     startDate: startDate,
     endDate: endDate,
@@ -476,7 +472,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     setTripProgress: setTripProgress,
     travellers: travellers,
     fetchAndSetTravellers: fetchAndSetTravellers,
-    setTotalSum: setTotalSum,
     setTripid: _setTripid,
     addTrip: addTrip,
     deleteTrip: deleteTrip,

--- a/TravelCostApp/types/trip.ts
+++ b/TravelCostApp/types/trip.ts
@@ -10,8 +10,6 @@ export interface TripData {
   tripCurrency?: string;
   travellers?: Traveller[];
   tripid?: string;
-  /** @deprecated derive trip total spent from expenses instead (see #247) */
-  totalSum?: number;
   tripProgress?: number;
   startDate?: string;
   endDate?: string;

--- a/TravelCostApp/util/expense.ts
+++ b/TravelCostApp/util/expense.ts
@@ -228,7 +228,10 @@ function calculateExpensesSum(expenses: ExpenseData[], hideSpecial = false) {
   return sum;
 }
 
-// Deprecated: Use getExpensesSumTotal or getExpensesSumPeriod instead
+/**
+ * @deprecated Prefer {@link sumForTrip} (total) or {@link sumByPeriod}/{@link asPeriodSlice} (period).
+ * This wrapper is kept for existing UI callers and will be removed in a follow-up cleanup.
+ */
 export function getExpensesSum(expenses: ExpenseData[], hideSpecial = false) {
   return getExpensesSumPeriod(expenses, hideSpecial);
 }

--- a/TravelCostApp/util/split.ts
+++ b/TravelCostApp/util/split.ts
@@ -350,21 +350,6 @@ export function travellerToDropdown(
   return [...listOfLabelValues];
 }
 
-/**
- * @deprecated Use `rollupOpenBalances(expenses, tripCurrency, tripIsPaidTimestamp?)`.
- *
- * Kept for backwards compatibility with older callers. This is now synchronous and
- * no longer fetches expenses over HTTP when none are provided.
- */
-export function calcOpenSplitsTable(
-  tripid: string,
-  tripCurrency: string,
-  givenExpenses?: ExpenseData[],
-  tripIsPaidTimestamp?: number
-) {
-  return rollupOpenBalances(givenExpenses ?? [], tripCurrency, tripIsPaidTimestamp);
-}
-
 export function rollupOpenBalances(
   expenses: ExpenseData[],
   tripCurrency: string,


### PR DESCRIPTION
## Summary
- Remove deprecated `totalSum` / `setTotalSum` from `TripContext`.
- Drop legacy persisted `totalSum` on load.
- Remove deprecated `calcOpenSplitsTable` alias.

Closes #257.

## Test plan
- `pnpm test`