### PR TITLE
ExpenseForm: useSplitEditor thin hook

### DIFF
--- a/TravelCostApp/__tests__/hooks/use-split-editor.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-split-editor.test.ts
@@ -3,7 +3,16 @@ import * as Haptics from "expo-haptics";
 
 import { useSplitEditor } from "../../hooks/useSplitEditor";
 import type { Split } from "../../util/expense";
-import { applySplitEdit, resetEditOrder, type splitType } from "../../util/split";
+import {
+  applySplitEdit,
+  calcSplitList,
+  recalcSplitsWithEditOrder,
+  resetEditOrder,
+  validateSplitList,
+  validateSplitListWithEditOrder,
+  type splitType,
+} from "../../util/split";
+import { divideAmountForRangedSplit } from "../../util/expense-form-range";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 
@@ -112,6 +121,102 @@ describe("useSplitEditor", () => {
       splitType: "EQUAL",
     });
     expect(onAutosave).toHaveBeenCalled();
+  });
+
+  it("falls back to SELF on remove without split-type analytics", () => {
+    const { result } = renderSplitEditor({
+      initialSplitList: [makeSplit({ userName: "A", amount: 100 })],
+      initialSplitType: "EXACT",
+      amount: 100,
+      tripTravellerNames: ["A"],
+    });
+
+    act(() => {
+      result.current.removeUserFromSplit("A");
+    });
+
+    expect(result.current.splitType).toBe("SELF");
+    expect(result.current.splitList).toEqual([]);
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("setSplitTravellersList updates travellers used by splitHandler", () => {
+    const { result } = renderSplitEditor({
+      initialSplitList: [],
+      initialSplitType: "SELF",
+      initialSplitTravellersList: ["A"],
+      amount: 100,
+      whoPaid: "Payer",
+    });
+
+    act(() => {
+      result.current.setSplitTravellersList(["A", "B", "C"]);
+    });
+    act(() => {
+      result.current.splitHandler("EQUAL");
+    });
+
+    expect(result.current.splitTravellersList).toEqual(["A", "B", "C"]);
+    const expectedList = resetEditOrder(
+      calcSplitList("EQUAL", 100, "Payer", ["A", "B", "C"])!
+    );
+    expect(result.current.splitList).toEqual(expectedList);
+  });
+
+  it("autoExpenseLinearSplitAdjust recalculates EXACT splits when amount changes", () => {
+    const initialSplitList = resetEditOrder([
+      makeSplit({ userName: "A", amount: 50 }),
+      makeSplit({ userName: "B", amount: 50 }),
+    ]);
+    const { result } = renderSplitEditor({
+      initialSplitList,
+      initialSplitType: "EXACT",
+      amount: 100,
+    });
+
+    act(() => {
+      result.current.autoExpenseLinearSplitAdjust("amount", "80");
+    });
+
+    const expectedList = recalcSplitsWithEditOrder(initialSplitList, 80);
+    expect(result.current.splitList).toEqual(expectedList);
+    expect(result.current.splitListValid).toBe(
+      Boolean(
+        validateSplitList(expectedList, "EXACT", 80) &&
+          validateSplitListWithEditOrder(expectedList, 80)
+      )
+    );
+  });
+
+  it("autoExpenseLinearSplitAdjust applies ranged per-day amount when editing a ranged split", () => {
+    const initialSplitList = resetEditOrder([
+      makeSplit({ userName: "A", amount: 50, editOrder: 0 }),
+      makeSplit({ userName: "B", amount: 50, editOrder: 1 }),
+    ]);
+    const amount = 150;
+    const rangedDayCount = 3;
+    const perDay = divideAmountForRangedSplit(amount, rangedDayCount);
+    const { result } = renderSplitEditor({
+      initialSplitList,
+      initialSplitType: "EXACT",
+      amount,
+      duplOrSplit: 2,
+      isEditing: true,
+      rangedDayCount,
+    });
+
+    act(() => {
+      result.current.autoExpenseLinearSplitAdjust("amount", String(perDay));
+    });
+
+    const expectedList = recalcSplitsWithEditOrder(initialSplitList, perDay);
+    expect(result.current.splitList).toEqual(expectedList);
+    expect(result.current.splitListValid).toBe(
+      Boolean(
+        validateSplitList(expectedList, "EXACT", perDay) &&
+          validateSplitListWithEditOrder(expectedList, perDay)
+      )
+    );
   });
 
   it("splitHandler recalculates splits and fires light impact haptics", () => {

--- a/TravelCostApp/__tests__/hooks/use-split-editor.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-split-editor.test.ts
@@ -1,0 +1,138 @@
+import { act, renderHook } from "@testing-library/react-native";
+import * as Haptics from "expo-haptics";
+
+import { useSplitEditor } from "../../hooks/useSplitEditor";
+import type { Split } from "../../util/expense";
+import { applySplitEdit, resetEditOrder, type splitType } from "../../util/split";
+import { trackEvent } from "../../util/vexo-tracking";
+import { VexoEvents } from "../../util/vexo-constants";
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  notificationAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+  NotificationFeedbackType: { Success: "Success" },
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+function makeSplit(overrides: Partial<Split> & Pick<Split, "userName">): Split {
+  return {
+    userName: overrides.userName,
+    amount: overrides.amount ?? 0,
+    editOrder: overrides.editOrder,
+  };
+}
+
+function renderSplitEditor(
+  overrides: Partial<Parameters<typeof useSplitEditor>[0]> = {}
+) {
+  return renderHook(() =>
+    useSplitEditor({
+      initialSplitList: [
+        makeSplit({ userName: "A", amount: 30, editOrder: 0 }),
+        makeSplit({ userName: "B", amount: 20, editOrder: 1 }),
+        makeSplit({ userName: "C", amount: 50 }),
+      ],
+      initialSplitType: "EXACT",
+      initialSplitTravellersList: ["A", "B", "C"],
+      amount: 100,
+      whoPaid: "Payer",
+      tripTravellerNames: ["A", "B", "C"],
+      onAutosave: jest.fn(),
+      ...overrides,
+    })
+  );
+}
+
+describe("useSplitEditor", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates splitList and splitListValid when a split amount is edited", () => {
+    const initialSplitList = resetEditOrder([
+      makeSplit({ userName: "A", amount: 30, editOrder: 0 }),
+      makeSplit({ userName: "B", amount: 20, editOrder: 1 }),
+      makeSplit({ userName: "C", amount: 50 }),
+    ]);
+    const { splitList: expectedList, valid } = applySplitEdit(
+      initialSplitList,
+      0,
+      "A",
+      "40",
+      100,
+      "EXACT"
+    );
+    const { result } = renderSplitEditor({ initialSplitList });
+
+    act(() => {
+      result.current.inputSplitListHandler(0, { userName: "A" }, "40");
+    });
+
+    expect(result.current.splitList).toEqual(expectedList);
+    expect(result.current.splitListValid).toBe(valid);
+  });
+
+  it("removes a traveller from the split list and fires success haptics", () => {
+    const { result } = renderSplitEditor({
+      initialSplitList: [
+        makeSplit({ userName: "A", amount: 40, editOrder: 0 }),
+        makeSplit({ userName: "B", amount: 60, editOrder: 1 }),
+      ],
+      amount: 40,
+    });
+
+    act(() => {
+      result.current.removeUserFromSplit("B");
+    });
+
+    expect(result.current.splitList).toEqual([
+      makeSplit({ userName: "A", amount: 40 }),
+    ]);
+    expect(result.current.splitType).toBe("EXACT");
+    expect(result.current.splitListValid).toBe(true);
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+      Haptics.NotificationFeedbackType.Success
+    );
+  });
+
+  it("setSplitType updates split type, tracks analytics, and autosaves", () => {
+    const onAutosave = jest.fn();
+    const { result } = renderSplitEditor({ onAutosave });
+
+    act(() => {
+      result.current.setSplitType("EQUAL" as splitType);
+    });
+
+    expect(result.current.splitType).toBe("EQUAL");
+    expect(trackEvent).toHaveBeenCalledWith(VexoEvents.SPLIT_TYPE_SELECTED, {
+      splitType: "EQUAL",
+    });
+    expect(onAutosave).toHaveBeenCalled();
+  });
+
+  it("splitHandler recalculates splits and fires light impact haptics", () => {
+    const { result } = renderSplitEditor({
+      initialSplitList: [],
+      initialSplitType: "SELF",
+      initialSplitTravellersList: ["A", "B"],
+      amount: 100,
+      whoPaid: "Payer",
+    });
+
+    act(() => {
+      result.current.splitHandler("EQUAL");
+    });
+
+    expect(result.current.splitList).toEqual([
+      makeSplit({ userName: "A", amount: 50 }),
+      makeSplit({ userName: "B", amount: 50 }),
+    ]);
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(
+      Haptics.ImpactFeedbackStyle.Light
+    );
+  });
+});

