### PR TITLE
fix(i18n): trip form copy audit — Trip vs Trip Budget (#223)

### DIFF
--- a/TravelCostApp/CONTEXT.md
+++ b/TravelCostApp/CONTEXT.md
@@ -126,6 +126,7 @@ Places where English UI copy or code identifiers still diverge from domain langu
 | Split Summary UI (i18n) | ~~“open splits”, “Calculate open splits”, “No open splits”~~ → balance copy (#222) | **Balance** | Aligned in #222 for EN/DE/FR/RU: balances wording, button helpers, Settlement vs Balance simplification labels. |
 | Split Summary UI (i18n) | ~~“settle splits”, “Could not settle splits”~~ → Settlement copy (#222) | **Settlement** | Aligned in #222; trip-wide settle actions and toasts use Settlement language. |
 | Split Summary UI (i18n) | ~~“simplify splits”, “Could not simplify splits”~~ → Balance simplification copy (#222) | **Balance simplification** | Aligned in #222; “Simplify splits” + helper clarifies no money has moved. |
+| Trip setup (i18n) | ~~“Trip Budget” as the named entity in alerts; FR/RU titles as budget container~~ → Trip copy (#223) | **Trip** | `enterNameAlert` names the trip in EN/DE/FR/RU; EN keeps “New Trip Budget” / “Edit Trip Budget” as form screen titles only; FR/RU titles use voyage / поездка like DE Reise. |
 
 ## Example dialogue
 

--- a/TravelCostApp/FEATURE_LIST.md
+++ b/TravelCostApp/FEATURE_LIST.md
@@ -42,7 +42,7 @@ This document contains a comprehensive list of all user-facing buttons, switches
 
 ### Trip Creation & Editing
 
-21. **Create New Trip Button** - Create a new trip budget (`components/ManageTrip/TripForm.tsx`)
+21. **Create New Trip Button** - Create a new trip (`components/ManageTrip/TripForm.tsx`)
 22. **Edit Trip Button** - Edit existing trip details (`components/ManageTrip/TripForm.tsx`)
 23. **Confirm Trip Button** - Save trip creation/edit (`components/ManageTrip/TripForm.tsx`)
 24. **Cancel Trip Button** - Cancel trip creation/edit (`components/ManageTrip/TripForm.tsx`)
@@ -51,7 +51,7 @@ This document contains a comprehensive list of all user-facing buttons, switches
 ### Trip Form Controls
 
 26. **Trip Name Input** - Enter trip name (`components/ManageTrip/TripForm.tsx`)
-27. **Total Budget Input** - Enter total trip budget (`components/ManageTrip/TripForm.tsx`)
+27. **Total Budget Input** - Enter total budget for the trip (`components/ManageTrip/TripForm.tsx`)
 28. **Daily Budget Input** - Enter daily budget (`components/ManageTrip/TripForm.tsx`)
 29. **Trip Currency Picker** - Select trip currency (`components/ManageTrip/TripForm.tsx`)
 30. **Trip Date Range Picker** - Select trip start and end dates (`components/ManageTrip/TripForm.tsx`)

--- a/TravelCostApp/__tests__/i18n/trip-form-copy.test.ts
+++ b/TravelCostApp/__tests__/i18n/trip-form-copy.test.ts
@@ -1,0 +1,77 @@
+import { de, en, fr, ru } from "../../i18n/supportedLanguages";
+
+/** Wording that treats the trip container as a "trip budget" entity (CONTEXT.md avoid). */
+const tripBudgetAsContainerEn = /trip budget/i;
+const tripBudgetAsContainerFr = /budget de voyage/i;
+const tripBudgetAsContainerRu = /бюджет\w* поездк/i;
+
+describe("trip form i18n (issue #223)", () => {
+  describe("English", () => {
+    it("enterNameAlert asks for a trip name, not a Trip Budget name", () => {
+      expect(en.enterNameAlert).toMatch(/trip/i);
+      expect(en.enterNameAlert).not.toMatch(tripBudgetAsContainerEn);
+    });
+
+    it("keeps Trip Budget only as form screen title (intentional)", () => {
+      expect(en.tripFormTitleNew).toBe("New Trip Budget");
+      expect(en.tripFormTitleEdit).toBe("Edit Trip Budget");
+    });
+
+    it("walkthrough onboarding refers to a trip, not a trip budget container", () => {
+      expect(en.walk5).toMatch(/new trip/i);
+      expect(en.walk5).not.toMatch(tripBudgetAsContainerEn);
+    });
+  });
+
+  describe("German (reference)", () => {
+    it("enterNameAlert names the Reise, not a budget container", () => {
+      expect(de.enterNameAlert).toMatch(/Reise/i);
+      expect(de.enterNameAlert).not.toMatch(/Budget/i);
+    });
+
+    it("form titles refer to Reise, not budget-as-container", () => {
+      expect(de.tripFormTitleNew).toMatch(/Reise/i);
+      expect(de.tripFormTitleEdit).toMatch(/Reise/i);
+      expect(de.tripFormTitleNew).not.toMatch(/Budget/i);
+    });
+  });
+
+  describe("French", () => {
+    it("enterNameAlert names the voyage, not budget de voyage as the container", () => {
+      expect(fr.enterNameAlert).toMatch(/voyage/i);
+      expect(fr.enterNameAlert).not.toMatch(tripBudgetAsContainerFr);
+    });
+
+    it("form titles refer to voyage, not budget de voyage as the container", () => {
+      expect(fr.tripFormTitleNew).toMatch(/voyage/i);
+      expect(fr.tripFormTitleEdit).toMatch(/voyage/i);
+      expect(fr.tripFormTitleNew).not.toMatch(tripBudgetAsContainerFr);
+    });
+  });
+
+  describe("Russian", () => {
+    it("enterNameAlert names the поездка, not бюджет поездки as the container", () => {
+      expect(ru.enterNameAlert).toMatch(/поездк/i);
+      expect(ru.enterNameAlert).not.toMatch(tripBudgetAsContainerRu);
+    });
+
+    it("form titles refer to поездка, not бюджет as the container noun", () => {
+      expect(ru.tripFormTitleNew).toMatch(/поездк/i);
+      expect(ru.tripFormTitleEdit).toMatch(/поездк/i);
+      expect(ru.tripFormTitleNew).not.toMatch(/^Бюджет /);
+    });
+
+    it("selectCurrencyAlert refers to this trip, not trip budget entity", () => {
+      expect(ru.selectCurrencyAlert).toMatch(/поездк/i);
+      expect(ru.selectCurrencyAlert).not.toMatch(tripBudgetAsContainerRu);
+    });
+  });
+
+  it("trip form alert keys exist in every locale", () => {
+    for (const locale of [en, de, fr, ru]) {
+      expect(locale.enterNameAlert).toBeTruthy();
+      expect(locale.tripFormTitleNew).toBeTruthy();
+      expect(locale.tripFormTitleEdit).toBeTruthy();
+    }
+  });
+});

--- a/TravelCostApp/__tests__/i18n/trip-form-copy.test.ts
+++ b/TravelCostApp/__tests__/i18n/trip-form-copy.test.ts
@@ -3,9 +3,54 @@ import { de, en, fr, ru } from "../../i18n/supportedLanguages";
 /** Wording that treats the trip container as a "trip budget" entity (CONTEXT.md avoid). */
 const tripBudgetAsContainerEn = /trip budget/i;
 const tripBudgetAsContainerFr = /budget de voyage/i;
-const tripBudgetAsContainerRu = /бюджет\w* поездк/i;
+/** Cyrillic inflection between бюджет and поездк (\\w does not match Russian suffixes). */
+const tripBudgetAsContainerRu = /бюджет.{0,4}поездк/iu;
+
+const walk5Expectations: Array<{
+  lang: string;
+  locale: Record<string, string>;
+  tripPattern: RegExp;
+  avoidPattern: RegExp;
+}> = [
+  {
+    lang: "en",
+    locale: en,
+    tripPattern: /new trip/i,
+    avoidPattern: tripBudgetAsContainerEn,
+  },
+  {
+    lang: "de",
+    locale: de,
+    tripPattern: /neue Reise/i,
+    avoidPattern: /budget.*reise/i,
+  },
+  {
+    lang: "fr",
+    locale: fr,
+    tripPattern: /nouveau voyage/i,
+    avoidPattern: tripBudgetAsContainerFr,
+  },
+  {
+    lang: "ru",
+    locale: ru,
+    tripPattern: /новое путешествие/i,
+    avoidPattern: tripBudgetAsContainerRu,
+  },
+];
 
 describe("trip form i18n (issue #223)", () => {
+  describe("tripBudgetAsContainerRu guard", () => {
+    it("matches inflected budget+trip phrasing that \\w-based patterns miss", () => {
+      expect("бюджета поездки").toMatch(tripBudgetAsContainerRu);
+      expect("бюджет поездки").toMatch(tripBudgetAsContainerRu);
+    });
+
+    it("does not match acceptable trip-only phrasing", () => {
+      expect("для этой поездки").not.toMatch(tripBudgetAsContainerRu);
+      expect("Новая поездка").not.toMatch(tripBudgetAsContainerRu);
+    });
+  });
+
   describe("English", () => {
     it("enterNameAlert asks for a trip name, not a Trip Budget name", () => {
       expect(en.enterNameAlert).toMatch(/trip/i);
@@ -15,11 +60,6 @@ describe("trip form i18n (issue #223)", () => {
     it("keeps Trip Budget only as form screen title (intentional)", () => {
       expect(en.tripFormTitleNew).toBe("New Trip Budget");
       expect(en.tripFormTitleEdit).toBe("Edit Trip Budget");
-    });
-
-    it("walkthrough onboarding refers to a trip, not a trip budget container", () => {
-      expect(en.walk5).toMatch(/new trip/i);
-      expect(en.walk5).not.toMatch(tripBudgetAsContainerEn);
     });
   });
 
@@ -67,11 +107,22 @@ describe("trip form i18n (issue #223)", () => {
     });
   });
 
+  describe("walkthrough onboarding (walk5)", () => {
+    it.each(walk5Expectations)(
+      "$lang walk5 promotes creating a Trip, not a trip-budget container",
+      ({ locale, tripPattern, avoidPattern }) => {
+        expect(locale.walk5).toMatch(tripPattern);
+        expect(locale.walk5).not.toMatch(avoidPattern);
+      }
+    );
+  });
+
   it("trip form alert keys exist in every locale", () => {
     for (const locale of [en, de, fr, ru]) {
       expect(locale.enterNameAlert).toBeTruthy();
       expect(locale.tripFormTitleNew).toBeTruthy();
       expect(locale.tripFormTitleEdit).toBeTruthy();
+      expect(locale.walk5).toBeTruthy();
     }
   });
 });

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -175,7 +175,7 @@ const en = {
   baseCurrencyLabel: "Home Currency",
   totalBudgetLabel: "Total Budget in",
   dailyBudgetLabel: "Daily Budget in",
-  enterNameAlert: "Please enter a Name for your new Trip Budget",
+  enterNameAlert: "Please enter a name for your new trip.",
   enterBudgetAlert: "Please enter a Total Budget higher than Daily Budget",
   selectCurrencyAlert: "Please select your home currency for this trip",
   alertChangeHomeCurrencyTitle: "Changing home currency",
@@ -1364,13 +1364,13 @@ const fr = {
   getLocalPriceError: "Veuillez entrer un nom de produit ou de service",
 
   // Trip Form Labels
-  tripFormTitleNew: "Nouveau budget de voyage",
-  tripFormTitleEdit: "Modifier le budget de voyage",
+  tripFormTitleNew: "Nouveau voyage",
+  tripFormTitleEdit: "Modifier le voyage",
   tripNameLabel: "Nom du voyage",
   baseCurrencyLabel: "Devise du domicile",
   totalBudgetLabel: "Budget total en",
   dailyBudgetLabel: "Budget quotidien en",
-  enterNameAlert: "Veuillez entrer un nom pour votre nouveau budget de voyage",
+  enterNameAlert: "Veuillez entrer un nom pour votre nouveau voyage.",
   enterBudgetAlert:
     "Veuillez entrer un budget total supérieur au budget quotidien",
   selectCurrencyAlert:
@@ -1969,15 +1969,15 @@ const ru = {
   getLocalPriceError: "Пожалуйста, введите название продукта или услуги",
 
   // Trip Form Labels
-  tripFormTitleNew: "Бюджет новой поездки",
-  tripFormTitleEdit: "Изменить бюджет поездки",
+  tripFormTitleNew: "Новая поездка",
+  tripFormTitleEdit: "Изменить поездку",
   tripNameLabel: "Название поездки",
   baseCurrencyLabel: "Домашняя валюта",
   totalBudgetLabel: "Общий бюджет в",
   dailyBudgetLabel: "Дневной бюджет в",
-  enterNameAlert: "Введите название нового бюджета поездки",
+  enterNameAlert: "Введите название новой поездки.",
   enterBudgetAlert: "Введите общий бюджет, превышающий дневной бюджет",
-  selectCurrencyAlert: "Выберите домашнюю валюту для бюджета поездки",
+  selectCurrencyAlert: "Выберите домашнюю валюту для этой поездки",
   alertChangeHomeCurrencyTitle: "Изменение домашней валюты",
   alertChangeHomeCurrencyMessage:
     "Вы уверены, что хотите изменить валюту? Укажите валюту, которую вы обычно используете дома.",


### PR DESCRIPTION
## Summary

Closes #223.

- Trip form alerts (`enterNameAlert`, RU `selectCurrencyAlert`) now name the **Trip** container, not a separate “trip budget” entity.
- FR/RU form screen titles aligned with DE (**voyage** / **поездка**), where they previously implied the screen creates a budget object.
- **Intentional keep (EN):** `tripFormTitleNew` / `tripFormTitleEdit` remain “New Trip Budget” / “Edit Trip Budget” as form screen titles only (per issue acceptance criteria).
- Added `__tests__/i18n/trip-form-copy.test.ts` and updated `CONTEXT.md` flagged ambiguities.

No functional changes to trip creation/edit flow.

## Test plan

- [x] `pnpm test -- __tests__/i18n/trip-form-copy.test.ts`
- [x] `pnpm test -- __tests__/i18n/`
- [ ] Smoke: open Trip form (new + edit) in EN — title still “New Trip Budget”; empty name shows updated alert
- [ ] Spot-check FR/RU form titles and name alert copy