### PR TITLE
ExpenseForm: pure submit assembly (ExpenseFormSnapshot + builders + validator)

### DIFF
--- a/TravelCostApp/__tests__/fixtures/expense-form.ts
+++ b/TravelCostApp/__tests__/fixtures/expense-form.ts
@@ -1,0 +1,34 @@
+import type { ExpenseFormSnapshot } from "../../util/expense-form-submit";
+import { DuplicateOption, isPaidString } from "../../util/expense";
+
+export function makeExpenseFormSnapshot(
+  overrides: Partial<ExpenseFormSnapshot> = {}
+): ExpenseFormSnapshot {
+  return {
+    uid: "u1",
+    amountValue: "42.5",
+    dateIso: "2026-01-15",
+    startDateIso: "2026-01-15",
+    endDateIso: "2026-01-16",
+    description: "Lunch",
+    categoryInput: "Food",
+    country: "DE",
+    currency: "EUR",
+    whoPaid: "Alice",
+    splitType: "EQUAL",
+    splitList: [{ userName: "Alice", amount: 21.25 }],
+    listEQUAL: ["Alice", "Bob"],
+    paidBack: isPaidString.notPaid,
+    isSpecialExpense: false,
+    duplOrSplit: DuplicateOption.null,
+    iconName: "food",
+    alreadyDividedAmountByDays: false,
+    newCat: false,
+    pickedCat: "food",
+    isSoloTraveller: false,
+    userName: "Alice",
+    lastCountry: "DE",
+    lastCurrency: "EUR",
+    ...overrides,
+  };
+}

