### PR TITLE
Align local expense delete with isDeleted tombstones

### DIFF
--- a/TravelCostApp/__tests__/store/expenses-soft-delete.test.ts
+++ b/TravelCostApp/__tests__/store/expenses-soft-delete.test.ts
@@ -1,0 +1,70 @@
+import {
+  activeExpenses,
+  expensesReducer,
+  mergeExpenseLists,
+} from "../../store/expenses-context";
+import { makeExpense } from "../fixtures/expense";
+
+describe("deleted expense tombstones in expenses state", () => {
+  it("marks an expense isDeleted instead of removing it from state", () => {
+    const expense = makeExpense({ id: "e1" });
+    let state = expensesReducer([], { type: "ADD", payload: expense });
+    state = expensesReducer(state, { type: "DELETE", payload: "e1" });
+
+    expect(state).toHaveLength(1);
+    expect(state[0].id).toBe("e1");
+    expect(state[0].isDeleted).toBe(true);
+  });
+
+  it("keeps a tombstone when sync merges a server-side deleted expense", () => {
+    const expense = makeExpense({
+      id: "e1",
+      serverTimestamp: 1,
+      editedTimestamp: 1,
+    });
+    let state = expensesReducer([], { type: "ADD", payload: expense });
+    state = mergeExpenseLists(state, [
+      makeExpense({
+        id: "e1",
+        isDeleted: true,
+        serverTimestamp: 2,
+        editedTimestamp: 2,
+      }),
+    ]);
+
+    expect(state).toHaveLength(1);
+    expect(state[0].id).toBe("e1");
+    expect(state[0].isDeleted).toBe(true);
+  });
+
+  it("removes draft temp rows from state instead of tombstoning them", () => {
+    const expense = makeExpense({ id: "temp" });
+    let state = expensesReducer([], { type: "ADD", payload: expense });
+    state = expensesReducer(state, { type: "DELETE", payload: "temp" });
+
+    expect(state).toHaveLength(0);
+  });
+
+  it("adds a tombstone when sync merges a deleted expense not yet on device", () => {
+    const state = mergeExpenseLists([], [
+      makeExpense({
+        id: "remote-deleted",
+        isDeleted: true,
+        serverTimestamp: 2,
+      }),
+    ]);
+
+    expect(state).toHaveLength(1);
+    expect(state[0].id).toBe("remote-deleted");
+    expect(state[0].isDeleted).toBe(true);
+  });
+
+  it("excludes deleted expenses from the active ledger view", () => {
+    const ledger = activeExpenses([
+      makeExpense({ id: "active" }),
+      makeExpense({ id: "gone", isDeleted: true }),
+    ]);
+
+    expect(ledger.map((expense) => expense.id)).toEqual(["active"]);
+  });
+});

--- a/TravelCostApp/__tests__/store/expenses-soft-delete.test.ts
+++ b/TravelCostApp/__tests__/store/expenses-soft-delete.test.ts
@@ -59,6 +59,48 @@ describe("deleted expense tombstones in expenses state", () => {
     expect(state[0].isDeleted).toBe(true);
   });
 
