### PR TITLE
Restore deleted expense via PATCH and offline queue

### DIFF
--- a/TravelCostApp/__tests__/store/expenses-soft-delete.test.ts
+++ b/TravelCostApp/__tests__/store/expenses-soft-delete.test.ts
@@ -116,8 +116,29 @@ describe("deleted expense tombstones in expenses state", () => {
     expect(state[0].isDeleted).toBe(false);
     expect(state[0].editedTimestamp).toBe(deleteTime);
     expect(state[0].serverTimestamp).toBe(deleteTime);
+    expect(activeExpenses(state).map((expense) => expense.id)).toEqual(["e1"]);
 
     jest.restoreAllMocks();
+  });
+
+  it("restores multiple deleted expenses", () => {
+    let state = expensesReducer([], {
+      type: "ADD",
+      payload: makeExpense({ id: "e1" }),
+    });
+    state = expensesReducer(state, {
+      type: "ADD",
+      payload: makeExpense({ id: "e2" }),
+    });
+    state = expensesReducer(state, { type: "DELETE", payload: "e1" });
+    state = expensesReducer(state, { type: "DELETE", payload: "e2" });
+    state = expensesReducer(state, { type: "RESTORE", payload: "e1" });
+    state = expensesReducer(state, { type: "RESTORE", payload: "e2" });
+
+    expect(activeExpenses(state).map((expense) => expense.id).sort()).toEqual([
+      "e1",
+      "e2",
+    ]);
   });
 
   it("excludes deleted expenses from the active ledger view", () => {

--- a/TravelCostApp/__tests__/store/expenses-soft-delete.test.ts
+++ b/TravelCostApp/__tests__/store/expenses-soft-delete.test.ts
@@ -101,6 +101,25 @@ describe("deleted expense tombstones in expenses state", () => {
     jest.restoreAllMocks();
   });
 
+  it("clears isDeleted when a deleted expense is restored", () => {
+    const deleteTime = 2_000;
+    jest.spyOn(Date, "now").mockReturnValue(deleteTime);
+
+    let state = expensesReducer([], {
+      type: "ADD",
+      payload: makeExpense({ id: "e1" }),
+    });
+    state = expensesReducer(state, { type: "DELETE", payload: "e1" });
+    state = expensesReducer(state, { type: "RESTORE", payload: "e1" });
+
+    expect(state).toHaveLength(1);
+    expect(state[0].isDeleted).toBe(false);
+    expect(state[0].editedTimestamp).toBe(deleteTime);
+    expect(state[0].serverTimestamp).toBe(deleteTime);
+
+    jest.restoreAllMocks();
+  });
+
   it("excludes deleted expenses from the active ledger view", () => {
     const ledger = activeExpenses([
       makeExpense({ id: "active" }),

--- a/TravelCostApp/__tests__/util/offline-queue-sync.test.ts
+++ b/TravelCostApp/__tests__/util/offline-queue-sync.test.ts
@@ -19,13 +19,14 @@ jest.mock("../../util/http", () => ({
   storeExpenseWithId: jest.fn(),
   updateExpense: jest.fn(),
   deleteExpense: jest.fn(),
+  restoreExpense: jest.fn(),
   touchAllTravelers: jest.fn(async () => {}),
 }));
 
 import { MMKV_KEYS } from "../../store/mmkv";
 import { makeExpense } from "../fixtures/expense";
 import { sendOfflineQueue } from "../../util/offline-queue";
-import { storeExpenseWithId } from "../../util/http";
+import { restoreExpense, storeExpenseWithId } from "../../util/http";
 
 const mmkvStore: Record<string, unknown> = {};
 
@@ -119,6 +120,27 @@ describe("sendOfflineQueue", () => {
       expect.objectContaining({ id: clientId })
     );
     expect(updateExpenseId).toHaveBeenCalledWith(clientId, serverId);
+    expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toEqual([]);
+  });
+
+  it("uploads queued restore items and clears the queue", async () => {
+    mmkvStore[MMKV_KEYS.OFFLINE_QUEUE] = [
+      {
+        type: "restore",
+        expense: { tripid: "trip-1", uid: "traveller-1", id: "exp-restored" },
+      },
+    ];
+
+    (restoreExpense as jest.Mock).mockResolvedValue({});
+
+    let mutex = false;
+    await sendOfflineQueue(mutex, jest.fn());
+
+    expect(restoreExpense).toHaveBeenCalledWith(
+      "trip-1",
+      "traveller-1",
+      "exp-restored",
+    );
     expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toEqual([]);
   });
 });

--- a/TravelCostApp/__tests__/util/restore-expense-online-offline.test.ts
+++ b/TravelCostApp/__tests__/util/restore-expense-online-offline.test.ts
@@ -1,0 +1,104 @@
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+}));
+
+jest.mock("../../util/connectionSpeed", () => ({
+  isConnectionFastEnough: jest.fn(async () => ({ isFastEnough: true })),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => "trip-1"),
+}));
+
+jest.mock("../../util/http", () => ({
+  restoreExpense: jest.fn(async () => ({})),
+}));
+
+const mmkvStore: Record<string, unknown> = {};
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: {
+    OFFLINE_QUEUE: "offlineQueue",
+  },
+  getMMKVObject: jest.fn((key: string) => mmkvStore[key] ?? null),
+  setMMKVObject: jest.fn((key: string, value: unknown) => {
+    mmkvStore[key] = value;
+  }),
+}));
+
+import { MMKV_KEYS } from "../../store/mmkv";
+import { restoreExpense } from "../../util/http";
+import { restoreExpenseOnlineOffline } from "../../util/offline-queue";
+
+describe("restoreExpenseOnlineOffline", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+  });
+
+  it("removes a pending queued delete instead of calling the server", async () => {
+    mmkvStore[MMKV_KEYS.OFFLINE_QUEUE] = [
+      {
+        type: "delete",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-1" },
+      },
+      {
+        type: "update",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-2" },
+      },
+    ];
+
+    await restoreExpenseOnlineOffline(
+      {
+        type: "restore",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-1" },
+      },
+      true,
+    );
+
+    expect(restoreExpense).not.toHaveBeenCalled();
+    expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toEqual([
+      {
+        type: "update",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-2" },
+      },
+    ]);
+  });
+
+  it("PATCHes restore on the server when online with no pending queued delete", async () => {
+    await restoreExpenseOnlineOffline(
+      {
+        type: "restore",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-9" },
+      },
+      true,
+    );
+
+    expect(restoreExpense).toHaveBeenCalledWith("trip-1", "u1", "exp-9");
+    expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE] ?? []).toEqual([]);
+  });
+
+  it("queues restore when the connection is not fast enough", async () => {
+    const { isConnectionFastEnough } = require("../../util/connectionSpeed");
+    (isConnectionFastEnough as jest.Mock).mockResolvedValueOnce({
+      isFastEnough: false,
+    });
+
+    await restoreExpenseOnlineOffline(
+      {
+        type: "restore",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-slow" },
+      },
+      true,
+    );
+
+    expect(restoreExpense).not.toHaveBeenCalled();
+    expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toEqual([
+      {
+        type: "restore",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-slow" },
+      },
+    ]);
+  });
+});