--- a/TravelCostApp/hooks/useSplitEditor.ts
+++ b/TravelCostApp/hooks/useSplitEditor.ts
@@ -51,14 +51,15 @@ export function useSplitEditor({
     resetEditOrder(initialSplitList)
   );
   const [splitListValid, setSplitListValid] = useState(true);
-  const [splitType, setSplitTypeState] = useState<splitType>(initialSplitType);
+  const [currentSplitType, setSplitTypeState] =
+    useState<splitType>(initialSplitType);
   const [splitTravellersList, setSplitTravellersList] = useState(
     initialSplitTravellersList
   );
 
   const inputSplitListHandler = useCallback(
     (index: number, props: { userName: string }, value: string) => {
-      if (splitType === SPLIT_TYPES.EQUAL) {
+      if (currentSplitType === SPLIT_TYPES.EQUAL) {
         return;
       }
       const { splitList: nextList, valid } = applySplitEdit(
@@ -67,12 +68,12 @@ export function useSplitEditor({
         props.userName,
         value,
         amount,
-        splitType
+        currentSplitType
       );
       setSplitList(nextList);
       setSplitListValid(valid);
     },
-    [amount, splitList, splitType]
+    [amount, currentSplitType, splitList]
   );
 
   const splitHandler = useCallback(
@@ -109,7 +110,7 @@ export function useSplitEditor({
         splitList,
         userName,
         whoPaid ?? "",
-        splitType,
+        currentSplitType,
         amount,
         tripTravellerNames
       );
@@ -117,7 +118,7 @@ export function useSplitEditor({
         return;
       }
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      if (result.splitType !== splitType) {
+      if (result.splitType !== currentSplitType) {
         setSplitTypeState(result.splitType);
       }
       setSplitList(result.splitList);
@@ -125,14 +126,15 @@ export function useSplitEditor({
         setSplitListValid(result.valid);
       }
     },
-    [amount, splitList, splitType, tripTravellerNames, whoPaid]
+    [amount, currentSplitType, splitList, tripTravellerNames, whoPaid]
   );
 
   const autoExpenseLinearSplitAdjust = useCallback(
     (inputIdentifier: string, value: string) => {
       if (
         inputIdentifier !== "amount" ||
-        (splitType !== SPLIT_TYPES.EXACT && splitType !== SPLIT_TYPES.EQUAL)
+        (currentSplitType !== SPLIT_TYPES.EXACT &&
+          currentSplitType !== SPLIT_TYPES.EQUAL)
       ) {
         return;
       }
@@ -144,7 +146,7 @@ export function useSplitEditor({
         setSplitList(rangedList);
         setSplitListValid(
           Boolean(
-            validateSplitList(rangedList, splitType, amount) &&
+            validateSplitList(rangedList, currentSplitType, amount) &&
               validateSplitListWithEditOrder(rangedList, amount)
           )
         );
@@ -154,26 +156,27 @@ export function useSplitEditor({
       setSplitList(nextList);
       setSplitListValid(
         Boolean(
-          validateSplitList(nextList, splitType, numericValue) &&
+          validateSplitList(nextList, currentSplitType, numericValue) &&
             validateSplitListWithEditOrder(nextList, numericValue)
         )
       );
     },
     [
       amount,
+      currentSplitType,
       duplOrSplit,
       isEditing,
       rangedDayCount,
       splitList,
-      splitType,
     ]
   );
 
   return {
     splitList,
-    splitType,
+    splitType: currentSplitType,
     splitListValid,
     splitTravellersList,
+    setSplitTravellersList,
     inputSplitListHandler,
     removeUserFromSplit,
     splitHandler,

--- a/TravelCostApp/hooks/useSplitEditor.ts
+++ b/TravelCostApp/hooks/useSplitEditor.ts
@@ -1,0 +1,183 @@
+import { useCallback, useState } from "react";
+import * as Haptics from "expo-haptics";
+
+import type { Split } from "../util/expense";
+import { divideAmountForRangedSplit } from "../util/expense-form-range";
+import {
+  applySplitEdit,
+  calcSplitList,
+  recalcSplitsWithEditOrder,
+  removeFromSplit,
+  resetEditOrder,
+  splitType,
+  validateSplitList,
+  validateSplitListWithEditOrder,
+} from "../util/split";
+import { VexoEvents } from "../util/vexo-constants";
+import { trackEvent } from "../util/vexo-tracking";
+
+const SPLIT_TYPES = {
+  EQUAL: "EQUAL",
+  EXACT: "EXACT",
+  SELF: "SELF",
+} as const satisfies Record<string, splitType>;
+
+export type UseSplitEditorOptions = {
+  initialSplitList?: Split[];
+  initialSplitType?: splitType;
+  initialSplitTravellersList?: string[];
+  amount: number;
+  whoPaid: string | null;
+  tripTravellerNames: string[];
+  onAutosave?: () => void;
+  duplOrSplit?: number;
+  isEditing?: boolean;
+  rangedDayCount?: number;
+};
+
+export function useSplitEditor({
+  initialSplitList = [],
+  initialSplitType = "SELF",
+  initialSplitTravellersList = [],
+  amount,
+  whoPaid,
+  tripTravellerNames,
+  onAutosave,
+  duplOrSplit = 0,
+  isEditing = false,
+  rangedDayCount = 1,
+}: UseSplitEditorOptions) {
+  const [splitList, setSplitList] = useState(() =>
+    resetEditOrder(initialSplitList)
+  );
+  const [splitListValid, setSplitListValid] = useState(true);
+  const [splitType, setSplitTypeState] = useState<splitType>(initialSplitType);
+  const [splitTravellersList, setSplitTravellersList] = useState(
+    initialSplitTravellersList
+  );
+
+  const inputSplitListHandler = useCallback(
+    (index: number, props: { userName: string }, value: string) => {
+      if (splitType === SPLIT_TYPES.EQUAL) {
+        return;
+      }
+      const { splitList: nextList, valid } = applySplitEdit(
+        splitList,
+        index,
+        props.userName,
+        value,
+        amount,
+        splitType
+      );
+      setSplitList(nextList);
+      setSplitListValid(valid);
+    },
+    [amount, splitList, splitType]
+  );
+
+  const splitHandler = useCallback(
+    (selectedSplitType: splitType) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      const listSplits = calcSplitList(
+        selectedSplitType,
+        amount,
+        whoPaid ?? "",
+        splitTravellersList
+      );
+      if (listSplits) {
+        setSplitList(resetEditOrder(listSplits));
+      }
+    },
+    [amount, splitTravellersList, whoPaid]
+  );
+
+  const setSplitType = useCallback(
+    (value: splitType) => {
+      setSplitTypeState(value);
+      trackEvent(VexoEvents.SPLIT_TYPE_SELECTED, { splitType: value });
+      onAutosave?.();
+    },
+    [onAutosave]
+  );
+
+  const removeUserFromSplit = useCallback(
+    (userName: string) => {
+      if (!splitList || splitList.length < 1) {
+        return;
+      }
+      const result = removeFromSplit(
+        splitList,
+        userName,
+        whoPaid ?? "",
+        splitType,
+        amount,
+        tripTravellerNames
+      );
+      if (!result) {
+        return;
+      }
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      if (result.splitType !== splitType) {
+        setSplitTypeState(result.splitType);
+      }
+      setSplitList(result.splitList);
+      if (result.valid !== undefined) {
+        setSplitListValid(result.valid);
+      }
+    },
+    [amount, splitList, splitType, tripTravellerNames, whoPaid]
+  );
+
+  const autoExpenseLinearSplitAdjust = useCallback(
+    (inputIdentifier: string, value: string) => {
+      if (
+        inputIdentifier !== "amount" ||
+        (splitType !== SPLIT_TYPES.EXACT && splitType !== SPLIT_TYPES.EQUAL)
+      ) {
+        return;
+      }
+      if (duplOrSplit === 2 && isEditing) {
+        const rangedList = recalcSplitsWithEditOrder(
+          splitList,
+          divideAmountForRangedSplit(amount, rangedDayCount)
+        );
+        setSplitList(rangedList);
+        setSplitListValid(
+          Boolean(
+            validateSplitList(rangedList, splitType, amount) &&
+              validateSplitListWithEditOrder(rangedList, amount)
+          )
+        );
+      }
+      const numericValue = +value;
+      const nextList = recalcSplitsWithEditOrder(splitList, numericValue);
+      setSplitList(nextList);
+      setSplitListValid(
+        Boolean(
+          validateSplitList(nextList, splitType, numericValue) &&
+            validateSplitListWithEditOrder(nextList, numericValue)
+        )
+      );
+    },
+    [
+      amount,
+      duplOrSplit,
+      isEditing,
+      rangedDayCount,
+      splitList,
+      splitType,
+    ]
+  );
+
+  return {
+    splitList,
+    splitType,
+    splitListValid,
+    splitTravellersList,
+    inputSplitListHandler,
+    removeUserFromSplit,
+    splitHandler,
+    autoExpenseLinearSplitAdjust,
+    setSplitType,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `useSplitEditor` in `hooks/` to own split editing state (`splitList`, `splitType`, `splitListValid`, `splitTravellersList`) and handlers.
- Delegate all split decisions to `util/split` pure functions (`applySplitEdit`, `removeFromSplit`, `calcSplitList`, recalc/validate); side effects limited to haptics, analytics, and optional autosave.
- Add `renderHook` tests for edit, remove, split-type change, and `splitHandler`. ExpenseForm is not wired yet.

## Test plan
- [x] `pnpm test __tests__/hooks/use-split-editor.test.ts`

Closes #277