+  it("preserves local tombstone when server refresh omits the deleted expense", () => {
+    let state = expensesReducer([], {
+      type: "ADD",
+      payload: makeExpense({ id: "e1" }),
+    });
+    state = expensesReducer(state, { type: "DELETE", payload: "e1" });
+    state = mergeExpenseLists(state, [makeExpense({ id: "e2" })]);
+
+    const tombstone = state.find((expense) => expense.id === "e1");
+    expect(tombstone?.isDeleted).toBe(true);
+    expect(state).toHaveLength(2);
+  });
+
+  it("preserves local tombstone when sync merges a stale active server row", () => {
+    const deleteTime = 2_000;
+    jest.spyOn(Date, "now").mockReturnValue(deleteTime);
+
+    let state = expensesReducer([], {
+      type: "ADD",
+      payload: makeExpense({
+        id: "e1",
+        editedTimestamp: 100,
+        serverTimestamp: 100,
+      }),
+    });
+    state = expensesReducer(state, { type: "DELETE", payload: "e1" });
+    state = mergeExpenseLists(state, [
+      makeExpense({
+        id: "e1",
+        isDeleted: false,
+        editedTimestamp: 100,
+        serverTimestamp: 150,
+      }),
+    ]);
+
+    expect(state).toHaveLength(1);
+    expect(state[0].isDeleted).toBe(true);
+    expect(state[0].editedTimestamp).toBe(deleteTime);
+
+    jest.restoreAllMocks();
+  });
+
   it("excludes deleted expenses from the active ledger view", () => {
     const ledger = activeExpenses([
       makeExpense({ id: "active" }),

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -289,8 +289,7 @@ const TripForm = ({ navigation, route }) => {
         setLoadingProgress(8);
         const expenses = await getAllExpenses(editedTripId, uid);
         setLoadingProgress(9);
-        expenseCtx.setExpenses([...expenses]);
-        setMMKVObject(MMKV_KEYS.EXPENSES, expenses);
+        expenseCtx.mergeExpenses([...expenses]);
         tripCtx.setdailyBudget(tripData.dailyBudget);
         return;
       }

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -31,7 +31,7 @@ import {
 import { NetworkContext } from "../store/network-context";
 import { Toast } from "react-native-toast-message/lib/src/Toast";
 import * as Haptics from "expo-haptics";
-import { clearExpenseDraft, MMKV_KEYS, setMMKVObject } from "../store/mmkv";
+import { clearExpenseDraft } from "../store/mmkv";
 import { formatExpenseWithCurrency } from "../util/string";
 import { isSameDay } from "../util/dateTime";
 import safeLogError from "../util/error";
@@ -531,8 +531,6 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
           tripId: tripid,
         });
       }
-      // await asyncStoreSetObject("expenses", expenseCtx.expenses);
-      setMMKVObject(MMKV_KEYS.EXPENSES, expenseCtx.expenses);
       await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       // Clear draft data after successful submission
       clearExpenseDraft(editedExpenseId);

--- a/TravelCostApp/store/expenses-context.tsx
+++ b/TravelCostApp/store/expenses-context.tsx
@@ -153,6 +153,11 @@ function findOfflineCreatedDuplicateIndex(
   );
 }
 
+/** Expenses visible in the ledger (excludes deleted tombstones). */
+export function activeExpenses(expenses: ExpenseData[]): ExpenseData[] {
+  return expenses.filter((expense) => !expense.isDeleted);
+}
+
 export function mergeExpenseLists(
   state: ExpenseData[],
   newExpenses: ExpenseData[]
@@ -183,11 +188,6 @@ export function expensesReducer(state: ExpenseData[], action) {
       if (!newExpenses || newExpenses.length === 0) {
         return state;
       }
-
-      // Create array of deleted expense IDs from sync results
-      const deletedIds = newExpenses
-        .filter((expense) => expense.isDeleted === true)
-        .map((expense) => expense.id);
 
       // Create a map of existing expenses by ID for quick lookup
       const existingExpensesMap = new Map();
@@ -233,18 +233,13 @@ export function expensesReducer(state: ExpenseData[], action) {
         }
       });
 
-      // Filter out deleted expenses from the final set
-      const filteredExpenses = mergedExpenses.filter(
-        (expense) => !deletedIds.includes(expense.id)
-      );
-
       // Sort by date (newest first) and remove duplicates
       const getSortedState = (data: ExpenseData[]) =>
         data.sort((a: ExpenseData, b: ExpenseData) => {
           return Number(new Date(b.date)) - Number(new Date(a.date));
         });
 
-      const sorted = uniqBy(getSortedState(filteredExpenses), "id");
+      const sorted = uniqBy(getSortedState(mergedExpenses), "id");
       return sorted;
     }
     case "UPDATE": {
@@ -257,8 +252,23 @@ export function expensesReducer(state: ExpenseData[], action) {
       updatedExpenses[updatableExpenseIndex] = updatedItem;
       return updatedExpenses;
     }
-    case "DELETE":
-      return state.filter((expense) => expense.id !== action.payload);
+    case "DELETE": {
+      if (action.payload === "temp") {
+        return state.filter((expense) => expense.id !== action.payload);
+      }
+      const deleteIndex = state.findIndex(
+        (expense) => expense.id === action.payload,
+      );
+      if (deleteIndex === -1) {
+        return state;
+      }
+      const updatedExpenses = [...state];
+      updatedExpenses[deleteIndex] = {
+        ...updatedExpenses[deleteIndex],
+        isDeleted: true,
+      };
+      return updatedExpenses;
+    }
     case "UPDATE_ID": {
       const { oldId, newId } = action.payload;
       const expenseIndex = state.findIndex((expense) => expense.id === oldId);
@@ -517,10 +527,10 @@ function ExpensesContextProvider({ children }) {
           expenses = getYearlyExpenses(0).yearlyExpenses;
           return expenses;
         case "total":
-          return expensesState;
+          return activeExpenses(expensesState);
 
         default:
-          return expensesState;
+          return activeExpenses(expensesState);
       }
     },
     [
@@ -555,7 +565,7 @@ function ExpensesContextProvider({ children }) {
   );
 
   const filteredExpenses = useMemo(
-    () => expensesState.filter((expense) => !expense.isDeleted),
+    () => activeExpenses(expensesState),
     [expensesState]
   );
 

--- a/TravelCostApp/store/expenses-context.tsx
+++ b/TravelCostApp/store/expenses-context.tsx
@@ -262,10 +262,13 @@ export function expensesReducer(state: ExpenseData[], action) {
       if (deleteIndex === -1) {
         return state;
       }
+      const deletedAt = Date.now();
       const updatedExpenses = [...state];
       updatedExpenses[deleteIndex] = {
         ...updatedExpenses[deleteIndex],
         isDeleted: true,
+        editedTimestamp: deletedAt,
+        serverTimestamp: deletedAt,
       };
       return updatedExpenses;
     }


### PR DESCRIPTION
## Summary

- Local delete sets `isDeleted: true` and keeps the row in `expensesState` / MMKV (draft `temp` still hard-removes).
- Sync MERGE applies server deletes as tombstones instead of purging rows from state.
- `activeExpenses()` centralizes ledger filtering; `getRecentExpenses("total")` no longer leaks deleted rows.
- Removed ManageExpense MMKV write that overwrote storage with the filtered expense list.

## Test plan

- [x] `pnpm test` (including `__tests__/store/expenses-soft-delete.test.ts`)
- [ ] Delete an expense on device — hidden from ledger; restart app — still hidden
- [ ] Sync from another device where an expense was deleted — stays hidden locally

Closes #264