### PR TITLE
ExpenseForm: extract ranged duplicate/split math and prompts (#273)

### DIFF
--- a/TravelCostApp/__tests__/util/expense-form-range.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-range.test.ts
@@ -1,0 +1,192 @@
+import { DuplicateOption } from "../../util/expense";
+import {
+  buildRangedDuplicatePromptString,
+  buildRangedDuplOrSplitPromptString,
+  buildRangedSplitPromptString,
+  countInclusiveDaysInRange,
+  divideAmountForRangedSplit,
+  formatRangedAmountFieldValue,
+  multiplyAmountForRangedDuplicate,
+  resolveAlreadyDividedAmountByDays,
+  resolveAmountWhenCollapsingRangeToSingleDay,
+} from "../../util/expense-form-range";
+
+describe("multiplyAmountForRangedDuplicate", () => {
+  it("multiplies per-day amount across an inclusive multi-day span", () => {
+    expect(multiplyAmountForRangedDuplicate(50, 3)).toBe(150);
+  });
+});
+
+describe("divideAmountForRangedSplit", () => {
+  it("spreads total amount evenly per day for a multi-day span", () => {
+    expect(divideAmountForRangedSplit(150, 3)).toBe(50);
+  });
+});
+
+describe("countInclusiveDaysInRange", () => {
+  it("returns 1 for a single-day span", () => {
+    const day = new Date("2026-01-15T12:00:00.000Z");
+    expect(
+      countInclusiveDaysInRange(day, day)
+    ).toBe(1);
+  });
+
+  it("counts inclusive days across a multi-day span", () => {
+    const start = new Date("2026-01-15T12:00:00.000Z");
+    const end = new Date("2026-01-17T12:00:00.000Z");
+    expect(countInclusiveDaysInRange(start, end)).toBe(3);
+  });
+});
+
+describe("resolveAlreadyDividedAmountByDays", () => {
+  it("is true when editing a ranged-split expense", () => {
+    expect(
+      resolveAlreadyDividedAmountByDays(true, DuplicateOption.split, false)
+    ).toBe(true);
+  });
+
+  it("is false for a new ranged-split expense", () => {
+    expect(
+      resolveAlreadyDividedAmountByDays(false, DuplicateOption.split, false)
+    ).toBe(false);
+  });
+
+  it("is false after the user picks split from the range prompt", () => {
+    expect(
+      resolveAlreadyDividedAmountByDays(true, DuplicateOption.split, true)
+    ).toBe(false);
+  });
+});
+
+describe("formatRangedAmountFieldValue", () => {
+  it("formats to two decimal places as a string", () => {
+    expect(formatRangedAmountFieldValue(10.5)).toBe("10.50");
+  });
+});
+
+describe("resolveAmountWhenCollapsingRangeToSingleDay", () => {
+  it("restores total when editing a ranged-split expense", () => {
+    expect(
+      resolveAmountWhenCollapsingRangeToSingleDay({
+        amount: 50,
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.split,
+        alreadyDividedAmountByDays: true,
+      })
+    ).toBe("150.00");
+  });
+
+  it("stores per-day amount when collapsing a new ranged-split expense", () => {
+    expect(
+      resolveAmountWhenCollapsingRangeToSingleDay({
+        amount: 150,
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.split,
+        alreadyDividedAmountByDays: false,
+      })
+    ).toBe("50.00");
+  });
+
+  it("returns null when duplOrSplit is not split", () => {
+    expect(
+      resolveAmountWhenCollapsingRangeToSingleDay({
+        amount: 50,
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.duplicate,
+        alreadyDividedAmountByDays: false,
+      })
+    ).toBeNull();
+  });
+});
+
+const formatAmount = (amount: number) => `$${amount.toFixed(2)}`;
+
+const promptLabels = {
+  duplString1: "Duplicating",
+  duplString2: "over",
+  duplString3: "days",
+  duplString4: "Resulting in a",
+  splitString1: "Splitting up the",
+  splitString2: "over",
+  splitString3: "days, each",
+  total: "Total",
+};
+
+describe("buildRangedDuplicatePromptString", () => {
+  it("describes per-day duplicate over a multi-day span", () => {
+    expect(
+      buildRangedDuplicatePromptString({
+        amount: 50,
+        inclusiveDayCount: 3,
+        formatAmount,
+        labels: promptLabels,
+      })
+    ).toBe(
+      "Duplicating $50.00 over 3 days. \nResulting in a $150.00 Total"
+    );
+  });
+});
+
+describe("buildRangedSplitPromptString", () => {
+  it("describes per-day split for a new ranged expense", () => {
+    expect(
+      buildRangedSplitPromptString({
+        amount: 150,
+        inclusiveDayCount: 3,
+        alreadyDividedAmountByDays: false,
+        formatAmount,
+        labels: promptLabels,
+      })
+    ).toBe(
+      "Splitting up the $150.00\nover 3 days, each $50.00"
+    );
+  });
+
+  it("describes per-day split when editing an already-divided ranged expense", () => {
+    expect(
+      buildRangedSplitPromptString({
+        amount: 50,
+        inclusiveDayCount: 3,
+        alreadyDividedAmountByDays: true,
+        formatAmount,
+        labels: promptLabels,
+      })
+    ).toBe(
+      "Splitting up the $150.00\nover 3 days, each $50.00"
+    );
+  });
+});
+
+describe("buildRangedDuplOrSplitPromptString", () => {
+  it("returns duplicate or split prompt for the chosen option", () => {
+    expect(
+      buildRangedDuplOrSplitPromptString(1, {
+        amount: 50,
+        inclusiveDayCount: 3,
+        alreadyDividedAmountByDays: false,
+        formatAmount,
+        labels: promptLabels,
+      })
+    ).toContain("Duplicating $50.00");
+
+    expect(
+      buildRangedDuplOrSplitPromptString(2, {
+        amount: 150,
+        inclusiveDayCount: 3,
+        alreadyDividedAmountByDays: false,
+        formatAmount,
+        labels: promptLabels,
+      })
+    ).toContain("days, each $50.00");
+
+    expect(
+      buildRangedDuplOrSplitPromptString(0, {
+        amount: 50,
+        inclusiveDayCount: 1,
+        alreadyDividedAmountByDays: false,
+        formatAmount,
+        labels: promptLabels,
+      })
+    ).toBe("");
+  });
+});

--- a/TravelCostApp/__tests__/util/expense-form-range.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-range.test.ts
@@ -1,4 +1,10 @@
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageTag: "en-US", languageCode: "en" }],
+}));
+
+import { i18n } from "../../i18n/i18n";
 import { DuplicateOption } from "../../util/expense";
