### PR TITLE
ExpenseForm: applySplitEdit / removeFromSplit in util/split.ts (pure)

### DIFF
--- a/TravelCostApp/__tests__/util/split-edit-actions.test.ts
+++ b/TravelCostApp/__tests__/util/split-edit-actions.test.ts
@@ -103,6 +103,28 @@ describe("removeFromSplit", () => {
     });
   });
 
+  it("omits valid when EQUAL recalc cannot run (legacy: splitListValid unchanged)", () => {
+    const splitList: Split[] = [
+      makeSplit({ userName: "A", amount: 50, editOrder: 0 }),
+      makeSplit({ userName: "B", amount: 50, editOrder: 1 }),
+    ];
+
+    const result = removeFromSplit(
+      splitList,
+      "A",
+      "Payer",
+      "EQUAL",
+      0,
+      ["A", "B"]
+    );
+
+    expect(result).toEqual({
+      splitList: [makeSplit({ userName: "B", amount: 50 })],
+      splitType: "EQUAL",
+    });
+    expect(result).not.toHaveProperty("valid");
+  });
+
   it("recalculates EQUAL splits for remaining travellers after removal", () => {
     const splitList: Split[] = [
       makeSplit({ userName: "A", amount: 33.33 }),

--- a/TravelCostApp/__tests__/util/split-edit-actions.test.ts
+++ b/TravelCostApp/__tests__/util/split-edit-actions.test.ts
@@ -1,0 +1,153 @@
+import {
+  applySplitEdit,
+  removeFromSplit,
+} from "../../util/split";
+import type { Split } from "../../util/expense";
+
+function makeSplit(overrides: Partial<Split> & Pick<Split, "userName">): Split {
+  return {
+    userName: overrides.userName,
+    amount: overrides.amount ?? 0,
+    whoPaid: overrides.whoPaid,
+    rate: overrides.rate,
+    editOrder: overrides.editOrder,
+  };
+}
+
+describe("applySplitEdit", () => {
+  it("bumps edit order on the edited split, recalculates remainder, and reports validity for EXACT", () => {
+    const splitList: Split[] = [
+      makeSplit({ userName: "A", amount: 30, editOrder: 0 }),
+      makeSplit({ userName: "B", amount: 20, editOrder: 1 }),
+      makeSplit({ userName: "C", amount: 50 }),
+    ];
+
+    const { splitList: result, valid } = applySplitEdit(
+      splitList,
+      0,
+      "A",
+      "40",
+      100,
+      "EXACT"
+    );
+
+    expect(result).toEqual([
+      makeSplit({ userName: "A", amount: 40, editOrder: 0 }),
+      makeSplit({ userName: "B", amount: 20, editOrder: 2 }),
+      makeSplit({ userName: "C", amount: 40 }),
+    ]);
+    expect(valid).toBe(true);
+  });
+
+  it("reports invalid when a split amount is cleared to zero", () => {
+    const splitList: Split[] = [
+      makeSplit({ userName: "A", amount: 60, editOrder: 0 }),
+      makeSplit({ userName: "B", amount: 40, editOrder: 1 }),
+    ];
+
+    const { valid } = applySplitEdit(splitList, 0, "A", "", 100, "EXACT");
+
+    expect(valid).toBe(false);
+  });
+});
+
+describe("removeFromSplit", () => {
+  it("returns null when the traveller is not on the split list", () => {
+    const splitList: Split[] = [
+      makeSplit({ userName: "A", amount: 50 }),
+      makeSplit({ userName: "B", amount: 50 }),
+    ];
+
+    expect(
+      removeFromSplit(splitList, "Z", "Payer", "EXACT", 100, [
+        "A",
+        "B",
+        "Z",
+      ])
+    ).toBeNull();
+  });
+
+  it("falls back to SELF with an empty split list when the last traveller is removed", () => {
+    const splitList: Split[] = [makeSplit({ userName: "A", amount: 100 })];
+
+    const result = removeFromSplit(splitList, "A", "Payer", "EXACT", 100, [
+      "A",
+    ]);
+
+    expect(result).toEqual({
+      splitList: [],
+      splitType: "SELF",
+      valid: true,
+    });
+  });
+
+  it("falls back to SELF when only the payer remains on the split list", () => {
+    const splitList: Split[] = [
+      makeSplit({ userName: "Payer", amount: 60 }),
+      makeSplit({ userName: "Guest", amount: 40 }),
+    ];
+
+    const result = removeFromSplit(
+      splitList,
+      "Guest",
+      "Payer",
+      "EXACT",
+      100,
+      ["Payer", "Guest"]
+    );
+
+    expect(result).toEqual({
+      splitList: [],
+      splitType: "SELF",
+      valid: true,
+    });
+  });
+
+  it("recalculates EQUAL splits for remaining travellers after removal", () => {
+    const splitList: Split[] = [
+      makeSplit({ userName: "A", amount: 33.33 }),
+      makeSplit({ userName: "B", amount: 33.33 }),
+      makeSplit({ userName: "C", amount: 33.34 }),
+    ];
+
+    const result = removeFromSplit(
+      splitList,
+      "C",
+      "Payer",
+      "EQUAL",
+      100,
+      ["A", "B", "C"]
+    );
+
+    expect(result).toEqual({
+      splitList: [
+        makeSplit({ userName: "A", amount: 50 }),
+        makeSplit({ userName: "B", amount: 50 }),
+      ],
+      splitType: "EQUAL",
+      valid: true,
+    });
+  });
+
+  it("strips edit order and validates EXACT splits after removal", () => {
+    const splitList: Split[] = [
+      makeSplit({ userName: "A", amount: 40, editOrder: 0 }),
+      makeSplit({ userName: "B", amount: 60, editOrder: 1 }),
+    ];
+
+    const result = removeFromSplit(
+      splitList,
+      "B",
+      "Payer",
+      "EXACT",
+      40,
+      ["A", "B"]
+    );
+
+    expect(result).toEqual({
+      splitList: [makeSplit({ userName: "A", amount: 40 })],
+      splitType: "EXACT",
+      valid: true,
+    });
+  });
+});

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -44,13 +44,16 @@ import DropDownPicker from "react-native-dropdown-picker";
 // import CurrencyPicker from "react-native-currency-picker";
 import { TripContext } from "../../store/trip-context";
 import {
+  applySplitEdit,
   calcSplitList,
   recalcSplitsWithEditOrder,
-  validateSplitListWithEditOrder,
+  removeFromSplit,
+  resetEditOrder,
   splitType,
   splitTypesDropdown,
   travellerToDropdown,
   validateSplitList,
+  validateSplitListWithEditOrder,
 } from "../../util/split";
 import { Traveller } from "../../util/traveler";
 
@@ -279,15 +282,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     amountValue &&
     inputs.currency.value &&
     inputs.currency.value !== tripCtx.tripCurrency;
-
-  // Helper function to reset editOrder from splitList
-  const resetEditOrder = (splits: Split[]): Split[] => {
-    if (!splits) return [];
-    return splits.map((split) => {
-      const { editOrder, ...splitWithoutOrder } = split;
-      return splitWithoutOrder;
-    });
-  };
 
   // Helper function to convert Traveller[] to string[] (user names)
   const extractUserNames = (
@@ -1099,36 +1093,16 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
 
   function inputSplitListHandler(index, props: { userName: string }, value) {
     if (splitType === splitTypes.EQUAL) return;
-    const tempList = splitList.map((split) => ({ ...split }));
-
-    // Set editOrder for the edited split to 0 (most recent)
-    // Increment all other splits' editOrder by 1 (if they have one)
-    tempList.forEach((split, i) => {
-      if (i === index) {
-        split.editOrder = 0;
-      } else if (split.editOrder !== undefined) {
-        split.editOrder = (split.editOrder || 0) + 1;
-      }
-    });
-
-    // Update the split amount
-    // eslint-disable-next-line react/prop-types
-    tempList[index] = {
-      ...tempList[index],
-      amount: Number(value) || 0,
-      userName: props.userName,
-      editOrder: 0,
-    };
-
-    // Recalculate splits using edit-order-based approach
-    const recalculatedList = recalcSplitsWithEditOrder(tempList, +amountValue);
-    setSplitList(recalculatedList);
-
-    // Validate using both old and new validation
-    const isValidSplit =
-      validateSplitList(recalculatedList, splitType, +amountValue) &&
-      validateSplitListWithEditOrder(recalculatedList, +amountValue);
-    setSplitListValid(isValidSplit);
+    const { splitList: nextList, valid } = applySplitEdit(
+      splitList,
+      index,
+      props.userName,
+      value,
+      +amountValue,
+      splitType
+    );
+    setSplitList(nextList);
+    setSplitListValid(valid);
   }
 
   function splitHandler(selectedSplitType: splitType) {
@@ -1165,51 +1139,22 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
 
   async function removeUserFromSplitHandler(userName: string) {
     if (!splitList || splitList.length < 1) return;
-    const splitListTemp = [...splitList];
-    const index = splitListTemp.findIndex(
-      (split) => split.userName === userName
+    const result = removeFromSplit(
+      splitList,
+      userName,
+      whoPaid,
+      splitType,
+      +amountValue,
+      extractUserNames(tripCtx.travellers)
     );
-    if (index === -1) {
+    if (!result) {
       return;
     }
-    splitListTemp.splice(index, 1);
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-    // if splitList is empty now, set splitType to "SELF"
-    // if we ever implement the "ADD LOCAL TRAVELLER" function, we could keep a
-    // List of length 1 here and remove the paidForSelf bool from the condition
-    // In case the Button for "ADD LOCAL TRAVELLER" is on the right side of splitlist
-    const paidForSelf =
-      splitListTemp.length == 1 && splitListTemp[0]?.userName == whoPaid;
-    if (splitListTemp.length === 0 || paidForSelf) {
-      setSplitType(splitTypes.SELF);
-      setSplitList([]);
-      setSplitListValid(true);
-      return;
-    }
-    // Reset edit order when traveller is removed
-    const splitListWithoutOrder = resetEditOrder(splitListTemp);
-    setSplitList(splitListWithoutOrder);
-    if (splitType === splitTypes.EQUAL) {
-      const splitTravellersTemp = extractUserNames(tripCtx.travellers).filter(
-        (travellerName) => travellerName !== userName
-      );
-      const listSplits = calcSplitList(
-        splitTypes.EQUAL,
-        +amountValue,
-        whoPaid,
-        splitTravellersTemp
-      );
-      if (listSplits) {
-        const splitsWithoutOrder = resetEditOrder(listSplits);
-        setSplitList(splitsWithoutOrder);
-        setSplitListValid(
-          validateSplitList(splitsWithoutOrder, splitType, +amountValue)
-        );
-      }
-    } else {
-      setSplitListValid(
-        validateSplitList(splitListWithoutOrder, splitType, +amountValue)
-      );
+    setSplitType(result.splitType);
+    setSplitList(result.splitList);
+    if (result.valid !== undefined) {
+      setSplitListValid(result.valid);
     }
   }
 

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -1151,7 +1151,9 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       return;
     }
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-    setSplitType(result.splitType);
+    if (result.splitType !== splitType) {
+      setSplitType(result.splitType);
+    }
     setSplitList(result.splitList);
     if (result.valid !== undefined) {
       setSplitListValid(result.valid);

--- a/TravelCostApp/util/split.ts
+++ b/TravelCostApp/util/split.ts
@@ -192,12 +192,6 @@ export function recalcSplitsWithEditOrder(
   return updatedList;
 }
 
-/**
- * Validates if split list can be made valid given edit constraints.
- * @param splitList - Array of splits with optional editOrder
- * @param amount - Total amount
- * @returns true if valid, false otherwise
- */
 /** Strips editOrder from each split (e.g. after traveller removal or split-type change). */
 export function resetEditOrder(splits: Split[]): Split[] {
   if (!splits) return [];
@@ -209,6 +203,7 @@ export function resetEditOrder(splits: Split[]): Split[] {
 
 /**
  * Applies a manual split amount edit: bumps edit order, recalculates, validates.
+ * @param splitType - Expense split mode (required for `validateSplitList`; issue #275 sketch omitted this param).
  */
 export function applySplitEdit(
   splitList: Split[],
@@ -311,6 +306,12 @@ export function removeFromSplit(
   };
 }
 
+/**
+ * Validates if split list can be made valid given edit constraints.
+ * @param splitList - Array of splits with optional editOrder
+ * @param amount - Total amount
+ * @returns true if valid, false otherwise
+ */
 export function validateSplitListWithEditOrder(
   splitList: Split[],
   amount: number

--- a/TravelCostApp/util/split.ts
+++ b/TravelCostApp/util/split.ts
@@ -198,6 +198,119 @@ export function recalcSplitsWithEditOrder(
  * @param amount - Total amount
  * @returns true if valid, false otherwise
  */
+/** Strips editOrder from each split (e.g. after traveller removal or split-type change). */
+export function resetEditOrder(splits: Split[]): Split[] {
+  if (!splits) return [];
+  return splits.map((split) => {
+    const { editOrder, ...splitWithoutOrder } = split;
+    return splitWithoutOrder;
+  });
+}
+
+/**
+ * Applies a manual split amount edit: bumps edit order, recalculates, validates.
+ */
+export function applySplitEdit(
+  splitList: Split[],
+  index: number,
+  userName: string,
+  value: string | number,
+  amount: number,
+  splitType: splitType
+): { splitList: Split[]; valid: boolean } {
+  const tempList = splitList.map((split) => ({ ...split }));
+
+  tempList.forEach((split, i) => {
+    if (i === index) {
+      split.editOrder = 0;
+    } else if (split.editOrder !== undefined) {
+      split.editOrder = (split.editOrder || 0) + 1;
+    }
+  });
+
+  tempList[index] = {
+    ...tempList[index],
+    amount: Number(value) || 0,
+    userName,
+    editOrder: 0,
+  };
+
+  const recalculatedList = recalcSplitsWithEditOrder(tempList, amount);
+  const valid = Boolean(
+    validateSplitList(recalculatedList, splitType, amount) &&
+      validateSplitListWithEditOrder(recalculatedList, amount)
+  );
+
+  return { splitList: recalculatedList, valid };
+}
+
+/**
+ * Removes a traveller from the split list; SELF fallback when list empties or only payer remains.
+ * Returns null when userName is not on the list.
+ */
+export type RemoveFromSplitResult = {
+  splitList: Split[];
+  splitType: splitType;
+  /** Omitted when EQUAL recalc fails (matches legacy ExpenseForm: validity left unchanged). */
+  valid?: boolean;
+};
+
+export function removeFromSplit(
+  splitList: Split[],
+  userName: string,
+  whoPaid: string,
+  splitType: splitType,
+  amount: number,
+  travellers: string[]
+): RemoveFromSplitResult | null {
+  const index = splitList.findIndex((split) => split.userName === userName);
+  if (index === -1) {
+    return null;
+  }
+
+  const splitListTemp = [...splitList];
+  splitListTemp.splice(index, 1);
+
+  const paidForSelf =
+    splitListTemp.length === 1 && splitListTemp[0]?.userName === whoPaid;
+  if (splitListTemp.length === 0 || paidForSelf) {
+    return { splitList: [], splitType: "SELF", valid: true };
+  }
+
+  const splitListWithoutOrder = resetEditOrder(splitListTemp);
+
+  if (splitType === "EQUAL") {
+    const splitTravellersTemp = travellers.filter(
+      (travellerName) => travellerName !== userName
+    );
+    const listSplits = calcSplitList(
+      "EQUAL",
+      amount,
+      whoPaid,
+      splitTravellersTemp
+    );
+    if (listSplits) {
+      const splitsWithoutOrder = resetEditOrder(listSplits);
+      return {
+        splitList: splitsWithoutOrder,
+        splitType,
+        valid: Boolean(
+          validateSplitList(splitsWithoutOrder, splitType, amount)
+        ),
+      };
+    }
+    return { splitList: splitListWithoutOrder, splitType };
+  }
+
+  return {
+    splitList: splitListWithoutOrder,
+    splitType,
+    valid: Boolean(
+      validateSplitList(splitListWithoutOrder, splitType, amount)
+    ),
+  };
+}
+
 export function validateSplitListWithEditOrder(
   splitList: Split[],
   amount: number


### PR DESCRIPTION
## Summary
- Add pure `applySplitEdit` and `removeFromSplit` (plus shared `resetEditOrder`) in `util/split.ts`, alongside existing `recalcSplitsWithEditOrder` / `validateSplitList`.
- Wire `ExpenseForm` split handlers to those functions; haptics and React state stay in the component.
- Add characterization tests in `__tests__/util/split-edit-actions.test.ts`.

## Test plan
- [x] `pnpm test -- __tests__/util/split`
- [x] `pnpm test`

Closes #275