--- a/TravelCostApp/__tests__/util/restore-expense-online-offline.test.ts
+++ b/TravelCostApp/__tests__/util/restore-expense-online-offline.test.ts
@@ -101,4 +101,23 @@ describe("restoreExpenseOnlineOffline", () => {
       },
     ]);
   });
+
+  it("queues restore when the PATCH returns no response", async () => {
+    (restoreExpense as jest.Mock).mockResolvedValueOnce(null);
+
+    await restoreExpenseOnlineOffline(
+      {
+        type: "restore",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-failed" },
+      },
+      true,
+    );
+
+    expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toEqual([
+      {
+        type: "restore",
+        expense: { tripid: "trip-1", uid: "u1", id: "exp-failed" },
+      },
+    ]);
+  });
 });

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -434,6 +434,7 @@ const en = {
   toastAccDeleted1: "Account Deleted",
   toastAccDeleted2: "Your account has been deleted successfully.",
   toastErrorDeleteExp: "Could not delete Expense, please try again!",
+  toastErrorRestoreExp: "Could not restore Expense, please try again!",
   toastErrorUpdateExp: "Could not update Expense, please try again!",
   toastErrorStoreExp: "Could not store Expense, please try again!",
   toastSyncChanges1: "Synchronizing offline changes",
@@ -1037,6 +1038,8 @@ const de = {
   toastAccDeleted2: "Dein Konto wurde erfolgreich gelöscht.",
   toastErrorDeleteExp:
     "Ausgabe konnte nicht gelöscht werden, bitte versuche es erneut!",
+  toastErrorRestoreExp:
+    "Ausgabe konnte nicht wiederhergestellt werden, bitte versuche es erneut!",
   toastErrorUpdateExp:
     "Ausgabe konnte nicht aktualisiert werden, bitte versuche es erneut!",
   toastErrorStoreExp:
@@ -1644,6 +1647,8 @@ const fr = {
   toastAccDeleted2: "Votre compte a été supprimé avec succès.",
   toastErrorDeleteExp:
     "Impossible de supprimer la dépense, veuillez réessayer !",
+  toastErrorRestoreExp:
+    "Impossible de restaurer la dépense, veuillez réessayer !",
   toastErrorUpdateExp:
     "Impossible de mettre à jour la dépense, veuillez réessayer !",
   toastErrorStoreExp:
@@ -2253,6 +2258,8 @@ const ru = {
   toastAccDeleted2: "Ваш аккаунт успешно удален.",
   toastErrorDeleteExp:
     "Не удалось удалить расход, пожалуйста, попробуйте снова!",
+  toastErrorRestoreExp:
+    "Не удалось восстановить расход, пожалуйста, попробуйте снова!",
   toastErrorUpdateExp:
     "Не удалось обновить расход, пожалуйста, попробуйте снова!",
   toastErrorStoreExp:

--- a/TravelCostApp/store/expenses-context.tsx
+++ b/TravelCostApp/store/expenses-context.tsx
@@ -30,6 +30,7 @@ export type ExpenseContextType = {
   setExpenses: (expenses: Array<ExpenseData>) => void;
   mergeExpenses: (newExpenses: Array<ExpenseData>) => void;
   deleteExpense: (id: string) => void;
+  restoreExpense: (id: string) => void;
   updateExpense: (id: string, expense: ExpenseData) => void;
   updateExpenseId: (oldId: string, newId: string) => void;
   getRecentExpenses: (rangestring: RangeString) => Array<ExpenseData>;
@@ -81,6 +82,7 @@ export const ExpensesContext = createContext<ExpenseContextType>({
   setExpenses: noop,
   mergeExpenses: noop,
   deleteExpense: noop,
+  restoreExpense: noop,
   updateExpense: noop,
   updateExpenseId: noop,
   getRecentExpenses: (rangestring: RangeString): Array<ExpenseData> => {
@@ -272,6 +274,23 @@ export function expensesReducer(state: ExpenseData[], action) {
       };
       return updatedExpenses;
     }
+    case "RESTORE": {
+      const restoreIndex = state.findIndex(
+        (expense) => expense.id === action.payload,
+      );
+      if (restoreIndex === -1) {
+        return state;
+      }
+      const restoredAt = Date.now();
+      const updatedExpenses = [...state];
+      updatedExpenses[restoreIndex] = {
+        ...updatedExpenses[restoreIndex],
+        isDeleted: false,
+        editedTimestamp: restoredAt,
+        serverTimestamp: restoredAt,
+      };
+      return updatedExpenses;
+    }
     case "UPDATE_ID": {
       const { oldId, newId } = action.payload;
       const expenseIndex = state.findIndex((expense) => expense.id === oldId);
@@ -328,6 +347,10 @@ function ExpensesContextProvider({ children }) {
 
   const deleteExpense = useCallback((id: string) => {
     dispatch({ type: "DELETE", payload: id });
+  }, []);
+
+  const restoreExpense = useCallback((id: string) => {
+    dispatch({ type: "RESTORE", payload: id });
   }, []);
 
   const updateExpense = useCallback((id: string, expenseData: ExpenseData) => {
@@ -581,6 +604,7 @@ function ExpensesContextProvider({ children }) {
       setExpenses,
       mergeExpenses,
       deleteExpense,
+      restoreExpense,
       updateExpense,
       updateExpenseId,
       getRecentExpenses,
@@ -599,6 +623,7 @@ function ExpensesContextProvider({ children }) {
     [
       addExpense,
       deleteExpense,
+      restoreExpense,
       filteredExpenses,
       getDailyExpenses,
       getMonthlyExpenses,

--- a/TravelCostApp/store/expenses-context.tsx
+++ b/TravelCostApp/store/expenses-context.tsx
@@ -31,6 +31,7 @@ export type ExpenseContextType = {
   mergeExpenses: (newExpenses: Array<ExpenseData>) => void;
   deleteExpense: (id: string) => void;
   restoreExpense: (id: string) => void;
+  restoreExpenses: (ids: string[]) => void;
   updateExpense: (id: string, expense: ExpenseData) => void;
   updateExpenseId: (oldId: string, newId: string) => void;
   getRecentExpenses: (rangestring: RangeString) => Array<ExpenseData>;
@@ -83,6 +84,7 @@ export const ExpensesContext = createContext<ExpenseContextType>({
   mergeExpenses: noop,
   deleteExpense: noop,
   restoreExpense: noop,
+  restoreExpenses: noop,
   updateExpense: noop,
   updateExpenseId: noop,
   getRecentExpenses: (rangestring: RangeString): Array<ExpenseData> => {
@@ -353,6 +355,10 @@ function ExpensesContextProvider({ children }) {
     dispatch({ type: "RESTORE", payload: id });
   }, []);
 
+  const restoreExpenses = useCallback((ids: string[]) => {
+    ids.forEach((id) => dispatch({ type: "RESTORE", payload: id }));
+  }, []);
+
   const updateExpense = useCallback((id: string, expenseData: ExpenseData) => {
     dispatch({ type: "UPDATE", payload: { id: id, data: expenseData } });
   }, []);
@@ -605,6 +611,7 @@ function ExpensesContextProvider({ children }) {
       mergeExpenses,
       deleteExpense,
       restoreExpense,
+      restoreExpenses,
       updateExpense,
       updateExpenseId,
       getRecentExpenses,
@@ -624,6 +631,7 @@ function ExpensesContextProvider({ children }) {
       addExpense,
       deleteExpense,
       restoreExpense,
+      restoreExpenses,
       filteredExpenses,
       getDailyExpenses,
       getMonthlyExpenses,

--- a/TravelCostApp/util/http.tsx
+++ b/TravelCostApp/util/http.tsx
@@ -504,6 +504,32 @@ export async function deleteExpense(tripid: string, uid: string, id: string) {
 }
 
 /**
+ * Restores a soft-deleted expense on a trip.
+ */
+export async function restoreExpense(tripid: string, uid: string, id: string) {
+  try {
+    const authToken = await getValidIdToken();
+    if (!authToken) {
+      console.warn("[HTTP] No valid auth token for restoreExpense");
+      return null;
+    }
+
+    const restoreData = {
+      isDeleted: false,
+      [SERVER_TIMESTAMP_FIELD]: Date.now(),
+    };
+
+    const response = await axios.patch(
+      `${BACKEND_URL}/trips/${tripid}/${uid}/expenses/${id}.json?auth=${authToken}`,
+      restoreData,
+    );
+    return response;
+  } catch (error) {
+    safeLogError(error);
+  }
+}
+
+/**
  * Stores the initially created User in Firebase,
  * @param uid
  * @param userData

--- a/TravelCostApp/util/offline-queue.ts
+++ b/TravelCostApp/util/offline-queue.ts
@@ -136,8 +136,13 @@ export const deleteExpenseOnlineOffline = async (
 };
 
 /**
- * Restores a soft-deleted expense online or offline (mirrors deleteExpenseOnlineOffline).
- * If a pending queued delete exists for this expense, removes it and skips the network.
+ * Restores a soft-deleted expense on the server or offline queue (mirrors deleteExpenseOnlineOffline).
+ *
+ * Callers must also clear the local tombstone via `restoreExpense` / `restoreExpenses` on expenses
+ * context and call `touchAllTravelers` after a successful restore — same three-step pattern as delete.
+ *
+ * Queue-first: if a pending queued `delete` exists for this expense id, only that queue entry is
+ * removed (no network). Local `isDeleted` is not cleared here.
  */
 export const restoreExpenseOnlineOffline = async (
   item: OfflineQueueManageExpenseItem,
@@ -148,10 +153,10 @@ export const restoreExpenseOnlineOffline = async (
     Toast.show({
       type: "error",
       text1: i18n.t("error"),
-      text2: i18n.t("toastErrorDeleteExp"),
+      text2: i18n.t("toastErrorRestoreExp"),
     });
     throw new Error(
-      "No tripid found in asyncStore! (restoreExpenseOnlineOffline)",
+      "No tripid found in secure store! (restoreExpenseOnlineOffline)",
     );
   }
   item.expense.tripid = tripid;
@@ -163,11 +168,14 @@ export const restoreExpenseOnlineOffline = async (
   const { isFastEnough } = await isConnectionFastEnough();
   if (online && isFastEnough) {
     try {
-      await restoreExpense(
+      const response = await restoreExpense(
         item.expense.tripid,
         item.expense.uid,
         item.expense.id,
       );
+      if (!response) {
+        await pushQueueReturnRndID(item);
+      }
     } catch (error) {
       await pushQueueReturnRndID(item);
     }

--- a/TravelCostApp/util/offline-queue.ts
+++ b/TravelCostApp/util/offline-queue.ts
@@ -4,6 +4,7 @@ import {
   storeExpenseWithId,
   updateExpense,
   deleteExpense,
+  restoreExpense,
   touchAllTravelers,
 } from "./http";
 
@@ -22,7 +23,7 @@ import safeLogError from "./error";
 // interface of offline queue manage expense item
 export interface OfflineQueueManageExpenseItem {
   timeStamp?: string;
-  type: "add" | "update" | "delete";
+  type: "add" | "update" | "delete" | "restore";
   expense: Expense;
 }
 
@@ -73,6 +74,22 @@ export const getOfflineQueue = () => {
   return offlineQueue || [];
 };
 
+/** Drops a queued delete for this expense id; returns true if one was removed. */
+export const removePendingDeleteFromOfflineQueue = (
+  expenseId: string,
+): boolean => {
+  const offlineQueue = getOfflineQueue();
+  const filtered = offlineQueue.filter(
+    (item: OfflineQueueManageExpenseItem) =>
+      !(item.type === "delete" && item.expense.id === expenseId),
+  );
+  if (filtered.length === offlineQueue.length) {
+    return false;
+  }
+  setMMKVObject(MMKV_KEYS.OFFLINE_QUEUE, filtered);
+  return true;
+};
+
 /**
  * Deletes an expense either online or offline based on the provided parameters.
  * @async
@@ -114,6 +131,47 @@ export const deleteExpenseOnlineOffline = async (
     }
   } else {
     // delete item offline
+    await pushQueueReturnRndID(item);
+  }
+};
+
+/**
+ * Restores a soft-deleted expense online or offline (mirrors deleteExpenseOnlineOffline).
+ * If a pending queued delete exists for this expense, removes it and skips the network.
+ */
+export const restoreExpenseOnlineOffline = async (
+  item: OfflineQueueManageExpenseItem,
+  online: boolean,
+) => {
+  const tripid = await secureStoreGetItem("currentTripId");
+  if (!tripid) {
+    Toast.show({
+      type: "error",
+      text1: i18n.t("error"),
+      text2: i18n.t("toastErrorDeleteExp"),
+    });
+    throw new Error(
+      "No tripid found in asyncStore! (restoreExpenseOnlineOffline)",
+    );
+  }
+  item.expense.tripid = tripid;
+
+  if (removePendingDeleteFromOfflineQueue(item.expense.id)) {
+    return;
+  }
+
+  const { isFastEnough } = await isConnectionFastEnough();
+  if (online && isFastEnough) {
+    try {
+      await restoreExpense(
+        item.expense.tripid,
+        item.expense.uid,
+        item.expense.id,
+      );
+    } catch (error) {
+      await pushQueueReturnRndID(item);
+    }
+  } else {
     await pushQueueReturnRndID(item);
   }
 };
@@ -318,6 +376,12 @@ export async function sendOfflineQueue(
           );
         } else if (item.type === "delete") {
           await deleteExpense(
+            item.expense.tripid,
+            item.expense.uid,
+            item.expense.id,
+          );
+        } else if (item.type === "restore") {
+          await restoreExpense(
             item.expense.tripid,
             item.expense.uid,
             item.expense.id,


### PR DESCRIPTION
## Summary
- Add `restoreExpense` PATCH (`isDeleted: false`) and `restoreExpenseOnlineOffline` mirroring delete: queue-first removal of pending deletes, otherwise online PATCH or queued `restore` when slow/offline.
- Expose `restoreExpense` on expenses context (`RESTORE` reducer clears tombstones so expenses reappear in ledger/totals/splits).
- Process queued restore items in `sendOfflineQueue`.

## Test plan
- [x] `pnpm test` in `TravelCostApp` (165 tests)
- [ ] Manual: delete expense offline → undo before sync → expense returns without server call
- [ ] Manual: delete online → undo → expense restored on server and in ledger

Closes #265