+import { formatExpenseWithCurrency } from "../../util/string";
 import {
   buildRangedDuplicatePromptString,
   buildRangedDuplOrSplitPromptString,
@@ -12,12 +18,20 @@ import {
 } from "../../util/expense-form-range";
 
 describe("multiplyAmountForRangedDuplicate", () => {
+  it("leaves amount unchanged for a single-day span", () => {
+    expect(multiplyAmountForRangedDuplicate(50, 1)).toBe(50);
+  });
+
   it("multiplies per-day amount across an inclusive multi-day span", () => {
     expect(multiplyAmountForRangedDuplicate(50, 3)).toBe(150);
   });
 });
 
 describe("divideAmountForRangedSplit", () => {
+  it("leaves amount unchanged for a single-day span", () => {
+    expect(divideAmountForRangedSplit(50, 1)).toBe(50);
+  });
+
   it("spreads total amount evenly per day for a multi-day span", () => {
     expect(divideAmountForRangedSplit(150, 3)).toBe(50);
   });
@@ -159,6 +173,14 @@ describe("buildRangedSplitPromptString", () => {
 
 describe("buildRangedDuplOrSplitPromptString", () => {
   it("returns duplicate or split prompt for the chosen option", () => {
+    const splitInput = {
+      amount: 150,
+      inclusiveDayCount: 3,
+      alreadyDividedAmountByDays: false,
+      formatAmount,
+      labels: promptLabels,
+    };
+
     expect(
       buildRangedDuplOrSplitPromptString(1, {
         amount: 50,
@@ -167,17 +189,13 @@ describe("buildRangedDuplOrSplitPromptString", () => {
         formatAmount,
         labels: promptLabels,
       })
-    ).toContain("Duplicating $50.00");
+    ).toBe(
+      "Duplicating $50.00 over 3 days. \nResulting in a $150.00 Total"
+    );
 
-    expect(
-      buildRangedDuplOrSplitPromptString(2, {
-        amount: 150,
-        inclusiveDayCount: 3,
-        alreadyDividedAmountByDays: false,
-        formatAmount,
-        labels: promptLabels,
-      })
-    ).toContain("days, each $50.00");
+    expect(buildRangedDuplOrSplitPromptString(2, splitInput)).toBe(
+      buildRangedSplitPromptString(splitInput)
+    );
 
     expect(
       buildRangedDuplOrSplitPromptString(0, {
@@ -188,5 +206,61 @@ describe("buildRangedDuplOrSplitPromptString", () => {
         labels: promptLabels,
       })
     ).toBe("");
+  });
+});
+
+function englishRangedPromptLabels() {
+  return {
+    duplString1: i18n.t("duplString1"),
+    duplString2: i18n.t("duplString2"),
+    duplString3: i18n.t("duplString3"),
+    duplString4: i18n.t("duplString4"),
+    splitString1: i18n.t("splitString1"),
+    splitString2: i18n.t("splitString2"),
+    splitString3: i18n.t("splitString3"),
+    total: i18n.t("total"),
+  };
+}
+
+describe("ranged prompts with formatExpenseWithCurrency", () => {
+  beforeAll(() => {
+    i18n.locale = "en";
+  });
+
+  const formatEur = (amount: number) => formatExpenseWithCurrency(amount, "EUR");
+
+  it("matches ExpenseForm duplicate prompt formatting for EUR", () => {
+    expect(
+      buildRangedDuplicatePromptString({
+        amount: 50,
+        inclusiveDayCount: 3,
+        formatAmount: formatEur,
+        labels: englishRangedPromptLabels(),
+      })
+    ).toBe("Duplicating €50 over 3 days. \nResulting in a €150 Total");
+  });
+
+  it("matches ExpenseForm split prompt formatting for EUR (new ranged expense)", () => {
+    expect(
+      buildRangedSplitPromptString({
+        amount: 150,
+        inclusiveDayCount: 3,
+        alreadyDividedAmountByDays: false,
+        formatAmount: formatEur,
+        labels: englishRangedPromptLabels(),
+      })
+    ).toBe("Splitting up the €150\nover 3 days, each €50");
+  });
+
+  it("matches ExpenseForm split prompt formatting for EUR (editing ranged split)", () => {
+    expect(
+      buildRangedSplitPromptString({
+        amount: 50,
+        inclusiveDayCount: 3,
+        alreadyDividedAmountByDays: true,
+        formatAmount: formatEur,
+        labels: englishRangedPromptLabels(),
+      })
+    ).toBe("Splitting up the €150\nover 3 days, each €50");
   });
 });

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -20,7 +20,6 @@ import {
   InputAccessoryView,
   Image,
 } from "react-native";
-import { daysBetween } from "../../util/date";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { useFocusEffect } from "@react-navigation/native";
 
@@ -79,6 +78,13 @@ import {
   Split,
   getEffectivePaidBack,
 } from "../../util/expense";
+import {
+  buildRangedDuplOrSplitPromptString,
+  countInclusiveDaysInRange,
+  divideAmountForRangedSplit,
+  resolveAlreadyDividedAmountByDays,
+  resolveAmountWhenCollapsingRangeToSingleDay,
+} from "../../util/expense-form-range";
 import { NetworkContext } from "../../store/network-context";
 import { SettingsContext } from "../../store/settings-context";
 import Autocomplete from "../UI/Autocomplete";
@@ -401,7 +407,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   );
   const daysBeween =
     startDate && endDate
-      ? daysBetween(new Date(endDate), new Date(startDate)) + 1
+      ? countInclusiveDaysInRange(new Date(startDate), new Date(endDate))
       : 1;
 
   const openDatePickerRange = () => {
@@ -454,52 +460,39 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     editingValues ? Number(editingValues.duplOrSplit) : DuplicateOption.null
   );
 
-  const expenseString = `${formatExpenseWithCurrency(
-    Number(amountValue),
-    inputs.currency.value
-  )}`;
-  const expenseTimesDaysString = formatExpenseWithCurrency(
-    Number(amountValue) * daysBeween,
-    inputs.currency.value
+  const alreadyDividedAmountByDays = resolveAlreadyDividedAmountByDays(
+    isEditing,
+    duplOrSplit,
+    helperStateForDividing
   );
-  const expenseDividedByDaysString = formatExpenseWithCurrency(
-    Number(amountValue) / daysBeween,
-    inputs.currency.value
-  );
-  const duplString = `${i18n.t("duplString1")} ${expenseString} ${i18n.t(
-    "duplString2"
-  )} ${daysBeween} ${i18n.t("duplString3")}. \n${i18n.t(
-    "duplString4"
-  )} ${expenseTimesDaysString} ${i18n.t("total")}`;
 
-  const newExpenseSplitString = `${i18n.t(
-    "splitString1"
-  )} ${expenseString}\n${i18n.t("splitString2")} ${daysBeween} ${i18n.t(
-    "splitString3"
-  )} ${expenseDividedByDaysString}`;
-
-  const editedSplitString = `${i18n.t(
-    "splitString1"
-  )} ${expenseTimesDaysString}\n${i18n.t(
-    "splitString2"
-  )} ${daysBeween} ${i18n.t("splitString3")} ${expenseString}`;
-
-  let alreadyDividedAmountByDays = isEditing && duplOrSplit === 2;
-  if (helperStateForDividing) alreadyDividedAmountByDays = false;
-
-  const splitString = alreadyDividedAmountByDays
-    ? editedSplitString
-    : newExpenseSplitString;
+  const rangedPromptInput = {
+    amount: Number(amountValue),
+    inclusiveDayCount: daysBeween,
+    alreadyDividedAmountByDays,
+    formatAmount: (amount: number) =>
+      formatExpenseWithCurrency(amount, inputs.currency.value),
+    labels: {
+      duplString1: i18n.t("duplString1"),
+      duplString2: i18n.t("duplString2"),
+      duplString3: i18n.t("duplString3"),
+      duplString4: i18n.t("duplString4"),
+      splitString1: i18n.t("splitString1"),
+      splitString2: i18n.t("splitString2"),
+      splitString3: i18n.t("splitString3"),
+      total: i18n.t("total"),
+    },
+  };
 
   const duplOrSplitString = useCallback(
-    (duplOrSplitNum: number) => {
-      return duplOrSplitNum === 1
-        ? duplString
-        : duplOrSplitNum === 2
-          ? splitString
-          : "";
-    },
-    [duplString, splitString]
+    (duplOrSplitNum: number) =>
+      buildRangedDuplOrSplitPromptString(duplOrSplitNum, rangedPromptInput),
+    [
+      amountValue,
+      inputs.currency.value,
+      daysBeween,
+      alreadyDividedAmountByDays,
+    ]
   );
 
   const onConfirmRange = (expenseOut) => {
@@ -525,22 +518,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     // no range
     if (startDateFormat === endDateFormat) {
       inputChangedHandler("date", startDateFormat);
-      // multiply amount by number of days to get total
-      if (duplOrSplit === DuplicateOption.split) {
-        inputChangedHandler(
-          "amount",
-          (Number(amountValue) * daysBeween).toFixed(2).toString()
-        );
-      }
-      if (
-        duplOrSplit === DuplicateOption.split &&
-        !alreadyDividedAmountByDays
-      ) {
-        // divide amount by number of days
-        inputChangedHandler(
-          "amount",
-          (Number(amountValue) / daysBeween).toFixed(2).toString()
-        );
+      const adjustedAmount = resolveAmountWhenCollapsingRangeToSingleDay({
+        amount: Number(amountValue),
+        inclusiveDayCount: daysBeween,
+        duplOrSplit,
+        alreadyDividedAmountByDays,
+      });
+      if (adjustedAmount !== null) {
+        inputChangedHandler("amount", adjustedAmount);
       }
       setDuplOrSplit(DuplicateOption.null);
       return;
@@ -715,7 +700,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       if (duplOrSplit === 2 && isEditing) {
         const newSplitList = recalcSplitsWithEditOrder(
           splitList,
-          +amountValue / daysBeween
+          divideAmountForRangedSplit(+amountValue, daysBeween)
         );
         setSplitList(newSplitList);
         const isValidSplit =
@@ -1233,7 +1218,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     if (duplOrSplit === 2 && !isEditing) {
       const newSplitList = recalcSplitsWithEditOrder(
         splitList,
-        +amountValue / daysBeween
+        divideAmountForRangedSplit(+amountValue, daysBeween)
       );
       setSplitList(newSplitList);
       const isValidSplit =

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -466,13 +466,8 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     helperStateForDividing
   );
 
-  const rangedPromptInput = {
-    amount: Number(amountValue),
-    inclusiveDayCount: daysBeween,
-    alreadyDividedAmountByDays,
-    formatAmount: (amount: number) =>
-      formatExpenseWithCurrency(amount, inputs.currency.value),
-    labels: {
+  const rangedPromptLabels = useMemo(
+    () => ({
       duplString1: i18n.t("duplString1"),
       duplString2: i18n.t("duplString2"),
       duplString3: i18n.t("duplString3"),
@@ -481,18 +476,32 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       splitString2: i18n.t("splitString2"),
       splitString3: i18n.t("splitString3"),
       total: i18n.t("total"),
-    },
-  };
+    }),
+    [i18n.locale]
+  );
 
-  const duplOrSplitString = useCallback(
-    (duplOrSplitNum: number) =>
-      buildRangedDuplOrSplitPromptString(duplOrSplitNum, rangedPromptInput),
+  const rangedPromptInput = useMemo(
+    () => ({
+      amount: Number(amountValue),
+      inclusiveDayCount: daysBeween,
+      alreadyDividedAmountByDays,
+      formatAmount: (amount: number) =>
+        formatExpenseWithCurrency(amount, inputs.currency.value),
+      labels: rangedPromptLabels,
+    }),
     [
       amountValue,
       inputs.currency.value,
       daysBeween,
       alreadyDividedAmountByDays,
+      rangedPromptLabels,
     ]
+  );
+
+  const duplOrSplitString = useCallback(
+    (duplOrSplitNum: number) =>
+      buildRangedDuplOrSplitPromptString(duplOrSplitNum, rangedPromptInput),
+    [rangedPromptInput]
   );
 
   const onConfirmRange = (expenseOut) => {

--- a/TravelCostApp/util/expense-form-range.ts
+++ b/TravelCostApp/util/expense-form-range.ts
@@ -1,0 +1,128 @@
+import { daysBetween } from "./date";
+import { DuplicateOption } from "./expense";
+
+export function countInclusiveDaysInRange(
+  startDate: Date,
+  endDate: Date
+): number {
+  if (!startDate || !endDate) return 1;
+  return daysBetween(endDate, startDate) + 1;
+}
+
+export function multiplyAmountForRangedDuplicate(
+  amount: number,
+  inclusiveDayCount: number
+): number {
+  return amount * inclusiveDayCount;
+}
+
+export function divideAmountForRangedSplit(
+  amount: number,
+  inclusiveDayCount: number
+): number {
+  return amount / inclusiveDayCount;
+}
+
+export function resolveAlreadyDividedAmountByDays(
+  isEditing: boolean,
+  duplOrSplit: DuplicateOption | number,
+  helperStateForDividing: boolean
+): boolean {
+  let alreadyDividedAmountByDays =
+    isEditing && Number(duplOrSplit) === DuplicateOption.split;
+  if (helperStateForDividing) alreadyDividedAmountByDays = false;
+  return alreadyDividedAmountByDays;
+}
+
+export function formatRangedAmountFieldValue(amount: number): string {
+  return amount.toFixed(2);
+}
+
+export type CollapseRangeToSingleDayInput = {
+  amount: number;
+  inclusiveDayCount: number;
+  duplOrSplit: DuplicateOption | number;
+  alreadyDividedAmountByDays: boolean;
+};
+
+export function resolveAmountWhenCollapsingRangeToSingleDay(
+  input: CollapseRangeToSingleDayInput
+): string | null {
+  if (Number(input.duplOrSplit) !== DuplicateOption.split) return null;
+
+  // Matches ExpenseForm's two sequential handlers: when both run, the divide
+  // call wins because it uses the original amount, not the multiplied value.
+  if (!input.alreadyDividedAmountByDays) {
+    return formatRangedAmountFieldValue(
+      divideAmountForRangedSplit(input.amount, input.inclusiveDayCount)
+    );
+  }
+  return formatRangedAmountFieldValue(
+    multiplyAmountForRangedDuplicate(input.amount, input.inclusiveDayCount)
+  );
+}
+
+export type RangedPromptLabels = {
+  duplString1: string;
+  duplString2: string;
+  duplString3: string;
+  duplString4: string;
+  splitString1: string;
+  splitString2: string;
+  splitString3: string;
+  total: string;
+};
+
+export type RangedPromptInput = {
+  amount: number;
+  inclusiveDayCount: number;
+  formatAmount: (amount: number) => string;
+  labels: RangedPromptLabels;
+};
+
+export type RangedSplitPromptInput = RangedPromptInput & {
+  alreadyDividedAmountByDays: boolean;
+};
+
+export function buildRangedDuplicatePromptString(
+  input: RangedPromptInput
+): string {
+  const expenseString = input.formatAmount(input.amount);
+  const expenseTimesDaysString = input.formatAmount(
+    multiplyAmountForRangedDuplicate(input.amount, input.inclusiveDayCount)
+  );
+  const { labels } = input;
+  return `${labels.duplString1} ${expenseString} ${labels.duplString2} ${input.inclusiveDayCount} ${labels.duplString3}. \n${labels.duplString4} ${expenseTimesDaysString} ${labels.total}`;
+}
+
+export function buildRangedSplitPromptString(
+  input: RangedSplitPromptInput
+): string {
+  const expenseString = input.formatAmount(input.amount);
+  const expenseTimesDaysString = input.formatAmount(
+    multiplyAmountForRangedDuplicate(input.amount, input.inclusiveDayCount)
+  );
+  const expenseDividedByDaysString = input.formatAmount(
+    divideAmountForRangedSplit(input.amount, input.inclusiveDayCount)
+  );
+  const { labels } = input;
+
+  if (input.alreadyDividedAmountByDays) {
+    return `${labels.splitString1} ${expenseTimesDaysString}\n${labels.splitString2} ${input.inclusiveDayCount} ${labels.splitString3} ${expenseString}`;
+  }
+
+  return `${labels.splitString1} ${expenseString}\n${labels.splitString2} ${input.inclusiveDayCount} ${labels.splitString3} ${expenseDividedByDaysString}`;
+}
+
+export function buildRangedDuplOrSplitPromptString(
+  duplOrSplitNum: number,
+  input: RangedSplitPromptInput
+): string {
+  if (duplOrSplitNum === DuplicateOption.duplicate) {
+    return buildRangedDuplicatePromptString(input);
+  }
+  if (duplOrSplitNum === DuplicateOption.split) {
+    return buildRangedSplitPromptString(input);
+  }
+  return "";
+}

--- a/TravelCostApp/util/expense-form-range.ts
+++ b/TravelCostApp/util/expense-form-range.ts
@@ -1,6 +1,7 @@
 import { daysBetween } from "./date";
 import { DuplicateOption } from "./expense";
 
+/** Inclusive day count for a date span (matches ExpenseForm `daysBeween`). */
 export function countInclusiveDaysInRange(
   startDate: Date,
   endDate: Date
@@ -9,6 +10,7 @@ export function countInclusiveDaysInRange(
   return daysBetween(endDate, startDate) + 1;
 }
 
+/** Per-day amount × days — **Ranged duplicate** total. */
 export function multiplyAmountForRangedDuplicate(
   amount: number,
   inclusiveDayCount: number
@@ -16,6 +18,7 @@ export function multiplyAmountForRangedDuplicate(
   return amount * inclusiveDayCount;
 }
 
+/** Total amount ÷ days — **Ranged split** per-day share. */
 export function divideAmountForRangedSplit(
   amount: number,
   inclusiveDayCount: number
@@ -23,6 +26,7 @@ export function divideAmountForRangedSplit(
   return amount / inclusiveDayCount;
 }
 
+/** Whether the amount field already holds a per-day share (editing ranged split). */
 export function resolveAlreadyDividedAmountByDays(
   isEditing: boolean,
   duplOrSplit: DuplicateOption | number,
@@ -45,6 +49,7 @@ export type CollapseRangeToSingleDayInput = {
   alreadyDividedAmountByDays: boolean;
 };
 
+/** Amount field value after the user collapses a range back to a single day. */
 export function resolveAmountWhenCollapsingRangeToSingleDay(
   input: CollapseRangeToSingleDayInput
 ): string | null {
@@ -84,6 +89,7 @@ export type RangedSplitPromptInput = RangedPromptInput & {
   alreadyDividedAmountByDays: boolean;
 };
 
+/** Alert copy for **Ranged duplicate** (per-day × days). */
 export function buildRangedDuplicatePromptString(
   input: RangedPromptInput
 ): string {
@@ -95,6 +101,7 @@ export function buildRangedDuplicatePromptString(
   return `${labels.duplString1} ${expenseString} ${labels.duplString2} ${input.inclusiveDayCount} ${labels.duplString3}. \n${labels.duplString4} ${expenseTimesDaysString} ${labels.total}`;
 }
 
+/** Alert copy for **Ranged split** (new vs already-divided editing). */
 export function buildRangedSplitPromptString(
   input: RangedSplitPromptInput
 ): string {
@@ -114,6 +121,7 @@ export function buildRangedSplitPromptString(
   return `${labels.splitString1} ${expenseString}\n${labels.splitString2} ${input.inclusiveDayCount} ${labels.splitString3} ${expenseDividedByDaysString}`;
 }
 
+/** Picker prompt for duplicate (1), split (2), or empty (0). */
 export function buildRangedDuplOrSplitPromptString(
   duplOrSplitNum: number,
   input: RangedSplitPromptInput


### PR DESCRIPTION
## Summary
- Add `util/expense-form-range.ts` with pure helpers for inclusive day count, per-day multiply/spread, `alreadyDividedAmountByDays`, collapse-to-single-day amount adjustment, and duplicate/split prompt strings.
- Add characterization tests for 1-day and multi-day spans, editing vs new split copy, and collapse behavior.
- Wire `ExpenseForm` to the util; `Alert.alert` and `useLayoutEffect` stay in the component.

## Test plan
- [x] `pnpm test -- __tests__/util/expense-form-range.test.ts`
- [x] Full `pnpm test` (210 tests)

Closes #273