### PR TITLE
Rename per-expense isPaid to paidBack (#224)

### DIFF
--- a/TravelCostApp/CONTEXT.md
+++ b/TravelCostApp/CONTEXT.md
@@ -57,8 +57,8 @@ The net amount one traveller owes another on a trip, rolled up across expenses. 
 _Avoid_: Open split (UI copy), debt (marketing copy)
 
 **Paid back**:
-Per-expense status: the travellers’ shares for that expense have been reimbursed to whoever paid. Expenses not yet paid back still count toward open **Balances**. (Code field: `isPaid`.)
-_Avoid_: Paid (ambiguous with who paid upfront), isPaid (implementation name)
+Per-expense status: the travellers’ shares for that expense have been reimbursed to whoever paid. Expenses not yet paid back still count toward open **Balances**. (Code field: `paidBack`.)
+_Avoid_: Paid (ambiguous with who paid upfront), isPaid (legacy field name)
 
 **Who paid**:
 The traveller who fronted the money for an expense (before **Splits** allocate shares among travellers). Distinct from **Paid back** (whether shares have been reimbursed).
@@ -122,7 +122,7 @@ Places where English UI copy or code identifiers still diverge from domain langu
 | Surface | Current wording / field | Domain term | Notes |
 | ------- | ----------------------- | ----------- | ----- |
 | Trip setup (i18n) | ~~“Base Currency”~~ → home / Heimatwährung / domicile copy (#221) | **Trip currency** | Aligned in #221 for EN/DE/FR/RU trip-currency alerts, info modals, and TripForm change-currency confirm. |
-| Expense / trip models | `isPaid`, `isPaidTimestamp` | **Paid back**, **Settlement** (trip-wide) | `isPaid` is per-expense paid-back status; trip `isPaid` + timestamp drive trip-wide **Settlement**. |
+| Expense / trip models | ~~`isPaid` (per expense)~~ → `paidBack`; `isPaid` + `isPaidTimestamp` on trip | **Paid back**, **Settlement** (trip-wide) | Per-expense **Paid back** uses `paidBack` (#224). Trip `isPaid` + `isPaidTimestamp` still name trip-wide **Settlement** (follow-up rename optional). |
 | Split Summary UI (i18n) | ~~“open splits”, “Calculate open splits”, “No open splits”~~ → balance copy (#222) | **Balance** | Aligned in #222 for EN/DE/FR/RU: balances wording, button helpers, Settlement vs Balance simplification labels. |
 | Split Summary UI (i18n) | ~~“settle splits”, “Could not settle splits”~~ → Settlement copy (#222) | **Settlement** | Aligned in #222; trip-wide settle actions and toasts use Settlement language. |
 | Split Summary UI (i18n) | ~~“simplify splits”, “Could not simplify splits”~~ → Balance simplification copy (#222) | **Balance simplification** | Aligned in #222; “Simplify splits” + helper clarifies no money has moved. |

--- a/TravelCostApp/CONTEXT.md
+++ b/TravelCostApp/CONTEXT.md
@@ -58,7 +58,7 @@ _Avoid_: Open split (UI copy), debt (marketing copy)
 
 **Paid back**:
 Per-expense status: the travellers’ shares for that expense have been reimbursed to whoever paid. Expenses not yet paid back still count toward open **Balances**. (Code field: `paidBack`.)
-_Avoid_: Paid (ambiguous with who paid upfront), isPaid (legacy field name)
+_Avoid_: Paid (ambiguous with who paid upfront), isPaid (legacy field name), isPaidString (legacy enum name; use `paidBackStatus`)
 
 **Who paid**:
 The traveller who fronted the money for an expense (before **Splits** allocate shares among travellers). Distinct from **Paid back** (whether shares have been reimbursed).

--- a/TravelCostApp/__tests__/docs/project-guidance.test.ts
+++ b/TravelCostApp/__tests__/docs/project-guidance.test.ts
@@ -17,7 +17,7 @@ describe("project guidance (issue #220)", () => {
     expect(context).toMatch(/## Flagged ambiguities/);
     expect(context).toMatch(/Base Currency/i);
     expect(context).toMatch(/\*\*Trip currency\*\*/);
-    expect(context).toMatch(/`isPaid`/);
+    expect(context).toMatch(/`paidBack`/);
     expect(context).toMatch(/\*\*Paid back\*\*/);
     expect(context).toMatch(/open splits/i);
     expect(context).toMatch(/settle splits/i);

--- a/TravelCostApp/__tests__/util/expense-paid-back-sync.test.ts
+++ b/TravelCostApp/__tests__/util/expense-paid-back-sync.test.ts
@@ -1,8 +1,10 @@
 import {
   isPaidString,
+  normalizeExpensePaidBack,
   readPaidBackFromOnlineRecord,
   toExpenseOnline,
 } from "../../util/expense";
+import type { ExpenseData } from "../../util/expense";
 import { makeExpense } from "../fixtures/expense";
 
 describe("expense paidBack sync", () => {
@@ -37,6 +39,43 @@ describe("expense paidBack sync", () => {
 
       expect(online.paidBack).toBe("paid");
       expect(online).not.toHaveProperty("isPaid");
+    });
+
+    it("migrates legacy isPaid to paidBack on write when paidBack is unset", () => {
+      const online = toExpenseOnline({
+        ...makeExpense(),
+        isPaid: isPaidString.paid,
+      } as ExpenseData & { isPaid: typeof isPaidString.paid });
+
+      expect(online.paidBack).toBe("paid");
+      expect(online).not.toHaveProperty("isPaid");
+    });
+
+    it("omits paidBack when neither paidBack nor legacy isPaid is set", () => {
+      const online = toExpenseOnline(makeExpense());
+
+      expect(online).not.toHaveProperty("paidBack");
+      expect(online).not.toHaveProperty("isPaid");
+    });
+  });
+
+  describe("normalizeExpensePaidBack", () => {
+    it("maps legacy isPaid onto paidBack and strips isPaid from in-memory expense", () => {
+      const normalized = normalizeExpensePaidBack({
+        ...makeExpense(),
+        isPaid: isPaidString.paid,
+      } as ExpenseData & { isPaid: typeof isPaidString.paid });
+
+      expect(normalized.paidBack).toBe(isPaidString.paid);
+      expect(normalized).not.toHaveProperty("isPaid");
+    });
+
+    it("leaves expense unchanged when no paid-back flag is stored", () => {
+      const expense = makeExpense();
+      const normalized = normalizeExpensePaidBack(expense);
+
+      expect(normalized).toEqual(expense);
+      expect(normalized).not.toHaveProperty("paidBack");
     });
   });
 });

--- a/TravelCostApp/__tests__/util/expense-paid-back-sync.test.ts
+++ b/TravelCostApp/__tests__/util/expense-paid-back-sync.test.ts
@@ -1,0 +1,42 @@
+import {
+  isPaidString,
+  readPaidBackFromOnlineRecord,
+  toExpenseOnline,
+} from "../../util/expense";
+import { makeExpense } from "../fixtures/expense";
+
+describe("expense paidBack sync", () => {
+  describe("readPaidBackFromOnlineRecord", () => {
+    it("reads paidBack when the server sends the new field", () => {
+      expect(readPaidBackFromOnlineRecord({ paidBack: "paid" })).toBe(
+        isPaidString.paid
+      );
+    });
+
+    it("falls back to legacy isPaid when paidBack is absent", () => {
+      expect(readPaidBackFromOnlineRecord({ isPaid: "paid" })).toBe(
+        isPaidString.paid
+      );
+    });
+
+    it("prefers paidBack when both legacy isPaid and paidBack are present", () => {
+      expect(
+        readPaidBackFromOnlineRecord({
+          paidBack: "not paid",
+          isPaid: "paid",
+        })
+      ).toBe(isPaidString.notPaid);
+    });
+  });
+
+  describe("toExpenseOnline", () => {
+    it("writes paidBack and omits legacy isPaid", () => {
+      const online = toExpenseOnline(
+        makeExpense({ paidBack: isPaidString.paid })
+      );
+
+      expect(online.paidBack).toBe("paid");
+      expect(online).not.toHaveProperty("isPaid");
+    });
+  });
+});

--- a/TravelCostApp/__tests__/util/paid-back-status.test.ts
+++ b/TravelCostApp/__tests__/util/paid-back-status.test.ts
@@ -1,40 +1,49 @@
-import { getEffectiveIsPaid, isPaidString } from "../../util/expense";
+import { getEffectivePaidBack, isPaidString } from "../../util/expense";
 import { makeExpense } from "../fixtures/expense";
 
-describe("Paid back status (getEffectiveIsPaid)", () => {
-  it("uses the expense stored isPaid when the trip has no Settlement timestamp", () => {
-    const expense = makeExpense({ isPaid: isPaidString.paid });
+describe("Paid back status (getEffectivePaidBack)", () => {
+  it("uses the expense stored paidBack when the trip has no Settlement timestamp", () => {
+    const expense = makeExpense({ paidBack: isPaidString.paid });
 
-    expect(getEffectiveIsPaid(expense)).toBe(isPaidString.paid);
-    expect(getEffectiveIsPaid(expense, 0)).toBe(isPaidString.paid);
+    expect(getEffectivePaidBack(expense)).toBe(isPaidString.paid);
+    expect(getEffectivePaidBack(expense, 0)).toBe(isPaidString.paid);
   });
 
-  it("defaults to not paid when the trip has no Settlement timestamp and isPaid is unset", () => {
-    const expense = makeExpense({ isPaid: undefined });
+  it("defaults to not paid when the trip has no Settlement timestamp and paidBack is unset", () => {
+    const expense = makeExpense({ paidBack: undefined });
 
-    expect(getEffectiveIsPaid(expense)).toBe(isPaidString.notPaid);
+    expect(getEffectivePaidBack(expense)).toBe(isPaidString.notPaid);
+  });
+
+  it("reads legacy isPaid on stored expenses when paidBack is unset", () => {
+    const expense = {
+      ...makeExpense(),
+      isPaid: isPaidString.paid,
+    };
+
+    expect(getEffectivePaidBack(expense)).toBe(isPaidString.paid);
   });
 
   it("treats an expense as paid back when Settlement is after the expense was last edited", () => {
     const expense = makeExpense({
-      isPaid: isPaidString.notPaid,
+      paidBack: isPaidString.notPaid,
       editedTimestamp: 1000,
     });
     const settlementTimestamp = 2000;
 
-    expect(getEffectiveIsPaid(expense, settlementTimestamp)).toBe(
+    expect(getEffectivePaidBack(expense, settlementTimestamp)).toBe(
       isPaidString.paid
     );
   });
 
-  it("keeps the expense stored isPaid when the expense was edited after Settlement", () => {
+  it("keeps the expense stored paidBack when the expense was edited after Settlement", () => {
     const expense = makeExpense({
-      isPaid: isPaidString.notPaid,
+      paidBack: isPaidString.notPaid,
       editedTimestamp: 3000,
     });
     const settlementTimestamp = 2000;
 
-    expect(getEffectiveIsPaid(expense, settlementTimestamp)).toBe(
+    expect(getEffectivePaidBack(expense, settlementTimestamp)).toBe(
       isPaidString.notPaid
     );
   });

--- a/TravelCostApp/__tests__/util/settlement.test.ts
+++ b/TravelCostApp/__tests__/util/settlement.test.ts
@@ -1,7 +1,7 @@
 import { settleTrip } from "../../util/settlement";
 import { makeExpense } from "../fixtures/expense";
 import { rollupOpenBalances } from "../../util/split";
-import { getEffectiveIsPaid, isPaidString } from "../../util/expense";
+import { getEffectivePaidBack, isPaidString } from "../../util/expense";
 
 describe("Settlement (settleTrip)", () => {
   it("sets isPaid, isPaidTimestamp, isPaidDate and preserves all other trip fields", () => {
@@ -66,9 +66,9 @@ describe("Settlement (settleTrip)", () => {
     expect(settledTrip.isPaidTimestamp).toBe(now);
     expect(settledTrip.isPaidDate).toBe(new Date(now).toISOString());
 
-    // Per-expense paid-back is derived by getEffectiveIsPaid with trip settlement timestamp.
+    // Per-expense paid-back is derived by getEffectivePaidBack with trip settlement timestamp.
     for (const exp of trip.expenses) {
-      expect(getEffectiveIsPaid(exp, settledTrip.isPaidTimestamp)).toBe(
+      expect(getEffectivePaidBack(exp, settledTrip.isPaidTimestamp)).toBe(
         isPaidString.paid
       );
     }
@@ -100,7 +100,7 @@ describe("Settlement (settleTrip)", () => {
     const settledTrip = settleTrip(trip, settledAt);
 
     expect(
-      getEffectiveIsPaid(trip.expenses[0], settledTrip.isPaidTimestamp)
+      getEffectivePaidBack(trip.expenses[0], settledTrip.isPaidTimestamp)
     ).toBe(isPaidString.notPaid);
 
     const openBalances = rollupOpenBalances(

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -74,7 +74,7 @@ import {
   ExpenseData,
   isPaidString,
   Split,
-  getEffectiveIsPaid,
+  getEffectivePaidBack,
 } from "../../util/expense";
 import { NetworkContext } from "../../store/network-context";
 import { SettingsContext } from "../../store/settings-context";
@@ -419,28 +419,28 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     setShowDatePickerRange(false);
   };
 
-  // Calculate effective isPaid status (with timestamp override) when editing
-  const effectiveIsPaid = isEditing
-    ? getEffectiveIsPaid(editingValues, tripCtx.isPaidTimestamp)
+  // Calculate effective paid-back status (with timestamp override) when editing
+  const effectivePaidBack = isEditing
+    ? getEffectivePaidBack(editingValues, tripCtx.isPaidTimestamp)
     : isPaidString.notPaid;
 
-  // Check if expense isPaid is overridden by timestamp
+  // Check if expense paidBack is overridden by timestamp
   const isOverridden =
     isEditing &&
     tripCtx.isPaidTimestamp &&
     tripCtx.isPaidTimestamp > (editingValues?.editedTimestamp || 0) &&
-    effectiveIsPaid === isPaidString.paid;
+    effectivePaidBack === isPaidString.paid;
 
-  const [isPaid, setIsPaid] = useState(
-    isEditing ? effectiveIsPaid : isPaidString.notPaid
+  const [paidBack, setPaidBack] = useState(
+    isEditing ? effectivePaidBack : isPaidString.notPaid
   );
-  const didUserChangeIsPaidRef = useRef(false);
+  const didUserChangePaidBackRef = useRef(false);
   const [isSpecialExpense, setIsSpecialExpense] = useState(
     editingValues?.isSpecialExpense ?? false
   );
 
   // Note: New expenses always default to "notPaid" - users must explicitly mark expenses as paid
-  // Trip-level settlement (isPaidTimestamp) affects effective isPaid status via timestamp override
+  // Trip-level settlement (isPaidTimestamp) affects effective paidBack via timestamp override
 
   useEffect(() => {
     if (dateISO) {
@@ -831,7 +831,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
         splitList,
         duplOrSplit,
         calcAmount: +amountValue,
-        isPaid,
+        paidBack,
         isSpecialExpense,
         categoryString: inputs.category.value,
         ...newValues,
@@ -853,7 +853,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       splitList,
       duplOrSplit,
       amountValue,
-      isPaid,
+      paidBack,
       isSpecialExpense,
     ]
   );
@@ -887,6 +887,9 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   useEffect(() => {
     const draftData: ExpenseData = getExpenseDraft(editedExpenseId);
     if (draftData) {
+      const draftPaidBack =
+        draftData.paidBack ??
+        (draftData as ExpenseData & { isPaid?: isPaidString }).isPaid;
       // Create a user-friendly list of changed items
       const changedItems = [];
 
@@ -920,9 +923,11 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
               : draftData.splitType;
         changedItems.push(`• ${i18n.t("splitType")}: ${splitTypeText}`);
       }
-      if (draftData.isPaid && draftData.isPaid !== "not paid") {
+      if (draftPaidBack && draftPaidBack !== "not paid") {
         const paidText =
-          draftData.isPaid === "paid" ? i18n.t("paid") : i18n.t("notPaidLabel");
+          draftPaidBack === "paid"
+            ? i18n.t("paid")
+            : i18n.t("notPaidLabel");
         changedItems.push(`• ${i18n.t("paymentStatus")}: ${paidText}`);
       }
       if (draftData.isSpecialExpense) {
@@ -985,8 +990,8 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
               if (draftData.duplOrSplit !== undefined) {
                 setDuplOrSplit(draftData.duplOrSplit);
               }
-              if (draftData.isPaid) {
-                setIsPaid(draftData.isPaid);
+              if (draftPaidBack) {
+                setPaidBack(draftPaidBack);
               }
               if (draftData.isSpecialExpense !== undefined) {
                 setIsSpecialExpense(draftData.isSpecialExpense);
@@ -1039,25 +1044,25 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     [scheduleDraftSave]
   );
 
-  const setIsPaidWithAutoSave = useCallback(
+  const setPaidBackWithAutoSave = useCallback(
     (value) => {
-      didUserChangeIsPaidRef.current = true;
-      setIsPaid(value);
+      didUserChangePaidBackRef.current = true;
+      setPaidBack(value);
       trackEvent(VexoEvents.EXPENSE_PAID_TOGGLE_CHANGED, {
-        isPaid: value === isPaidString.paid,
+        paidBack: value === isPaidString.paid,
       });
       scheduleDraftSave();
     },
     [scheduleDraftSave]
   );
 
-  // If the edited expense changes (or effectiveIsPaid changes due to settlement timestamp),
+  // If the edited expense changes (or effectivePaidBack changes due to settlement timestamp),
   // only sync local UI state if the user hasn't manually changed it in this session.
   useEffect(() => {
     if (!isEditing) return;
-    if (didUserChangeIsPaidRef.current) return;
-    setIsPaid(effectiveIsPaid);
-  }, [effectiveIsPaid, isEditing, editingValues?.id]);
+    if (didUserChangePaidBackRef.current) return;
+    setPaidBack(effectivePaidBack);
+  }, [effectivePaidBack, isEditing, editingValues?.id]);
 
   const setIsSpecialExpenseWithAutoSave = useCallback(
     (value) => {
@@ -1253,7 +1258,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       splitList: splitList,
       duplOrSplit: duplOrSplit,
       iconName: iconName,
-      isPaid: isPaid,
+      paidBack: paidBack,
       isSpecialExpense: isSpecialExpense,
       alreadyDividedAmountByDays: alreadyDividedAmountByDays,
     };
@@ -1373,7 +1378,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       listEQUAL: extractUserNames(currentTravellers),
       splitList: splitList,
       iconName: iconName,
-      isPaid: isPaid,
+      paidBack: paidBack,
       isSpecialExpense: isSpecialExpense,
       duplOrSplit: duplOrSplit,
     };
@@ -1496,7 +1501,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     </Pressable>
   );
 
-  const isPaidJSX = (
+  const paidBackJSX = (
     <View style={styles.isPaidContainer}>
       {isOverridden ? (
         <View style={{ padding: 8 }}>
@@ -1511,10 +1516,10 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
         </View>
       ) : (
         <SegmentedButtons
-          value={isPaid}
+          value={paidBack}
           onValueChange={(value: string) => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-            setIsPaidWithAutoSave(value);
+            setPaidBackWithAutoSave(value);
           }}
           buttons={[
             {
@@ -1524,11 +1529,13 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
               style: [
                 {
                   backgroundColor:
-                    isPaid == isPaidString.paid
+                    paidBack == isPaidString.paid
                       ? GlobalStyles.colors.gray500
                       : GlobalStyles.colors.gray300,
                 },
-                isPaid == isPaidString.paid ? GlobalStyles.strongShadow : null,
+                paidBack == isPaidString.paid
+                  ? GlobalStyles.strongShadow
+                  : null,
               ],
             },
             {
@@ -1538,11 +1545,11 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
               style: [
                 {
                   backgroundColor:
-                    isPaid == isPaidString.notPaid
+                    paidBack == isPaidString.notPaid
                       ? GlobalStyles.colors.gray500
                       : GlobalStyles.colors.gray300,
                 },
-                isPaid == isPaidString.notPaid
+                paidBack == isPaidString.notPaid
                   ? GlobalStyles.strongShadow
                   : null,
               ],
@@ -2339,7 +2346,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
                     ></FlatList>
                   </KeyboardAvoidingView>
                 )}
-                {!splitTypeSelf && splitListHasNonZeroEntries && isPaidJSX}
+                {!splitTypeSelf && splitListHasNonZeroEntries && paidBackJSX}
                 {isSpecialExpenseJSX}
               </Animated.View>
             )}

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -426,7 +426,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
       }
       // IMPORTANT: don't mutate the shared expenseData object inside the loop.
       // Mutating can cause stale/incorrect state during rerenders (and can lead to loops),
-      // especially when toggling fields like isPaid on ranged expenses.
+      // especially when toggling fields like paidBack on ranged expenses.
       const updatedExpenseData: ExpenseData = {
         ...expenseData,
         date: newDate,

--- a/TravelCostApp/screens/SplitSummaryScreen.tsx
+++ b/TravelCostApp/screens/SplitSummaryScreen.tsx
@@ -35,7 +35,7 @@ import {
   ExpenseData,
   Split,
   isPaidString,
-  getEffectiveIsPaid,
+  getEffectivePaidBack,
 } from "../util/expense";
 import Animated from "react-native-reanimated";
 import { formatExpenseWithCurrency } from "../util/string";
@@ -181,7 +181,7 @@ const SplitSummaryScreen = ({ navigation }) => {
         const expensesList = expenses.filter((expense: ExpenseData) => {
           // Skip paid expenses
           if (
-            getEffectiveIsPaid(expense, isPaidTimestamp) === isPaidString.paid
+            getEffectivePaidBack(expense, isPaidTimestamp) === isPaidString.paid
           ) {
             return false;
           }

--- a/TravelCostApp/util/expense.ts
+++ b/TravelCostApp/util/expense.ts
@@ -42,7 +42,7 @@ export interface ExpenseData {
   listEQUAL?: string[];
   iconName?: string;
   rangeId?: string;
-  isPaid?: isPaidString;
+  paidBack?: isPaidString;
   isSpecialExpense?: boolean;
   editedTimestamp?: number;
   isDeleted?: boolean;
@@ -60,38 +60,64 @@ export enum isPaidString {
   notPaid = "not paid",
 }
 
+/** Legacy expense records (server, MMKV) may still use `isPaid`. */
+type ExpensePaidBackSource = {
+  paidBack?: unknown;
+  isPaid?: unknown;
+};
+
+function normalizePaidBackValue(value: unknown): isPaidString {
+  return value === isPaidString.paid ? isPaidString.paid : isPaidString.notPaid;
+}
+
+/** Read path: accept `paidBack` or legacy `isPaid` from sync payloads. */
+export function readPaidBackFromOnlineRecord(
+  record: ExpensePaidBackSource
+): isPaidString {
+  if (record.paidBack !== undefined && record.paidBack !== null) {
+    return normalizePaidBackValue(record.paidBack);
+  }
+  return normalizePaidBackValue(record.isPaid);
+}
+
+/** Stored per-expense paid-back flag (legacy `isPaid` field on old records). */
+export function getStoredPaidBack(expense: ExpenseData): isPaidString | undefined {
+  if (expense.paidBack !== undefined) {
+    return expense.paidBack;
+  }
+  const legacy = expense as ExpenseData & { isPaid?: isPaidString };
+  return legacy.isPaid;
+}
+
 /**
- * Computes the effective isPaid status for an expense based on timestamp override logic.
+ * Computes the effective paid-back status for an expense based on timestamp override logic.
  * If trip was settled (isPaidTimestamp exists) and expense was created/edited before settlement,
- * then the expense is effectively "paid" regardless of its stored isPaid value.
- *
- * @param expense - The expense data
- * @param tripIsPaidTimestamp - The timestamp when the trip was settled (in milliseconds)
- * @returns The effective isPaid status (paid or not paid)
+ * then the expense is effectively paid back regardless of its stored paidBack value.
  */
-export function getEffectiveIsPaid(
+export function getEffectivePaidBack(
   expense: ExpenseData,
   tripIsPaidTimestamp?: number
 ): isPaidString {
-  // If no trip settlement timestamp, use expense's stored isPaid value
   if (!tripIsPaidTimestamp || tripIsPaidTimestamp === 0) {
-    return expense.isPaid ?? isPaidString.notPaid;
+    return getStoredPaidBack(expense) ?? isPaidString.notPaid;
   }
 
-  // Get expense editedTimestamp, default to 0 if missing
   const expenseTimestamp = expense.editedTimestamp || 0;
 
-  // If trip was settled after expense was created/edited, override to "paid"
   if (tripIsPaidTimestamp > expenseTimestamp) {
     return isPaidString.paid;
   }
 
-  // Otherwise, use expense's stored isPaid value
-  return expense.isPaid ?? isPaidString.notPaid;
+  return getStoredPaidBack(expense) ?? isPaidString.notPaid;
 }
 
+/** @deprecated Use {@link getEffectivePaidBack}. */
+export const getEffectiveIsPaid = getEffectivePaidBack;
+
 export interface ExpenseDataOnline {
-  isPaid: string;
+  /** Write path uses `paidBack`; read path may still see legacy `isPaid`. */
+  paidBack?: string;
+  isPaid?: string;
   id?: string;
   uid?: string;
   splitType: splitType;
@@ -114,6 +140,16 @@ export interface ExpenseDataOnline {
   editedTimestamp?: string;
   isDeleted?: boolean;
   serverTimestamp?: number;
+}
+
+/** Write path: serialize expense for Firebase using `paidBack` only. */
+export function toExpenseOnline(expense: ExpenseData): ExpenseDataOnline {
+  const { paidBack, ...rest } = expense;
+  const legacy = expense as ExpenseData & { isPaid?: isPaidString };
+  const stored = paidBack ?? legacy.isPaid ?? isPaidString.notPaid;
+  const online = { ...rest, paidBack: stored } as ExpenseDataOnline & ExpenseData;
+  delete (online as ExpenseData & { isPaid?: isPaidString }).isPaid;
+  return online;
 }
 
 export interface Split {

--- a/TravelCostApp/util/expense.ts
+++ b/TravelCostApp/util/expense.ts
@@ -42,7 +42,7 @@ export interface ExpenseData {
   listEQUAL?: string[];
   iconName?: string;
   rangeId?: string;
-  paidBack?: isPaidString;
+  paidBack?: paidBackStatus;
   isSpecialExpense?: boolean;
   editedTimestamp?: number;
   isDeleted?: boolean;
@@ -55,10 +55,13 @@ export enum DuplicateOption {
   split = 2,
 }
 
-export enum isPaidString {
+export enum paidBackStatus {
   paid = "paid",
   notPaid = "not paid",
 }
+
+/** @deprecated Use {@link paidBackStatus}. */
+export const isPaidString = paidBackStatus;
 
 /** Legacy expense records (server, MMKV) may still use `isPaid`. */
 type ExpensePaidBackSource = {
@@ -66,14 +69,16 @@ type ExpensePaidBackSource = {
   isPaid?: unknown;
 };
 
-function normalizePaidBackValue(value: unknown): isPaidString {
-  return value === isPaidString.paid ? isPaidString.paid : isPaidString.notPaid;
+function normalizePaidBackValue(value: unknown): paidBackStatus {
+  return value === paidBackStatus.paid
+    ? paidBackStatus.paid
+    : paidBackStatus.notPaid;
 }
 
 /** Read path: accept `paidBack` or legacy `isPaid` from sync payloads. */
 export function readPaidBackFromOnlineRecord(
   record: ExpensePaidBackSource
-): isPaidString {
+): paidBackStatus {
   if (record.paidBack !== undefined && record.paidBack !== null) {
     return normalizePaidBackValue(record.paidBack);
   }
@@ -81,12 +86,27 @@ export function readPaidBackFromOnlineRecord(
 }
 
 /** Stored per-expense paid-back flag (legacy `isPaid` field on old records). */
-export function getStoredPaidBack(expense: ExpenseData): isPaidString | undefined {
+export function getStoredPaidBack(
+  expense: ExpenseData
+): paidBackStatus | undefined {
   if (expense.paidBack !== undefined) {
     return expense.paidBack;
   }
-  const legacy = expense as ExpenseData & { isPaid?: isPaidString };
+  const legacy = expense as ExpenseData & { isPaid?: paidBackStatus };
   return legacy.isPaid;
+}
+
+/**
+ * Normalizes in-memory/cached expenses: `paidBack` from legacy `isPaid`, strips `isPaid`.
+ */
+export function normalizeExpensePaidBack(expense: ExpenseData): ExpenseData {
+  const stored = getStoredPaidBack(expense);
+  if (stored === undefined) {
+    return expense;
+  }
+  const legacy = expense as ExpenseData & { isPaid?: paidBackStatus };
+  const { isPaid: _legacy, ...rest } = legacy;
+  return { ...rest, paidBack: stored };
 }
 
 /**
@@ -97,18 +117,18 @@ export function getStoredPaidBack(expense: ExpenseData): isPaidString | undefine
 export function getEffectivePaidBack(
   expense: ExpenseData,
   tripIsPaidTimestamp?: number
-): isPaidString {
+): paidBackStatus {
   if (!tripIsPaidTimestamp || tripIsPaidTimestamp === 0) {
-    return getStoredPaidBack(expense) ?? isPaidString.notPaid;
+    return getStoredPaidBack(expense) ?? paidBackStatus.notPaid;
   }
 
   const expenseTimestamp = expense.editedTimestamp || 0;
 
   if (tripIsPaidTimestamp > expenseTimestamp) {
-    return isPaidString.paid;
+    return paidBackStatus.paid;
   }
 
-  return getStoredPaidBack(expense) ?? isPaidString.notPaid;
+  return getStoredPaidBack(expense) ?? paidBackStatus.notPaid;
 }
 
 /** @deprecated Use {@link getEffectivePaidBack}. */
@@ -142,13 +162,16 @@ export interface ExpenseDataOnline {
   serverTimestamp?: number;
 }
 
-/** Write path: serialize expense for Firebase using `paidBack` only. */
+/** Write path: serialize expense for Firebase using `paidBack` only when set. */
 export function toExpenseOnline(expense: ExpenseData): ExpenseDataOnline {
   const { paidBack, ...rest } = expense;
-  const legacy = expense as ExpenseData & { isPaid?: isPaidString };
-  const stored = paidBack ?? legacy.isPaid ?? isPaidString.notPaid;
-  const online = { ...rest, paidBack: stored } as ExpenseDataOnline & ExpenseData;
-  delete (online as ExpenseData & { isPaid?: isPaidString }).isPaid;
+  const legacy = expense as ExpenseData & { isPaid?: paidBackStatus };
+  const stored = paidBack ?? legacy.isPaid;
+  const online = { ...rest } as ExpenseDataOnline & ExpenseData;
+  delete (online as ExpenseData & { isPaid?: paidBackStatus }).isPaid;
+  if (stored !== undefined) {
+    online.paidBack = stored;
+  }
   return online;
 }
 
@@ -402,9 +425,10 @@ export async function getAllExpensesData(tripid: string) {
     cachedExpenses &&
     isToday(new Date(lastCacheUpdateExpenses));
 
-  const _expenses: ExpenseData[] = lastUpdateWasToday
+  const rawExpenses: ExpenseData[] = lastUpdateWasToday
     ? cachedExpenses
     : await getAllExpenses(tripid);
+  const expenses = rawExpenses.map(normalizeExpensePaidBack);
   if (!lastUpdateWasToday) {
     // update cache
     setMMKVString(
@@ -413,8 +437,8 @@ export async function getAllExpensesData(tripid: string) {
     );
     setMMKVObject(
       MMKV_KEY_PATTERNS.LAST_UPDATE_ALL_EXPENSES_TRIP(tripid),
-      _expenses
+      expenses
     );
   }
-  return _expenses;
+  return expenses;
 }

--- a/TravelCostApp/util/http.tsx
+++ b/TravelCostApp/util/http.tsx
@@ -8,7 +8,10 @@ import {
 import { Category } from "./category";
 import type { TripData } from "../types/trip";
 import type { ExpenseData, ExpenseDataOnline } from "./expense";
-import { isPaidString } from "./expense";
+import {
+  readPaidBackFromOnlineRecord,
+  toExpenseOnline,
+} from "./expense";
 import { UserData } from "../store/user-context";
 
 import { i18n } from "../i18n/i18n";
@@ -28,10 +31,6 @@ import {
 
 const BACKEND_URL =
   "https://travelcostnative-default-rtdb.asia-southeast1.firebasedatabase.app";
-
-function normalizeIsPaid(value: unknown): isPaidString {
-  return value === isPaidString.paid ? isPaidString.paid : isPaidString.notPaid;
-}
 
 // Field name for server timestamp in expense data -- needs to be updated in .rules firebase backend
 export const SERVER_TIMESTAMP_FIELD = "serverTimestamp";
@@ -173,7 +172,7 @@ export async function storeExpense(
 
     // Add serverTimestamp to expense data
     const expenseDataWithTimestamp = {
-      ...expenseData,
+      ...toExpenseOnline(expenseData),
       [SERVER_TIMESTAMP_FIELD]: Date.now(),
     };
 
@@ -204,7 +203,7 @@ export async function storeExpenseWithId(
 
     // Add serverTimestamp to expense data
     const expenseDataWithTimestamp = {
-      ...expenseData,
+      ...toExpenseOnline(expenseData),
       [SERVER_TIMESTAMP_FIELD]: Date.now(),
     };
 
@@ -248,7 +247,7 @@ const processExpenseResponse = (data: any): ExpenseData[] => {
       categoryString: r.categoryString,
       duplOrSplit: r.duplOrSplit,
       rangeId: r.rangeId,
-      isPaid: normalizeIsPaid(r.isPaid),
+      paidBack: readPaidBackFromOnlineRecord(r),
       isSpecialExpense: r.isSpecialExpense,
       editedTimestamp: editedTimestamp,
       isDeleted: r.isDeleted || false,
@@ -375,7 +374,7 @@ export async function fetchExpenses(
           categoryString: r.categoryString,
           duplOrSplit: r.duplOrSplit,
           rangeId: r.rangeId,
-          isPaid: normalizeIsPaid(r.isPaid),
+          paidBack: readPaidBackFromOnlineRecord(r),
           isSpecialExpense: r.isSpecialExpense,
           editedTimestamp: editedTimestamp,
           isDeleted: r.isDeleted || false,
@@ -459,7 +458,7 @@ export async function updateExpense(
 
     // Add serverTimestamp to expense data
     const expenseDataWithTimestamp = {
-      ...expenseData,
+      ...toExpenseOnline(expenseData),
       [SERVER_TIMESTAMP_FIELD]: Date.now(),
     };
 

--- a/TravelCostApp/util/split.ts
+++ b/TravelCostApp/util/split.ts
@@ -4,7 +4,7 @@ import {
   Split,
   ExpenseData,
   isPaidString,
-  getEffectiveIsPaid,
+  getEffectivePaidBack,
 } from "./expense";
 import { Traveller } from "./traveler";
 import { DateOrDateTime } from "./date";
@@ -366,11 +366,11 @@ export function rollupOpenBalances(
     // Skip expense if:
     // 1. Expense type is SELF
     // 2. Expense has no split list
-    // 3. Expense has effective isPaid status of "paid" (checked via timestamp override logic)
+    // 3. Expense is effectively paid back (checked via settlement timestamp override)
     if (
       expense.splitType === "SELF" ||
       !expense.splitList ||
-      getEffectiveIsPaid(expense, tripIsPaidTimestamp) === isPaidString.paid
+      getEffectivePaidBack(expense, tripIsPaidTimestamp) === isPaidString.paid
     ) {
       continue;
     }


### PR DESCRIPTION
## Summary

Closes #224.

- Renames the per-expense reimbursement flag from `isPaid` to `paidBack` on `ExpenseData`, expense form, split rollup, and Firebase sync.
- **Read path:** `readPaidBackFromOnlineRecord()` and `getStoredPaidBack()` accept legacy `isPaid` from server, MMKV cache, and drafts (`paidBack` wins when both are present).
- **Write path:** `toExpenseOnline()` serializes expenses with `paidBack` only (`storeExpense`, `storeExpenseWithId`, `updateExpense`).
- Renames `getEffectiveIsPaid` → `getEffectivePaidBack` (deprecated alias kept). Trip-level **Settlement** fields (`isPaid`, `isPaidTimestamp`, `isPaidDate`) unchanged.
- Updates `CONTEXT.md` glossary and flagged-ambiguities table.

## Migration

| Direction | Behavior |
|-----------|----------|
| Read (sync / cache) | `paidBack` ?? legacy `isPaid` |
| Write (Firebase) | `paidBack` only |
| Local drafts | Restore from `paidBack` or legacy `isPaid` |

No Cloud Functions changes (none referenced `isPaid` on expenses).

## Test plan

- [x] `pnpm test` in `TravelCostApp/` (149 tests)
- [ ] Add expense, toggle **Paid back**, save — sync shows `paidBack` in Firebase
- [ ] Open trip with legacy `isPaid` expenses — balances and Split Summary unchanged
- [ ] Trip **Settlement** still overrides pre-settlement expenses; post-settlement edits stay open