### PR TITLE
ExpenseForm: pure modalFlowReducer with effect descriptors (#274)

### DIFF
--- a/TravelCostApp/__tests__/util/modal-flow-reducer.test.ts
+++ b/TravelCostApp/__tests__/util/modal-flow-reducer.test.ts
@@ -1,0 +1,94 @@
+import type { splitType } from "../../util/split";
+import {
+  MODAL_FLOW_STATE,
+  type ModalFlowEffect,
+  type ModalFlowResult,
+  type ModalFlowState,
+  modalFlowReducer,
+} from "../../util/modal-flow-reducer";
+
+type TransitionCase = {
+  current: ModalFlowState;
+  selectedValue: string;
+  expected: ModalFlowResult;
+};
+
+const closedNoEffects: ModalFlowResult = {
+  next: MODAL_FLOW_STATE.CLOSED,
+  effects: [],
+};
+
+function splitTypeEffects(splitType: splitType): ModalFlowEffect[] {
+  return [
+    { type: "SET_SPLIT_TYPE", splitType },
+    { type: "RUN_SPLIT_HANDLER", splitType },
+  ];
+}
+
+const transitionTable: TransitionCase[] = [
+  {
+    current: MODAL_FLOW_STATE.CLOSED,
+    selectedValue: "EQUAL",
+    expected: closedNoEffects,
+  },
+  {
+    current: MODAL_FLOW_STATE.WHO_PAID,
+    selectedValue: "Alice",
+    expected: {
+      next: MODAL_FLOW_STATE.CLOSED,
+      deferred: { reopen: MODAL_FLOW_STATE.HOW_SHARED },
+      effects: [],
+    },
+  },
+  {
+    current: MODAL_FLOW_STATE.WHO_PAID,
+    selectedValue: "__ADD_TRAVELLER__",
+    expected: {
+      next: MODAL_FLOW_STATE.CLOSED,
+      effects: [{ type: "NAVIGATE_SHARE" }],
+    },
+  },
+  {
+    current: MODAL_FLOW_STATE.HOW_SHARED,
+    selectedValue: "EXACT",
+    expected: {
+      next: MODAL_FLOW_STATE.CLOSED,
+      deferred: { reopen: MODAL_FLOW_STATE.EXACT_SHARING },
+      effects: [],
+    },
+  },
+  {
+    current: MODAL_FLOW_STATE.HOW_SHARED,
+    selectedValue: "EQUAL",
+    expected: {
+      next: MODAL_FLOW_STATE.CLOSED,
+      effects: splitTypeEffects("EQUAL"),
+    },
+  },
+  {
+    current: MODAL_FLOW_STATE.HOW_SHARED,
+    selectedValue: "SELF",
+    expected: {
+      next: MODAL_FLOW_STATE.CLOSED,
+      effects: splitTypeEffects("SELF"),
+    },
+  },
+  {
+    current: MODAL_FLOW_STATE.EXACT_SHARING,
+    selectedValue: "ignored",
+    expected: {
+      next: MODAL_FLOW_STATE.CLOSED,
+      deferred: { effects: [{ type: "OPEN_TRAVELLER_MULTI_PICKER" }] },
+      effects: [],
+    },
+  },
+];
+
+describe("modalFlowReducer transition table", () => {
+  it.each(transitionTable)(
+    "$current + $selectedValue → next/deferred/effects",
+    ({ current, selectedValue, expected }) => {
+      expect(modalFlowReducer(current, selectedValue)).toEqual(expected);
+    }
+  );
+});

--- a/TravelCostApp/__tests__/util/modal-flow-reducer.test.ts
+++ b/TravelCostApp/__tests__/util/modal-flow-reducer.test.ts
@@ -1,11 +1,19 @@
 import type { splitType } from "../../util/split";
 import {
+  MODAL_FLOW_ADD_TRAVELLER,
+  MODAL_FLOW_DEFER_MS,
   MODAL_FLOW_STATE,
   type ModalFlowEffect,
   type ModalFlowResult,
   type ModalFlowState,
   modalFlowReducer,
 } from "../../util/modal-flow-reducer";
+
+describe("modal flow constants", () => {
+  it("documents the close-then-reopen delay used by ExpenseForm", () => {
+    expect(MODAL_FLOW_DEFER_MS).toBe(100);
+  });
+});
 
 type TransitionCase = {
   current: ModalFlowState;
@@ -42,7 +50,7 @@ const transitionTable: TransitionCase[] = [
   },
   {
     current: MODAL_FLOW_STATE.WHO_PAID,
-    selectedValue: "__ADD_TRAVELLER__",
+    selectedValue: MODAL_FLOW_ADD_TRAVELLER,
     expected: {
       next: MODAL_FLOW_STATE.CLOSED,
       effects: [{ type: "NAVIGATE_SHARE" }],

--- a/TravelCostApp/util/modal-flow-reducer.ts
+++ b/TravelCostApp/util/modal-flow-reducer.ts
@@ -1,0 +1,80 @@
+import type { splitType } from "./split";
+
+export const MODAL_FLOW_STATE = {
+  CLOSED: "closed",
+  WHO_PAID: "whoPaid",
+  HOW_SHARED: "howShared",
+  EXACT_SHARING: "exactSharing",
+} as const;
+
+export type ModalFlowState =
+  (typeof MODAL_FLOW_STATE)[keyof typeof MODAL_FLOW_STATE];
+
+export type ModalFlowDeferred = {
+  reopen?: ModalFlowState;
+  effects?: ModalFlowEffect[];
+};
+
+export type ModalFlowEffect =
+  | { type: "SET_SPLIT_TYPE"; splitType: splitType }
+  | { type: "RUN_SPLIT_HANDLER"; splitType: splitType }
+  | { type: "OPEN_TRAVELLER_MULTI_PICKER" }
+  | { type: "NAVIGATE_SHARE" };
+
+export type ModalFlowResult = {
+  next: ModalFlowState;
+  deferred?: ModalFlowDeferred;
+  effects: ModalFlowEffect[];
+};
+
+const ADD_TRAVELLER_VALUE = "__ADD_TRAVELLER__";
+const SPLIT_TYPE_EXACT = "EXACT";
+
+export function modalFlowReducer(
+  current: ModalFlowState,
+  selectedValue: string
+): ModalFlowResult {
+  switch (current) {
+    case MODAL_FLOW_STATE.WHO_PAID:
+      if (selectedValue === ADD_TRAVELLER_VALUE) {
+        return {
+          next: MODAL_FLOW_STATE.CLOSED,
+          effects: [{ type: "NAVIGATE_SHARE" }],
+        };
+      }
+      return {
+        next: MODAL_FLOW_STATE.CLOSED,
+        deferred: { reopen: MODAL_FLOW_STATE.HOW_SHARED },
+        effects: [],
+      };
+
+    case MODAL_FLOW_STATE.EXACT_SHARING:
+      return {
+        next: MODAL_FLOW_STATE.CLOSED,
+        deferred: { effects: [{ type: "OPEN_TRAVELLER_MULTI_PICKER" }] },
+        effects: [],
+      };
+
+    case MODAL_FLOW_STATE.HOW_SHARED:
+      if (selectedValue === SPLIT_TYPE_EXACT) {
+        return {
+          next: MODAL_FLOW_STATE.CLOSED,
+          deferred: { reopen: MODAL_FLOW_STATE.EXACT_SHARING },
+          effects: [],
+        };
+      }
+      return {
+        next: MODAL_FLOW_STATE.CLOSED,
+        effects: [
+          { type: "SET_SPLIT_TYPE", splitType: selectedValue as splitType },
+          {
+            type: "RUN_SPLIT_HANDLER",
+            splitType: selectedValue as splitType,
+          },
+        ],
+      };
+
+    default:
+      return { next: MODAL_FLOW_STATE.CLOSED, effects: [] };
+  }
+}

--- a/TravelCostApp/util/modal-flow-reducer.ts
+++ b/TravelCostApp/util/modal-flow-reducer.ts
@@ -1,5 +1,11 @@
 import type { splitType } from "./split";
 
+/** Matches ExpenseForm `setTimeout(…, 100)` between modal close and deferred reopen/effects. */
+export const MODAL_FLOW_DEFER_MS = 100;
+
+/** WHO_PAID picker sentinel; also used in ExpenseForm `onSelectItem`. */
+export const MODAL_FLOW_ADD_TRAVELLER = "__ADD_TRAVELLER__" as const;
+
 export const MODAL_FLOW_STATE = {
   CLOSED: "closed",
   WHO_PAID: "whoPaid",
@@ -10,6 +16,10 @@ export const MODAL_FLOW_STATE = {
 export type ModalFlowState =
   (typeof MODAL_FLOW_STATE)[keyof typeof MODAL_FLOW_STATE];
 
+/**
+ * Work scheduled after `next` is applied. The UI interpreter should wait
+ * {@link MODAL_FLOW_DEFER_MS} before applying `reopen` or `effects`.
+ */
 export type ModalFlowDeferred = {
   reopen?: ModalFlowState;
   effects?: ModalFlowEffect[];
@@ -27,7 +37,6 @@ export type ModalFlowResult = {
   effects: ModalFlowEffect[];
 };
 
-const ADD_TRAVELLER_VALUE = "__ADD_TRAVELLER__";
 const SPLIT_TYPE_EXACT = "EXACT";
 
 export function modalFlowReducer(
@@ -36,7 +45,7 @@ export function modalFlowReducer(
 ): ModalFlowResult {
   switch (current) {
     case MODAL_FLOW_STATE.WHO_PAID:
-      if (selectedValue === ADD_TRAVELLER_VALUE) {
+      if (selectedValue === MODAL_FLOW_ADD_TRAVELLER) {
         return {
           next: MODAL_FLOW_STATE.CLOSED,
           effects: [{ type: "NAVIGATE_SHARE" }],


### PR DESCRIPTION
## Summary
- Add `modalFlowReducer` in `util/` for the who-paid → how-shared → exact-sharing modal cascade (CLOSED / WHO_PAID / HOW_SHARED / EXACT_SHARING).
- Return `next`, optional `deferred` (timed reopen or deferred effects), and effect descriptors (`SET_SPLIT_TYPE`, `RUN_SPLIT_HANDLER`, `OPEN_TRAVELLER_MULTI_PICKER`, `NAVIGATE_SHARE`).
- Characterization tests cover the full transition table; `ExpenseForm` unchanged (rewire in #270).

## Test plan
- [x] `pnpm test -- __tests__/util/modal-flow-reducer.test.ts`

Closes #274