### PR TITLE
ExpenseForm: pure draft round-trip helpers (#276)

### DIFF
--- a/TravelCostApp/__tests__/util/expense-form-draft.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-draft.test.ts
@@ -4,7 +4,8 @@ jest.mock("expo-localization", () => ({
 
 import { DateTime } from "luxon";
 import { i18n } from "../../i18n/i18n";
-import { paidBackStatus } from "../../util/expense";
+import { getCatLocalized } from "../../util/category";
+import { ExpenseData, paidBackStatus } from "../../util/expense";
 import { makeExpense } from "../fixtures/expense";
 import { makeExpenseFormSnapshot } from "../fixtures/expense-form";
 import {
@@ -117,6 +118,9 @@ describe("draft round-trip", () => {
     expect(restored.endDate).toBe(
       dateFromIso(snapshot.endDateIso).toISOString()
     );
+    expect(restored.inputs?.date?.value).toBe(
+      dateFromIso(snapshot.dateIso).toISOString()
+    );
   });
 });
 
@@ -142,7 +146,7 @@ describe("summarizeDraftChanges", () => {
     expect(lines).toEqual([
       `• ${i18n.t("amount")}: 50`,
       `• ${i18n.t("description")}: coffee`,
-      `• ${i18n.t("category")}: Food`,
+      `• ${i18n.t("category")}: ${getCatLocalized("Food")}`,
       `• ${i18n.t("currency")}: USD`,
       `• ${i18n.t("country")}: US`,
       `• ${i18n.t("whoPaid")}: Bob`,
@@ -169,5 +173,25 @@ describe("summarizeDraftChanges", () => {
     );
 
     expect(lines).toEqual([]);
+  });
+});
+
+describe("legacy draft paidBack field", () => {
+  const baseline = { lastCountry: "DE", lastCurrency: "EUR" };
+
+  it("restore and summary accept isPaid when paidBack is missing", () => {
+    const { paidBack: _paidBack, ...withoutPaidBack } = makeExpense({
+      amount: 50,
+      category: "Food",
+    });
+    const legacyDraft = {
+      ...withoutPaidBack,
+      isPaid: paidBackStatus.paid,
+    } as ExpenseData & { isPaid: paidBackStatus };
+
+    expect(applyDraftToForm(legacyDraft).paidBack).toBe(paidBackStatus.paid);
+    expect(summarizeDraftChanges(legacyDraft, baseline)).toContain(
+      `• ${i18n.t("paymentStatus")}: ${i18n.t("paid")}`
+    );
   });
 });

--- a/TravelCostApp/__tests__/util/expense-form-draft.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-draft.test.ts
@@ -1,0 +1,173 @@
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageTag: "en-US", languageCode: "en" }],
+}));
+
+import { DateTime } from "luxon";
+import { i18n } from "../../i18n/i18n";
+import { paidBackStatus } from "../../util/expense";
+import { makeExpense } from "../fixtures/expense";
+import { makeExpenseFormSnapshot } from "../fixtures/expense-form";
+import {
+  applyDraftToForm,
+  summarizeDraftChanges,
+  toExpenseDraft,
+} from "../../util/expense-form-draft";
+
+function dateFromIso(iso: string): Date {
+  return DateTime.fromISO(iso).toJSDate();
+}
+
+describe("toExpenseDraft", () => {
+  it("persists the same ExpenseData shape as ExpenseForm saveDraftData", () => {
+    const draft = toExpenseDraft(makeExpenseFormSnapshot());
+
+    expect(draft.category).toBe("Food");
+    expect(draft.categoryString).toBe("Food");
+    expect(draft.description).toBe("Lunch");
+    expect(draft.amount).toBe(42.5);
+    expect(draft.calcAmount).toBe(42.5);
+    expect(draft.country).toBe("DE");
+    expect(draft.currency).toBe("EUR");
+    expect(draft.whoPaid).toBe("Alice");
+    expect(draft.splitType).toBe("EQUAL");
+    expect(draft.listEQUAL).toEqual(["Alice", "Bob"]);
+    expect(draft.splitList).toEqual([{ userName: "Alice", amount: 21.25 }]);
+    expect(draft.duplOrSplit).toBe(0);
+    expect(draft.paidBack).toBe("not paid");
+    expect(draft.isSpecialExpense).toBe(false);
+    expect(draft.date).toEqual(dateFromIso("2026-01-15"));
+    expect(draft.startDate).toEqual(dateFromIso("2026-01-15"));
+    expect(draft.endDate).toEqual(dateFromIso("2026-01-16"));
+  });
+
+  it("keeps display amount separate from resolved calcAmount when amountInput differs", () => {
+    const draft = toExpenseDraft(
+      makeExpenseFormSnapshot({
+        amountInput: "10",
+        amountValue: 25,
+      })
+    );
+
+    expect(draft.amount).toBe(10);
+    expect(draft.calcAmount).toBe(25);
+  });
+});
+
+describe("applyDraftToForm", () => {
+  it("maps persisted draft fields into form input state", () => {
+    const restored = applyDraftToForm(makeExpense());
+
+    expect(restored.inputs?.amount).toEqual({ value: "100", isValid: true });
+    expect(restored.inputs?.description).toEqual({
+      value: "dinner",
+      isValid: true,
+    });
+    expect(restored.inputs?.category).toEqual({
+      value: "Food",
+      isValid: true,
+    });
+    expect(restored.inputs?.country).toEqual({ value: "", isValid: true });
+    expect(restored.inputs?.currency).toEqual({ value: "EUR", isValid: true });
+    expect(restored.inputs?.whoPaid).toEqual({ value: "Alice", isValid: true });
+    expect(restored.inputs?.date?.value).toBe(
+      new Date("2026-01-15T12:00:00.000Z").toISOString()
+    );
+    expect(restored.splitType).toBe("EQUAL");
+    expect(restored.splitList).toEqual([
+      { userName: "Alice", amount: 50 },
+      { userName: "Bob", amount: 50 },
+    ]);
+    expect(restored.listEQUAL).toBeUndefined();
+    expect(restored.paidBack).toBeUndefined();
+    expect(restored.isSpecialExpense).toBe(false);
+    expect(restored.startDate).toBe(
+      new Date("2026-01-15T12:00:00.000Z").toISOString()
+    );
+    expect(restored.endDate).toBe(
+      new Date("2026-01-15T12:00:00.000Z").toISOString()
+    );
+    expect(restored.calcAmount).toBe("100");
+  });
+});
+
+describe("draft round-trip", () => {
+  it("restores equivalent form state from snapshot via draft persistence", () => {
+    const snapshot = makeExpenseFormSnapshot({
+      amountInput: "10",
+      amountValue: 25,
+    });
+    const restored = applyDraftToForm(toExpenseDraft(snapshot));
+
+    expect(restored.inputs?.amount?.value).toBe("10");
+    expect(restored.inputs?.description?.value).toBe(snapshot.description);
+    expect(restored.inputs?.category?.value).toBe(snapshot.categoryInput);
+    expect(restored.inputs?.country?.value).toBe(snapshot.country);
+    expect(restored.inputs?.currency?.value).toBe(snapshot.currency);
+    expect(restored.inputs?.whoPaid?.value).toBe(snapshot.whoPaid);
+    expect(restored.splitType).toBe(snapshot.splitType);
+    expect(restored.listEQUAL).toEqual(snapshot.listEQUAL);
+    expect(restored.splitList).toEqual(snapshot.splitList);
+    expect(restored.duplOrSplit).toBe(snapshot.duplOrSplit);
+    expect(restored.paidBack).toBe(snapshot.paidBack);
+    expect(restored.isSpecialExpense).toBe(snapshot.isSpecialExpense);
+    expect(restored.calcAmount).toBe("25");
+    expect(restored.startDate).toBe(
+      dateFromIso(snapshot.startDateIso).toISOString()
+    );
+    expect(restored.endDate).toBe(
+      dateFromIso(snapshot.endDateIso).toISOString()
+    );
+  });
+});
+
+describe("summarizeDraftChanges", () => {
+  const baseline = { lastCountry: "DE", lastCurrency: "EUR" };
+
+  it("lists changed draft fields with localized labels", () => {
+    const lines = summarizeDraftChanges(
+      makeExpense({
+        amount: 50,
+        description: "coffee",
+        category: "Food",
+        currency: "USD",
+        country: "US",
+        whoPaid: "Bob",
+        splitType: "EXACT",
+        paidBack: paidBackStatus.paid,
+        isSpecialExpense: true,
+      }),
+      baseline
+    );
+
+    expect(lines).toEqual([
+      `• ${i18n.t("amount")}: 50`,
+      `• ${i18n.t("description")}: coffee`,
+      `• ${i18n.t("category")}: Food`,
+      `• ${i18n.t("currency")}: USD`,
+      `• ${i18n.t("country")}: US`,
+      `• ${i18n.t("whoPaid")}: Bob`,
+      `• ${i18n.t("splitType")}: ${i18n.t("exact")}`,
+      `• ${i18n.t("paymentStatus")}: ${i18n.t("paid")}`,
+      `• ${i18n.t("specialExpense")}: ${i18n.t("yes")}`,
+    ]);
+  });
+
+  it("omits fields that match baseline or default sentinels", () => {
+    const lines = summarizeDraftChanges(
+      makeExpense({
+        amount: 0,
+        description: "",
+        category: "undefined",
+        currency: "EUR",
+        country: "DE",
+        whoPaid: "",
+        splitType: "SELF",
+        paidBack: paidBackStatus.notPaid,
+        isSpecialExpense: false,
+      }),
+      baseline
+    );
+
+    expect(lines).toEqual([]);
+  });
+});

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -79,6 +79,11 @@ import {
   getEffectivePaidBack,
 } from "../../util/expense";
 import {
+  applyDraftToForm,
+  summarizeDraftChanges,
+  toExpenseDraft,
+} from "../../util/expense-form-draft";
+import {
   buildRangedDuplOrSplitPromptString,
   countInclusiveDaysInRange,
   divideAmountForRangedSplit,
@@ -804,26 +809,39 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   // Helper function to save current form state to draft storage
   const saveDraftData = useCallback(
     (newValues: Partial<ExpenseData> = {}) => {
-      setExpenseDraft(editedExpenseId, {
-        category: inputs.category.value,
-        description: inputs.description.value,
-        amount: +inputs.amount.value,
-        date: createSafeDate(inputs.date.value),
-        startDate: createSafeDate(startDate),
-        endDate: createSafeDate(endDate),
-        country: inputs.country.value,
-        currency: inputs.currency.value,
-        whoPaid: whoPaid,
-        splitType: splitType,
-        listEQUAL: splitTravellersList,
-        splitList,
-        duplOrSplit,
-        calcAmount: +amountValue,
-        paidBack,
-        isSpecialExpense,
-        categoryString: inputs.category.value,
-        ...newValues,
-      });
+      setExpenseDraft(
+        editedExpenseId,
+        toExpenseDraft(
+          {
+            uid: "",
+            amountInput: inputs.amount.value,
+            amountValue,
+            dateIso: inputs.date.value,
+            startDateIso: startDate,
+            endDateIso: endDate,
+            description: inputs.description.value,
+            categoryInput: inputs.category.value,
+            country: inputs.country.value,
+            currency: inputs.currency.value,
+            whoPaid,
+            splitType,
+            splitList,
+            listEQUAL: splitTravellersList,
+            paidBack,
+            isSpecialExpense,
+            duplOrSplit,
+            iconName,
+            alreadyDividedAmountByDays,
+            newCat,
+            pickedCat,
+            isSoloTraveller: IsSoloTraveller,
+            userName: userCtx.userName,
+            lastCountry: userCtx.lastCountry,
+            lastCurrency: userCtx.lastCurrency,
+          },
+          newValues
+        )
+      );
     },
     [
       editedExpenseId,
@@ -843,6 +861,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       amountValue,
       paidBack,
       isSpecialExpense,
+      iconName,
+      alreadyDividedAmountByDays,
+      newCat,
+      pickedCat,
+      IsSoloTraveller,
+      userCtx.userName,
+      userCtx.lastCountry,
+      userCtx.lastCurrency,
     ]
   );
   const saveDraftDataRef = useRef(saveDraftData);
@@ -875,52 +901,10 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   useEffect(() => {
     const draftData: ExpenseData = getExpenseDraft(editedExpenseId);
     if (draftData) {
-      const draftPaidBack =
-        draftData.paidBack ??
-        (draftData as ExpenseData & { isPaid?: isPaidString }).isPaid;
-      // Create a user-friendly list of changed items
-      const changedItems = [];
-
-      if (draftData.amount && draftData.amount !== 0) {
-        changedItems.push(`• ${i18n.t("amount")}: ${draftData.amount}`);
-      }
-      if (draftData.description && draftData.description !== "") {
-        changedItems.push(
-          `• ${i18n.t("description")}: ${draftData.description}`
-        );
-      }
-      if (draftData.category && draftData.category !== "undefined") {
-        const categoryName = getCatLocalized(draftData.category);
-        changedItems.push(`• ${i18n.t("category")}: ${categoryName}`);
-      }
-      if (draftData.currency && draftData.currency !== userCtx.lastCurrency) {
-        changedItems.push(`• ${i18n.t("currency")}: ${draftData.currency}`);
-      }
-      if (draftData.country && draftData.country !== userCtx.lastCountry) {
-        changedItems.push(`• ${i18n.t("country")}: ${draftData.country}`);
-      }
-      if (draftData.whoPaid && draftData.whoPaid !== "") {
-        changedItems.push(`• ${i18n.t("whoPaid")}: ${draftData.whoPaid}`);
-      }
-      if (draftData.splitType && draftData.splitType !== "SELF") {
-        const splitTypeText =
-          draftData.splitType === "EQUAL"
-            ? i18n.t("equal")
-            : draftData.splitType === "EXACT"
-              ? i18n.t("exact")
-              : draftData.splitType;
-        changedItems.push(`• ${i18n.t("splitType")}: ${splitTypeText}`);
-      }
-      if (draftPaidBack && draftPaidBack !== "not paid") {
-        const paidText =
-          draftPaidBack === "paid"
-            ? i18n.t("paid")
-            : i18n.t("notPaidLabel");
-        changedItems.push(`• ${i18n.t("paymentStatus")}: ${paidText}`);
-      }
-      if (draftData.isSpecialExpense) {
-        changedItems.push(`• ${i18n.t("specialExpense")}: ${i18n.t("yes")}`);
-      }
+      const changedItems = summarizeDraftChanges(draftData, {
+        lastCountry: userCtx.lastCountry,
+        lastCurrency: userCtx.lastCurrency,
+      });
 
       const changedItemsText =
         changedItems.length > 0
@@ -941,57 +925,36 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
           {
             text: i18n.t("restore"),
             onPress: () => {
-              // Restore form state from draft data
-              // Extract inputs from the spread data structure
-              const inputsToRestore = {
-                amount: {
-                  value: draftData.amount?.toString() || "",
-                  isValid: true,
-                },
-                description: {
-                  value: draftData.description || "",
-                  isValid: true,
-                },
-                date: {
-                  value: draftData.date
-                    ? convertToISOString(draftData.date)
-                    : "",
-                  isValid: true,
-                },
-                category: { value: draftData.category || "", isValid: true },
-                country: { value: draftData.country || "", isValid: true },
-                currency: { value: draftData.currency || "", isValid: true },
-                whoPaid: { value: draftData.whoPaid || "", isValid: true },
-              };
-              setInputs(inputsToRestore);
-              if (draftData.splitType) {
-                setSplitType(draftData.splitType);
+              const restored = applyDraftToForm(draftData);
+              if (restored.inputs) {
+                setInputs(restored.inputs);
               }
-              if (draftData.listEQUAL) {
-                setListEQUAL(draftData.listEQUAL);
+              if (restored.splitType) {
+                setSplitType(restored.splitType);
               }
-              if (draftData.splitList) {
-                // Reset edit order when loading draft data
-                const splitsWithoutOrder = resetEditOrder(draftData.splitList);
-                setSplitList(splitsWithoutOrder);
+              if (restored.listEQUAL) {
+                setListEQUAL(restored.listEQUAL);
               }
-              if (draftData.duplOrSplit !== undefined) {
-                setDuplOrSplit(draftData.duplOrSplit);
+              if (restored.splitList) {
+                setSplitList(restored.splitList);
               }
-              if (draftPaidBack) {
-                setPaidBack(draftPaidBack);
+              if (restored.duplOrSplit !== undefined) {
+                setDuplOrSplit(restored.duplOrSplit);
               }
-              if (draftData.isSpecialExpense !== undefined) {
-                setIsSpecialExpense(draftData.isSpecialExpense);
+              if (restored.paidBack) {
+                setPaidBack(restored.paidBack);
               }
-              if (draftData.startDate) {
-                setStartDate(convertToISOString(draftData.startDate));
+              if (restored.isSpecialExpense !== undefined) {
+                setIsSpecialExpense(restored.isSpecialExpense);
               }
-              if (draftData.endDate) {
-                setEndDate(convertToISOString(draftData.endDate));
+              if (restored.startDate) {
+                setStartDate(restored.startDate);
               }
-              if (draftData.calcAmount) {
-                setCalcAmount(draftData.calcAmount.toString());
+              if (restored.endDate) {
+                setEndDate(restored.endDate);
+              }
+              if (restored.calcAmount) {
+                setCalcAmount(restored.calcAmount);
               }
             },
           },

--- a/TravelCostApp/util/date.ts
+++ b/TravelCostApp/util/date.ts
@@ -233,3 +233,14 @@ export const getLocaleDateFormat = (separator = "-") => {
 
   return format.replace(/\W/g, separator);
 };
+
+/** Parse ISO date string for expense forms; falls back to now when empty/invalid. */
+export function createSafeDate(dateValue: string): Date {
+  if (dateValue && dateValue !== "") {
+    const parsedDate = DateTime.fromISO(dateValue);
+    return parsedDate.isValid
+      ? parsedDate.toJSDate()
+      : DateTime.now().toJSDate();
+  }
+  return DateTime.now().toJSDate();
+}

--- a/TravelCostApp/util/expense-form-draft.ts
+++ b/TravelCostApp/util/expense-form-draft.ts
@@ -1,0 +1,207 @@
+import { DateTime } from "luxon";
+import { i18n } from "../i18n/i18n";
+import { getCatLocalized } from "./category";
+import type { ExpenseFormSnapshot } from "./expense-form-submit";
+import {
+  ExpenseData,
+  paidBackStatus,
+} from "./expense";
+import { DateOrDateTime } from "./date";
+import { resetEditOrder, splitType } from "./split";
+
+export type FormFieldState = {
+  value: string;
+  isValid: boolean;
+};
+
+export type ExpenseFormDraftRestore = {
+  inputs: {
+    amount: FormFieldState;
+    description: FormFieldState;
+    date: FormFieldState;
+    category: FormFieldState;
+    country: FormFieldState;
+    currency: FormFieldState;
+    whoPaid: FormFieldState;
+  };
+  splitType?: splitType;
+  listEQUAL?: string[];
+  splitList?: ReturnType<typeof resetEditOrder>;
+  duplOrSplit?: ExpenseData["duplOrSplit"];
+  paidBack?: paidBackStatus;
+  isSpecialExpense?: boolean;
+  startDate?: string;
+  endDate?: string;
+  calcAmount?: string;
+};
+
+function createSafeDate(dateValue: string): Date {
+  if (dateValue && dateValue !== "") {
+    const parsedDate = DateTime.fromISO(dateValue);
+    return parsedDate.isValid
+      ? parsedDate.toJSDate()
+      : DateTime.now().toJSDate();
+  }
+  return DateTime.now().toJSDate();
+}
+
+export function toExpenseDraft(
+  snapshot: ExpenseFormSnapshot,
+  overrides: Partial<ExpenseData> = {}
+): ExpenseData {
+  const amountInput = snapshot.amountInput ?? snapshot.amountValue;
+  const resolvedAmount = +snapshot.amountValue;
+
+  return {
+    category: snapshot.categoryInput,
+    description: snapshot.description,
+    amount: +amountInput,
+    date: createSafeDate(snapshot.dateIso),
+    startDate: createSafeDate(snapshot.startDateIso),
+    endDate: createSafeDate(snapshot.endDateIso),
+    country: snapshot.country,
+    currency: snapshot.currency,
+    whoPaid: snapshot.whoPaid as string,
+    splitType: snapshot.splitType,
+    listEQUAL: snapshot.listEQUAL,
+    splitList: snapshot.splitList,
+    duplOrSplit: snapshot.duplOrSplit,
+    calcAmount: resolvedAmount,
+    paidBack: snapshot.paidBack,
+    isSpecialExpense: snapshot.isSpecialExpense,
+    categoryString: snapshot.categoryInput,
+    ...overrides,
+  };
+}
+
+function convertToISOString(dateValue: DateOrDateTime): string {
+  if (typeof dateValue === "string") {
+    return dateValue;
+  }
+  if (dateValue instanceof Date) {
+    return dateValue.toISOString();
+  }
+  if (dateValue && typeof (dateValue as { toJSDate?: () => Date }).toJSDate === "function") {
+    return (dateValue as { toJSDate: () => Date }).toJSDate().toISOString();
+  }
+  return new Date(dateValue as string | number).toISOString();
+}
+
+function readDraftPaidBack(
+  draft: ExpenseData
+): paidBackStatus | undefined {
+  return (
+    draft.paidBack ??
+    (draft as ExpenseData & { isPaid?: paidBackStatus }).isPaid
+  );
+}
+
+export function applyDraftToForm(
+  draft: ExpenseData
+): Partial<ExpenseFormDraftRestore> {
+  const draftPaidBack = readDraftPaidBack(draft);
+  const restored: Partial<ExpenseFormDraftRestore> = {
+    inputs: {
+      amount: {
+        value: draft.amount?.toString() || "",
+        isValid: true,
+      },
+      description: {
+        value: draft.description || "",
+        isValid: true,
+      },
+      date: {
+        value: draft.date ? convertToISOString(draft.date) : "",
+        isValid: true,
+      },
+      category: { value: draft.category || "", isValid: true },
+      country: { value: draft.country || "", isValid: true },
+      currency: { value: draft.currency || "", isValid: true },
+      whoPaid: { value: draft.whoPaid || "", isValid: true },
+    },
+  };
+
+  if (draft.splitType) {
+    restored.splitType = draft.splitType;
+  }
+  if (draft.listEQUAL) {
+    restored.listEQUAL = draft.listEQUAL;
+  }
+  if (draft.splitList) {
+    restored.splitList = resetEditOrder(draft.splitList);
+  }
+  if (draft.duplOrSplit !== undefined) {
+    restored.duplOrSplit = draft.duplOrSplit;
+  }
+  if (draftPaidBack) {
+    restored.paidBack = draftPaidBack;
+  }
+  if (draft.isSpecialExpense !== undefined) {
+    restored.isSpecialExpense = draft.isSpecialExpense;
+  }
+  if (draft.startDate) {
+    restored.startDate = convertToISOString(draft.startDate);
+  }
+  if (draft.endDate) {
+    restored.endDate = convertToISOString(draft.endDate);
+  }
+  if (draft.calcAmount) {
+    restored.calcAmount = draft.calcAmount.toString();
+  }
+
+  return restored;
+}
+
+export type DraftChangeBaseline = {
+  lastCountry: string;
+  lastCurrency: string;
+};
+
+export function summarizeDraftChanges(
+  draft: ExpenseData,
+  baseline: DraftChangeBaseline
+): string[] {
+  const draftPaidBack = readDraftPaidBack(draft);
+  const changedItems: string[] = [];
+
+  if (draft.amount && draft.amount !== 0) {
+    changedItems.push(`• ${i18n.t("amount")}: ${draft.amount}`);
+  }
+  if (draft.description && draft.description !== "") {
+    changedItems.push(`• ${i18n.t("description")}: ${draft.description}`);
+  }
+  if (draft.category && draft.category !== "undefined") {
+    const categoryName = getCatLocalized(draft.category);
+    changedItems.push(`• ${i18n.t("category")}: ${categoryName}`);
+  }
+  if (draft.currency && draft.currency !== baseline.lastCurrency) {
+    changedItems.push(`• ${i18n.t("currency")}: ${draft.currency}`);
+  }
+  if (draft.country && draft.country !== baseline.lastCountry) {
+    changedItems.push(`• ${i18n.t("country")}: ${draft.country}`);
+  }
+  if (draft.whoPaid && draft.whoPaid !== "") {
+    changedItems.push(`• ${i18n.t("whoPaid")}: ${draft.whoPaid}`);
+  }
+  if (draft.splitType && draft.splitType !== "SELF") {
+    const splitTypeText =
+      draft.splitType === "EQUAL"
+        ? i18n.t("equal")
+        : draft.splitType === "EXACT"
+          ? i18n.t("exact")
+          : draft.splitType;
+    changedItems.push(`• ${i18n.t("splitType")}: ${splitTypeText}`);
+  }
+  if (draftPaidBack && draftPaidBack !== paidBackStatus.notPaid) {
+    const paidText =
+      draftPaidBack === paidBackStatus.paid
+        ? i18n.t("paid")
+        : i18n.t("notPaidLabel");
+    changedItems.push(`• ${i18n.t("paymentStatus")}: ${paidText}`);
+  }
+  if (draft.isSpecialExpense) {
+    changedItems.push(`• ${i18n.t("specialExpense")}: ${i18n.t("yes")}`);
+  }
+
+  return changedItems;
+}

--- a/TravelCostApp/util/expense-form-draft.ts
+++ b/TravelCostApp/util/expense-form-draft.ts
@@ -1,12 +1,11 @@
-import { DateTime } from "luxon";
 import { i18n } from "../i18n/i18n";
 import { getCatLocalized } from "./category";
+import { createSafeDate, DateOrDateTime } from "./date";
 import type { ExpenseFormSnapshot } from "./expense-form-submit";
 import {
   ExpenseData,
   paidBackStatus,
 } from "./expense";
-import { DateOrDateTime } from "./date";
 import { resetEditOrder, splitType } from "./split";
 
 export type FormFieldState = {
@@ -34,16 +33,6 @@ export type ExpenseFormDraftRestore = {
   endDate?: string;
   calcAmount?: string;
 };
-
-function createSafeDate(dateValue: string): Date {
-  if (dateValue && dateValue !== "") {
-    const parsedDate = DateTime.fromISO(dateValue);
-    return parsedDate.isValid
-      ? parsedDate.toJSDate()
-      : DateTime.now().toJSDate();
-  }
-  return DateTime.now().toJSDate();
-}
 
 export function toExpenseDraft(
   snapshot: ExpenseFormSnapshot,

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
 import { getCatLocalized } from "./category";
+import { createSafeDate } from "./date";
 import {
   DuplicateOption,
   ExpenseData,
@@ -50,16 +51,6 @@ export type ExpenseFieldValidity = {
 export type BuiltAdvancedExpenseData = ExpenseData & {
   alreadyDividedAmountByDays: boolean;
 };
-
-function createSafeDate(dateValue: string): Date {
-  if (dateValue && dateValue !== "") {
-    const parsedDate = DateTime.fromISO(dateValue);
-    return parsedDate.isValid
-      ? parsedDate.toJSDate()
-      : DateTime.now().toJSDate();
-  }
-  return DateTime.now().toJSDate();
-}
 
 function sharedExpenseCore(snapshot: ExpenseFormSnapshot) {
   return {

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -10,6 +10,8 @@ import { splitType } from "./split";
 
 export type ExpenseFormSnapshot = {
   uid: string;
+  /** Raw amount field text; defaults to {@link amountValue} when omitted (draft save path). */
+  amountInput?: string | number;
   amountValue: string | number;
   dateIso: string;
   startDateIso: string;


### PR DESCRIPTION
## Summary
- Add `util/expense-form-draft.ts` with `toExpenseDraft`, `applyDraftToForm`, and `summarizeDraftChanges` for MMKV draft save/restore/summary.
- Wire `ExpenseForm` to the helpers; Alert and `useFocusEffect` UI unchanged.
- Extend `ExpenseFormSnapshot` with optional `amountInput` so display amount and resolved `calcAmount` can diverge (temp-amount path).
- Characterization tests in `__tests__/util/expense-form-draft.test.ts` (round-trip included).

## Test plan
- [x] `pnpm test -- __tests__/util/expense-form-draft.test.ts`
- [ ] Add expense, background app, reopen — restore prompt bullets match prior behavior
- [ ] Restore draft — form fields, split list, dates repopulate as before
- [ ] Discard draft — draft cleared, no stale restore prompt

Closes #276