--- a/TravelCostApp/__tests__/util/expense-form-submit.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-submit.test.ts
@@ -1,0 +1,174 @@
+import { DateTime } from "luxon";
+import { getCatLocalized } from "../../util/category";
+import { makeExpense } from "../fixtures/expense";
+import { makeExpenseFormSnapshot } from "../fixtures/expense-form";
+import {
+  buildExpenseData,
+  buildFastExpenseData,
+  validateExpenseData,
+} from "../../util/expense-form-submit";
+
+function dateFromIso(iso: string): Date {
+  return DateTime.fromISO(iso).toJSDate();
+}
+
+describe("buildExpenseData", () => {
+  it("assembles advanced-path ExpenseData from resolved form state", () => {
+    const snapshot = makeExpenseFormSnapshot();
+    const built = buildExpenseData(snapshot);
+
+    expect(built.uid).toBe("u1");
+    expect(built.amount).toBe(42.5);
+    expect(built.calcAmount).toBe(42.5);
+    expect(built.category).toBe("Food");
+    expect(built.categoryString).toBe("Food");
+    expect(built.description).toBe("Lunch");
+    expect(built.country).toBe("DE");
+    expect(built.currency).toBe("EUR");
+    expect(built.whoPaid).toBe("Alice");
+    expect(built.splitType).toBe("EQUAL");
+    expect(built.listEQUAL).toEqual(["Alice", "Bob"]);
+    expect(built.splitList).toEqual([{ userName: "Alice", amount: 21.25 }]);
+    expect(built.duplOrSplit).toBe(0);
+    expect(built.iconName).toBe("food");
+    expect(built.paidBack).toBe("not paid");
+    expect(built.isSpecialExpense).toBe(false);
+    expect(built.alreadyDividedAmountByDays).toBe(false);
+    expect(built.date).toEqual(dateFromIso("2026-01-15"));
+    expect(built.startDate).toEqual(dateFromIso("2026-01-15"));
+    expect(built.endDate).toEqual(dateFromIso("2026-01-16"));
+  });
+
+  it("uses pickedCat for category when newCat is true", () => {
+    const built = buildExpenseData(
+      makeExpenseFormSnapshot({
+        newCat: true,
+        pickedCat: "custom-cat",
+        categoryInput: "Food",
+      })
+    );
+
+    expect(built.category).toBe("custom-cat");
+    expect(built.categoryString).toBe("Food");
+  });
+
+  it("defaults whoPaid to userName for solo travellers or null whoPaid", () => {
+    const solo = buildExpenseData(
+      makeExpenseFormSnapshot({
+        isSoloTraveller: true,
+        whoPaid: "Bob",
+        userName: "Alice",
+      })
+    );
+    expect(solo.whoPaid).toBe("Alice");
+
+    const nullWhoPaid = buildExpenseData(
+      makeExpenseFormSnapshot({
+        whoPaid: null,
+        userName: "Alice",
+      })
+    );
+    expect(nullWhoPaid.whoPaid).toBe("Alice");
+  });
+
+  it("fills empty description from localized category label", () => {
+    const built = buildExpenseData(
+      makeExpenseFormSnapshot({
+        description: "",
+        categoryInput: "Food",
+        newCat: false,
+      })
+    );
+
+    expect(built.description).toBe(getCatLocalized("Food"));
+  });
+});
+
+describe("buildFastExpenseData", () => {
+  it("assembles fast-path ExpenseData with deliberate omissions", () => {
+    const snapshot = makeExpenseFormSnapshot({
+      pickedCat: "food",
+      lastCountry: "FR",
+      lastCurrency: "USD",
+      userName: "Bob",
+      listEQUAL: ["Bob", "Carol"],
+    });
+    const built = buildFastExpenseData(snapshot);
+    const rangeStart = dateFromIso("2026-01-15");
+
+    expect(built).toEqual({
+      uid: "u1",
+      amount: 42.5,
+      date: rangeStart,
+      startDate: rangeStart,
+      endDate: dateFromIso("2026-01-16"),
+      description: getCatLocalized("food"),
+      category: "food",
+      country: "FR",
+      currency: "USD",
+      whoPaid: "Bob",
+      splitType: "EQUAL",
+      listEQUAL: ["Bob", "Carol"],
+      splitList: [{ userName: "Alice", amount: 21.25 }],
+      iconName: "food",
+      paidBack: "not paid",
+      isSpecialExpense: false,
+      duplOrSplit: 0,
+    });
+    expect(built).not.toHaveProperty("calcAmount");
+    expect(built).not.toHaveProperty("categoryString");
+    expect(built).not.toHaveProperty("alreadyDividedAmountByDays");
+  });
+
+  it("uses empty country when lastCountry is unset", () => {
+    const built = buildFastExpenseData(
+      makeExpenseFormSnapshot({ lastCountry: "" })
+    );
+
+    expect(built.country).toBe("");
+  });
+});
+
+describe("validateExpenseData", () => {
+  it("marks a well-formed expense as valid", () => {
+    const result = validateExpenseData(makeExpense());
+
+    expect(result.valid).toBe(true);
+    expect(result.fieldValidity).toEqual({
+      amount: true,
+      date: true,
+      description: true,
+      whoPaid: true,
+      category: true,
+      country: true,
+      currency: true,
+    });
+  });
+
+  it("rejects invalid amount, date, and empty description", () => {
+    const invalid = makeExpense({
+      amount: 0,
+      date: new Date("not-a-date"),
+      description: "   ",
+    });
+    const result = validateExpenseData(invalid);
+
+    expect(result.valid).toBe(false);
+    expect(result.fieldValidity.amount).toBe(false);
+    expect(result.fieldValidity.date).toBe(false);
+    expect(result.fieldValidity.description).toBe(false);
+    expect(result.fieldValidity.whoPaid).toBe(true);
+    expect(result.fieldValidity.category).toBe(true);
+    expect(result.fieldValidity.country).toBe(true);
+    expect(result.fieldValidity.currency).toBe(true);
+  });
+
+  it("rejects amounts at or above the upper bound", () => {
+    const result = validateExpenseData(
+      makeExpense({ amount: 34359738368 })
+    );
+
+    expect(result.fieldValidity.amount).toBe(false);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/TravelCostApp/__tests__/util/expense-form-submit.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-submit.test.ts
@@ -82,6 +82,36 @@ describe("buildExpenseData", () => {
 
     expect(built.description).toBe(getCatLocalized("Food"));
   });
+
+  it("coerces numeric amountValue like the hasTempAndInput sum path", () => {
+    const built = buildExpenseData(
+      makeExpenseFormSnapshot({ amountValue: 100 })
+    );
+
+    expect(built.amount).toBe(100);
+    expect(built.calcAmount).toBe(100);
+  });
+
+  it("falls back to now for empty or invalid date ISO strings", () => {
+    const fixedNow = DateTime.fromISO("2026-06-15T10:00:00.000Z");
+    const nowSpy = jest
+      .spyOn(DateTime, "now")
+      .mockReturnValue(fixedNow as DateTime<true>);
+
+    const built = buildExpenseData(
+      makeExpenseFormSnapshot({
+        dateIso: "",
+        startDateIso: "not-a-date",
+        endDateIso: "",
+      })
+    );
+
+    expect(built.date).toEqual(fixedNow.toJSDate());
+    expect(built.startDate).toEqual(fixedNow.toJSDate());
+    expect(built.endDate).toEqual(fixedNow.toJSDate());
+
+    nowSpy.mockRestore();
+  });
 });
 
 describe("buildFastExpenseData", () => {

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -79,30 +79,31 @@ export function buildExpenseData(
     ? snapshot.pickedCat
     : snapshot.categoryInput;
 
-  const expenseData: BuiltAdvancedExpenseData = {
+  const whoPaid =
+    snapshot.isSoloTraveller || snapshot.whoPaid === null
+      ? snapshot.userName
+      : snapshot.whoPaid;
+
+  let description = snapshot.description;
+  if (description === "") {
+    description = getCatLocalized(category);
+  }
+
+  return {
     ...sharedExpenseCore(snapshot),
     date: createSafeDate(snapshot.dateIso),
     startDate: createSafeDate(snapshot.startDateIso),
     endDate: createSafeDate(snapshot.endDateIso),
-    description: snapshot.description,
+    description,
     category,
     categoryString: snapshot.categoryInput,
     calcAmount: +snapshot.amountValue,
     country: snapshot.country,
     currency: snapshot.currency,
-    whoPaid: snapshot.whoPaid,
+    whoPaid,
     listEQUAL: snapshot.listEQUAL,
     alreadyDividedAmountByDays: snapshot.alreadyDividedAmountByDays,
   };
-
-  if (snapshot.isSoloTraveller || expenseData.whoPaid === null) {
-    expenseData.whoPaid = snapshot.userName;
-  }
-  if (expenseData.description === "") {
-    expenseData.description = getCatLocalized(expenseData.category);
-  }
-
-  return expenseData;
 }
 
 export function buildFastExpenseData(

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -1,0 +1,148 @@
+import { DateTime } from "luxon";
+import { getCatLocalized } from "./category";
+import {
+  DuplicateOption,
+  ExpenseData,
+  paidBackStatus,
+  Split,
+} from "./expense";
+import { splitType } from "./split";
+
+export type ExpenseFormSnapshot = {
+  uid: string;
+  amountValue: string | number;
+  dateIso: string;
+  startDateIso: string;
+  endDateIso: string;
+  description: string;
+  categoryInput: string;
+  country: string;
+  currency: string;
+  whoPaid: string | null;
+  splitType: splitType;
+  splitList: Split[];
+  listEQUAL: string[];
+  paidBack?: paidBackStatus;
+  isSpecialExpense: boolean;
+  duplOrSplit: DuplicateOption | number;
+  iconName: string;
+  alreadyDividedAmountByDays: boolean;
+  newCat: boolean;
+  pickedCat: string;
+  isSoloTraveller: boolean;
+  userName: string;
+  lastCountry: string;
+  lastCurrency: string;
+};
+
+export type ExpenseFieldValidity = {
+  amount: boolean;
+  date: boolean;
+  description: boolean;
+  whoPaid: boolean;
+  category: boolean;
+  country: boolean;
+  currency: boolean;
+};
+
+export type BuiltAdvancedExpenseData = ExpenseData & {
+  alreadyDividedAmountByDays: boolean;
+};
+
+function createSafeDate(dateValue: string): Date {
+  if (dateValue && dateValue !== "") {
+    const parsedDate = DateTime.fromISO(dateValue);
+    return parsedDate.isValid
+      ? parsedDate.toJSDate()
+      : DateTime.now().toJSDate();
+  }
+  return DateTime.now().toJSDate();
+}
+
+function sharedExpenseCore(snapshot: ExpenseFormSnapshot) {
+  return {
+    uid: snapshot.uid,
+    amount: +snapshot.amountValue,
+    splitType: snapshot.splitType,
+    splitList: snapshot.splitList,
+    iconName: snapshot.iconName,
+    paidBack: snapshot.paidBack,
+    isSpecialExpense: snapshot.isSpecialExpense,
+    duplOrSplit: snapshot.duplOrSplit,
+  };
+}
+
+export function buildExpenseData(
+  snapshot: ExpenseFormSnapshot
+): BuiltAdvancedExpenseData {
+  const category = snapshot.newCat
+    ? snapshot.pickedCat
+    : snapshot.categoryInput;
+
+  const expenseData: BuiltAdvancedExpenseData = {
+    ...sharedExpenseCore(snapshot),
+    date: createSafeDate(snapshot.dateIso),
+    startDate: createSafeDate(snapshot.startDateIso),
+    endDate: createSafeDate(snapshot.endDateIso),
+    description: snapshot.description,
+    category,
+    categoryString: snapshot.categoryInput,
+    calcAmount: +snapshot.amountValue,
+    country: snapshot.country,
+    currency: snapshot.currency,
+    whoPaid: snapshot.whoPaid,
+    listEQUAL: snapshot.listEQUAL,
+    alreadyDividedAmountByDays: snapshot.alreadyDividedAmountByDays,
+  };
+
+  if (snapshot.isSoloTraveller || expenseData.whoPaid === null) {
+    expenseData.whoPaid = snapshot.userName;
+  }
+  if (expenseData.description === "") {
+    expenseData.description = getCatLocalized(expenseData.category);
+  }
+
+  return expenseData;
+}
+
+export function buildFastExpenseData(
+  snapshot: ExpenseFormSnapshot
+): ExpenseData {
+  const rangeDate = DateTime.fromISO(snapshot.startDateIso).toJSDate();
+
+  return {
+    ...sharedExpenseCore(snapshot),
+    date: rangeDate,
+    startDate: rangeDate,
+    endDate: DateTime.fromISO(snapshot.endDateIso).toJSDate(),
+    description: getCatLocalized(snapshot.pickedCat),
+    category: snapshot.pickedCat,
+    country: snapshot.lastCountry ? snapshot.lastCountry : "",
+    currency: snapshot.lastCurrency,
+    whoPaid: snapshot.userName,
+    listEQUAL: snapshot.listEQUAL,
+  };
+}
+
+export function validateExpenseData(expenseData: ExpenseData): {
+  valid: boolean;
+  fieldValidity: ExpenseFieldValidity;
+} {
+  const fieldValidity: ExpenseFieldValidity = {
+    amount:
+      !isNaN(expenseData.amount) &&
+      expenseData.amount > 0 &&
+      expenseData.amount < 34359738368,
+    date: expenseData.date?.toString() !== "Invalid Date",
+    description: expenseData.description.trim()?.length > 0,
+    whoPaid: true,
+    category: true,
+    country: true,
+    currency: true,
+  };
+
+  return {
+    valid: Object.values(fieldValidity).every(Boolean),
+    fieldValidity,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `ExpenseFormSnapshot` and pure `buildExpenseData` / `buildFastExpenseData` in `util/expense-form-submit.ts`, sharing a private core while preserving the advanced vs fast output shapes.
- Add `validateExpenseData` to replace the inline amount/date/description validity block from `submitHandler`.
- Characterization tests and `makeExpenseFormSnapshot` fixture; `ExpenseForm` not wired yet (follow-up #270).

## Test plan
- [x] `pnpm test -- __tests__/util/expense-form-submit.test.ts`
- [ ] Confirm no runtime change (ExpenseForm still uses inline logic)

Closes #272