### PR TITLE
ExpenseForm: useExpenseFx + useExpenseFormInputs + useCategoryAutomap hooks

### DIFF
--- a/TravelCostApp/__tests__/hooks/use-category-automap.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-category-automap.test.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useCategoryAutomap } from "../../hooks/useCategoryAutomap";
+import { makeExpense } from "../fixtures/expense";
+
+describe("useCategoryAutomap", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("debounces description automap and applies category via callback", () => {
+    const onApplyCategory = jest.fn();
+    const mapDescription = jest.fn(() => "food");
+    const getIconForCategory = jest.fn(() => "food-icon");
+
+    const { result } = renderHook(() =>
+      useCategoryAutomap({
+        pickedCat: "undefined",
+        categories: [],
+        recentExpenses: [makeExpense({ description: "coffee", category: "food" })],
+        onApplyCategory,
+        mapDescription,
+        getIconForCategory,
+      })
+    );
+
+    act(() => {
+      result.current.debouncedAutoCategory("description", "coffee shop");
+    });
+
+    expect(mapDescription).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(mapDescription).toHaveBeenCalledWith(
+      "coffee shop",
+      [],
+      expect.any(Array)
+    );
+    expect(onApplyCategory).toHaveBeenCalled();
+    expect(getIconForCategory).toHaveBeenCalledWith("food");
+    expect(result.current.icon).toBe("food-icon");
+  });
+
+  it("updateCategoryAndIcon applies category fields and icon immediately", () => {
+    const onApplyCategory = jest.fn();
+    const getIconForCategory = jest.fn(() => "transport-icon");
+
+    const { result } = renderHook(() =>
+      useCategoryAutomap({
+        pickedCat: "undefined",
+        categories: [],
+        recentExpenses: [],
+        onApplyCategory,
+        getIconForCategory,
+      })
+    );
+
+    act(() => {
+      result.current.updateCategoryAndIcon("transport", {
+        description: "",
+        category: "undefined",
+      });
+    });
+
+    expect(onApplyCategory).toHaveBeenCalledWith(
+      expect.objectContaining({ category: "transport" })
+    );
+    expect(result.current.icon).toBe("transport-icon");
+  });
+});

--- a/TravelCostApp/__tests__/hooks/use-expense-form-inputs.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-expense-form-inputs.test.ts
@@ -1,7 +1,9 @@
 import { act, renderHook } from "@testing-library/react-native";
 
 import { useExpenseFormInputs } from "../../hooks/useExpenseFormInputs";
+import { validateExpenseData } from "../../util/expense-form-submit";
 import type { ExpenseFormInputsState } from "../../util/expense-form-inputs";
+import { makeExpense } from "../fixtures/expense";
 
 function makeInitialInputs(): ExpenseFormInputsState {
   return {
@@ -49,20 +51,15 @@ describe("useExpenseFormInputs", () => {
   });
 
   it("applies field validity flags from validateExpenseData", () => {
+    const { fieldValidity } = validateExpenseData(
+      makeExpense({ amount: 0, description: "   " })
+    );
     const { result } = renderHook(() =>
       useExpenseFormInputs({ initialInputs: makeInitialInputs() })
     );
 
     act(() => {
-      result.current.applyFieldValidity({
-        amount: false,
-        date: true,
-        description: false,
-        whoPaid: true,
-        category: true,
-        country: true,
-        currency: true,
-      });
+      result.current.applyFieldValidity(fieldValidity);
     });
 
     expect(result.current.inputs.amount.isValid).toBe(false);

--- a/TravelCostApp/__tests__/hooks/use-expense-form-inputs.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-expense-form-inputs.test.ts
@@ -1,0 +1,72 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useExpenseFormInputs } from "../../hooks/useExpenseFormInputs";
+import type { ExpenseFormInputsState } from "../../util/expense-form-inputs";
+
+function makeInitialInputs(): ExpenseFormInputsState {
+  return {
+    amount: { value: "10", isValid: true },
+    date: { value: "2026-01-15", isValid: true },
+    description: { value: "coffee", isValid: true },
+    category: { value: "food", isValid: true },
+    country: { value: "US", isValid: true },
+    currency: { value: "EUR", isValid: true },
+    whoPaid: { value: "alice", isValid: true },
+  };
+}
+
+describe("useExpenseFormInputs", () => {
+  it("updates a field via inputChangedHandler and resets validity", () => {
+    const onInputChange = jest.fn();
+    const { result } = renderHook(() =>
+      useExpenseFormInputs({
+        initialInputs: makeInitialInputs(),
+        onInputChange,
+      })
+    );
+
+    act(() => {
+      result.current.inputChangedHandler("description", "lunch");
+    });
+
+    expect(result.current.inputs.description).toEqual({
+      value: "lunch",
+      isValid: true,
+    });
+    expect(onInputChange).toHaveBeenCalledWith("description", "lunch");
+  });
+
+  it("derives amountValue from amount input and temp amount", () => {
+    const { result } = renderHook(() =>
+      useExpenseFormInputs({ initialInputs: makeInitialInputs() })
+    );
+
+    act(() => {
+      result.current.setTempAmount("5");
+    });
+
+    expect(result.current.amountValue).toBe(15);
+  });
+
+  it("applies field validity flags from validateExpenseData", () => {
+    const { result } = renderHook(() =>
+      useExpenseFormInputs({ initialInputs: makeInitialInputs() })
+    );
+
+    act(() => {
+      result.current.applyFieldValidity({
+        amount: false,
+        date: true,
+        description: false,
+        whoPaid: true,
+        category: true,
+        country: true,
+        currency: true,
+      });
+    });
+
+    expect(result.current.inputs.amount.isValid).toBe(false);
+    expect(result.current.inputs.description.isValid).toBe(false);
+    expect(result.current.inputs.amount.value).toBe("10");
+  });
+});

--- a/TravelCostApp/__tests__/hooks/use-expense-fx.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-expense-fx.test.ts
@@ -1,0 +1,90 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+
+import { useExpenseFx } from "../../hooks/useExpenseFx";
+import type { Split } from "../../util/expense";
+
+function makeSplit(overrides: Partial<Split> & Pick<Split, "userName">): Split {
+  return {
+    userName: overrides.userName,
+    amount: overrides.amount ?? 50,
+    rate: overrides.rate,
+  };
+}
+
+describe("useExpenseFx", () => {
+  it("computes trip-currency calcAmount when expense currency differs", async () => {
+    const getRate = jest.fn(async () => 2);
+    const { result } = renderHook(() =>
+      useExpenseFx({
+        tripCurrency: "USD",
+        expenseCurrency: "EUR",
+        amountValue: 100,
+        splitList: [],
+        getRate,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.calcAmount).toBe("50.00");
+    });
+    expect(getRate).toHaveBeenCalledWith("USD", "EUR");
+  });
+
+  it("clears converted amounts when rate is unavailable or trip currency matches", async () => {
+    const getRateUnavailable = jest.fn(async () => -1);
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useExpenseFx>[0]) => useExpenseFx(props),
+      {
+        initialProps: {
+          tripCurrency: "USD",
+          expenseCurrency: "EUR",
+          amountValue: 100,
+          splitList: [],
+          getRate: getRateUnavailable,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.calcAmount).toBe("");
+      expect(result.current.splitListCalcAmounts).toEqual([""]);
+    });
+
+    rerender({
+      tripCurrency: "USD",
+      expenseCurrency: "USD",
+      amountValue: 100,
+      splitList: [],
+      getRate: jest.fn(async () => 1),
+    });
+
+    await waitFor(() => {
+      expect(result.current.calcAmount).toBe("");
+    });
+  });
+
+  it("mutates split.rate in place and exposes per-split converted amounts", async () => {
+    const splitList = [
+      makeSplit({ userName: "A", amount: 100 }),
+      makeSplit({ userName: "B", amount: 50 }),
+    ];
+    const getRate = jest.fn(async () => 2);
+
+    const { result } = renderHook(() =>
+      useExpenseFx({
+        tripCurrency: "USD",
+        expenseCurrency: "EUR",
+        amountValue: 100,
+        splitList,
+        getRate,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.splitListCalcAmounts).toEqual(["50.00", "25.00"]);
+    });
+
+    expect(splitList[0].rate).toBe(2);
+    expect(splitList[1].rate).toBe(2);
+  });
+});

--- a/TravelCostApp/__tests__/util/expense-form-category.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-category.test.ts
@@ -1,0 +1,37 @@
+import {
+  deriveCategoryFieldsOnAutomap,
+  shouldAutomapCategory,
+} from "../../util/expense-form-category";
+
+describe("shouldAutomapCategory", () => {
+  it("runs only for description when picked category is undefined", () => {
+    expect(shouldAutomapCategory("description", "undefined")).toBe(true);
+    expect(shouldAutomapCategory("amount", "undefined")).toBe(false);
+    expect(shouldAutomapCategory("description", "food")).toBe(false);
+  });
+});
+
+describe("deriveCategoryFieldsOnAutomap", () => {
+  it("fills localized description when category changes from empty description", () => {
+    const patch = deriveCategoryFieldsOnAutomap(
+      { description: "", category: "undefined" },
+      "food"
+    );
+
+    expect(patch.category).toBe("food");
+    expect(patch.description).toBeTruthy();
+    expect(patch.description).not.toBe("");
+  });
+
+  it("keeps existing description when category already set", () => {
+    const patch = deriveCategoryFieldsOnAutomap(
+      { description: "my note", category: "transport" },
+      "food"
+    );
+
+    expect(patch).toEqual({
+      category: "food",
+      description: "my note",
+    });
+  });
+});

--- a/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
@@ -1,0 +1,65 @@
+import {
+  applyFieldValidityToInputs,
+  resolveAmountValue,
+} from "../../util/expense-form-inputs";
+import type { ExpenseFormInputsState } from "../../util/expense-form-inputs";
+
+function makeInputs(
+  overrides: Partial<{
+    amount: string;
+    date: string;
+    description: string;
+    category: string;
+    country: string;
+    currency: string;
+    whoPaid: string;
+  }> = {}
+): ExpenseFormInputsState {
+  return {
+    amount: { value: overrides.amount ?? "", isValid: true },
+    date: { value: overrides.date ?? "2026-01-15", isValid: true },
+    description: { value: overrides.description ?? "", isValid: true },
+    category: { value: overrides.category ?? "food", isValid: true },
+    country: { value: overrides.country ?? "US", isValid: true },
+    currency: { value: overrides.currency ?? "USD", isValid: true },
+    whoPaid: { value: overrides.whoPaid ?? "alice", isValid: true },
+  };
+}
+
+describe("resolveAmountValue", () => {
+  it("sums amount input and temp amount when both are set", () => {
+    expect(resolveAmountValue("10", "5")).toBe(15);
+  });
+
+  it("uses amount input when temp amount is empty", () => {
+    expect(resolveAmountValue("42", "")).toBe("42");
+  });
+
+  it("uses temp amount when amount input is empty", () => {
+    expect(resolveAmountValue("", "7")).toBe("7");
+  });
+});
+
+describe("applyFieldValidityToInputs", () => {
+  it("updates isValid flags from field validity without changing values", () => {
+    const inputs = makeInputs({
+      amount: "0",
+      description: "   ",
+    });
+
+    const next = applyFieldValidityToInputs(inputs, {
+      amount: false,
+      date: true,
+      description: false,
+      whoPaid: true,
+      category: true,
+      country: true,
+      currency: true,
+    });
+
+    expect(next.amount).toEqual({ value: "0", isValid: false });
+    expect(next.description).toEqual({ value: "   ", isValid: false });
+    expect(next.date.value).toBe("2026-01-15");
+    expect(next.date.isValid).toBe(true);
+  });
+});

--- a/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
@@ -38,6 +38,10 @@ describe("resolveAmountValue", () => {
   it("uses temp amount when amount input is empty", () => {
     expect(resolveAmountValue("", "7")).toBe("7");
   });
+
+  it("returns empty string when both amount input and temp amount are empty", () => {
+    expect(resolveAmountValue("", "")).toBe("");
+  });
 });
 
 describe("applyFieldValidityToInputs", () => {

--- a/TravelCostApp/hooks/useCategoryAutomap.ts
+++ b/TravelCostApp/hooks/useCategoryAutomap.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { callDebounced } from "../components/Hooks/useDebounce";
+import {
+  DEFAULTCATEGORIES,
+  getCatSymbolMMKV,
+  mapDescriptionToCategory,
+  type Category,
+} from "../util/category";
+import {
+  deriveCategoryFieldsOnAutomap,
+  shouldAutomapCategory,
+} from "../util/expense-form-category";
+import type { ExpenseData } from "../util/expense";
+
+export type UseCategoryAutomapOptions = {
+  pickedCat: string;
+  categories?: Category[];
+  recentExpenses: ExpenseData[];
+  onApplyCategory: (fields: {
+    category: string;
+    description: string;
+  }) => void;
+  initialIcon?: string;
+  mapDescription?: typeof mapDescriptionToCategory;
+  getIconForCategory?: (category: string) => string;
+  debounceMs?: number;
+};
+
+export function useCategoryAutomap({
+  pickedCat,
+  categories = DEFAULTCATEGORIES,
+  recentExpenses,
+  onApplyCategory,
+  initialIcon = "",
+  mapDescription = mapDescriptionToCategory,
+  getIconForCategory = getCatSymbolMMKV,
+  debounceMs = 250,
+}: UseCategoryAutomapOptions) {
+  const [icon, setIcon] = useState(initialIcon);
+
+  const updateCategoryAndIcon = useCallback(
+    (
+      categoryValue: string,
+      prevFields: { description: string; category: string }
+    ) => {
+      setIcon(getIconForCategory(categoryValue));
+      onApplyCategory(deriveCategoryFieldsOnAutomap(prevFields, categoryValue));
+    },
+    [getIconForCategory, onApplyCategory]
+  );
+
+  const autoCategory = useCallback(
+    (inputIdentifier: string, enteredValue: string) => {
+      if (!shouldAutomapCategory(inputIdentifier, pickedCat)) {
+        return;
+      }
+      const mappedCategory = mapDescription(
+        enteredValue,
+        categories,
+        recentExpenses
+      );
+      if (mappedCategory) {
+        updateCategoryAndIcon(mappedCategory, {
+          description: enteredValue,
+          category: pickedCat,
+        });
+      }
+    },
+    [
+      categories,
+      mapDescription,
+      pickedCat,
+      recentExpenses,
+      updateCategoryAndIcon,
+    ]
+  );
+
+  const autoCategoryRef = useRef(autoCategory);
+  useEffect(() => {
+    autoCategoryRef.current = autoCategory;
+  }, [autoCategory]);
+
+  const debouncedAutoCategory = useMemo(
+    () =>
+      callDebounced((inputIdentifier: string, enteredValue: string) => {
+        autoCategoryRef.current(inputIdentifier, enteredValue);
+      }, debounceMs),
+    [debounceMs]
+  );
+
+  return {
+    icon,
+    setIcon,
+    updateCategoryAndIcon,
+    debouncedAutoCategory,
+  };
+}

--- a/TravelCostApp/hooks/useExpenseFormInputs.ts
+++ b/TravelCostApp/hooks/useExpenseFormInputs.ts
@@ -1,0 +1,51 @@
+import { useCallback, useMemo, useState } from "react";
+
+import {
+  applyFieldValidityToInputs,
+  resolveAmountValue,
+  type ExpenseFormInputsState,
+} from "../util/expense-form-inputs";
+import type { ExpenseFieldValidity } from "../util/expense-form-submit";
+
+export type UseExpenseFormInputsOptions = {
+  initialInputs: ExpenseFormInputsState;
+  onInputChange?: (inputIdentifier: string, enteredValue: string) => void;
+};
+
+export function useExpenseFormInputs({
+  initialInputs,
+  onInputChange,
+}: UseExpenseFormInputsOptions) {
+  const [inputs, setInputs] = useState(initialInputs);
+  const [tempAmount, setTempAmount] = useState("");
+
+  const amountValue = useMemo(
+    () => resolveAmountValue(inputs.amount.value, tempAmount),
+    [inputs.amount.value, tempAmount]
+  );
+
+  const inputChangedHandler = useCallback(
+    (inputIdentifier: string, enteredValue: string) => {
+      setInputs((curInputs) => ({
+        ...curInputs,
+        [inputIdentifier]: { value: enteredValue, isValid: true },
+      }));
+      onInputChange?.(inputIdentifier, enteredValue);
+    },
+    [onInputChange]
+  );
+
+  const applyFieldValidity = useCallback((fieldValidity: ExpenseFieldValidity) => {
+    setInputs((curInputs) => applyFieldValidityToInputs(curInputs, fieldValidity));
+  }, []);
+
+  return {
+    inputs,
+    setInputs,
+    tempAmount,
+    setTempAmount,
+    amountValue,
+    inputChangedHandler,
+    applyFieldValidity,
+  };
+}

--- a/TravelCostApp/hooks/useExpenseFx.ts
+++ b/TravelCostApp/hooks/useExpenseFx.ts
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { getRate } from "../util/currencyExchange";
+import type { Split } from "../util/expense";
+
+export type GetRateFn = (
+  base: string,
+  target: string
+) => Promise<number>;
+
+export type UseExpenseFxOptions = {
+  tripCurrency: string;
+  expenseCurrency: string;
+  amountValue: string | number;
+  splitList: Split[];
+  getRate?: GetRateFn;
+};
+
+export function useExpenseFx({
+  tripCurrency,
+  expenseCurrency,
+  amountValue,
+  splitList,
+  getRate: getRateFn = getRate,
+}: UseExpenseFxOptions) {
+  const [calcAmount, setCalcAmount] = useState("");
+  const [splitListCalcAmounts, setSplitListCalcAmounts] = useState([""]);
+
+  const hasCalcAmount = Boolean(
+    amountValue &&
+      expenseCurrency &&
+      expenseCurrency !== tripCurrency
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function runFxConversion() {
+      const rate = await getRateFn(tripCurrency, expenseCurrency);
+      if (cancelled) {
+        return;
+      }
+
+      const convertedAmount = +amountValue / rate;
+      const splitConvertedAmounts: string[] = [];
+
+      if (splitList?.length > 0) {
+        splitList.forEach((split) => {
+          split.rate = rate;
+          splitConvertedAmounts.push((split.amount / split.rate).toFixed(2));
+        });
+      }
+
+      if (!hasCalcAmount || rate === -1 || rate === 1) {
+        setCalcAmount("");
+        setSplitListCalcAmounts([""]);
+        return;
+      }
+
+      setSplitListCalcAmounts(splitConvertedAmounts);
+      setCalcAmount(convertedAmount.toFixed(2));
+    }
+
+    runFxConversion();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    amountValue,
+    expenseCurrency,
+    getRateFn,
+    hasCalcAmount,
+    splitList,
+    tripCurrency,
+  ]);
+
+  return useMemo(
+    () => ({
+      calcAmount,
+      splitListCalcAmounts,
+      hasCalcAmount,
+    }),
+    [calcAmount, hasCalcAmount, splitListCalcAmounts]
+  );
+}

--- a/TravelCostApp/util/expense-form-category.ts
+++ b/TravelCostApp/util/expense-form-category.ts
@@ -1,0 +1,26 @@
+import { getCatLocalized } from "./category";
+
+export function shouldAutomapCategory(
+  inputIdentifier: string,
+  pickedCat: string
+): boolean {
+  return inputIdentifier === "description" && pickedCat === "undefined";
+}
+
+export function deriveCategoryFieldsOnAutomap(
+  prev: { description: string; category: string },
+  categoryValue: string
+): { category: string; description: string } {
+  const canSetNewDescription =
+    categoryValue !== "undefined" &&
+    prev.description === "" &&
+    prev.category !== categoryValue;
+  const description = canSetNewDescription
+    ? getCatLocalized(categoryValue)
+    : prev.description || "";
+
+  return {
+    category: categoryValue,
+    description,
+  };
+}

--- a/TravelCostApp/util/expense-form-inputs.ts
+++ b/TravelCostApp/util/expense-form-inputs.ts
@@ -1,0 +1,52 @@
+import type { ExpenseFieldValidity } from "./expense-form-submit";
+
+export type ExpenseFormInputField = {
+  value: string;
+  isValid: boolean;
+};
+
+export type ExpenseFormInputsState = {
+  amount: ExpenseFormInputField;
+  date: ExpenseFormInputField;
+  description: ExpenseFormInputField;
+  category: ExpenseFormInputField;
+  country: ExpenseFormInputField;
+  currency: ExpenseFormInputField;
+  whoPaid: ExpenseFormInputField;
+};
+
+/** Quick-sum amount: main field + keypad temp, matching ExpenseForm derivation. */
+export function resolveAmountValue(
+  inputsAmount: string,
+  tempAmount: string
+): string | number {
+  const hasTempAndInput = !!(inputsAmount && tempAmount);
+  if (hasTempAndInput) {
+    return +inputsAmount + +tempAmount;
+  }
+  return inputsAmount.length > 0 ? inputsAmount : tempAmount;
+}
+
+export function applyFieldValidityToInputs(
+  inputs: ExpenseFormInputsState,
+  fieldValidity: ExpenseFieldValidity
+): ExpenseFormInputsState {
+  return {
+    amount: { value: inputs.amount.value, isValid: fieldValidity.amount },
+    date: { value: inputs.date.value, isValid: fieldValidity.date },
+    description: {
+      value: inputs.description.value,
+      isValid: fieldValidity.description,
+    },
+    category: {
+      value: inputs.category.value,
+      isValid: fieldValidity.category,
+    },
+    country: { value: inputs.country.value, isValid: fieldValidity.country },
+    currency: {
+      value: inputs.currency.value,
+      isValid: fieldValidity.currency,
+    },
+    whoPaid: { value: inputs.whoPaid.value, isValid: fieldValidity.whoPaid },
+  };
+}


### PR DESCRIPTION
## Summary
- Extract `useExpenseFormInputs`, `useExpenseFx`, and `useCategoryAutomap` into `hooks/` with pure helpers in `util/`.
- Preserve current behavior, including in-place `split.rate` mutation in `useExpenseFx`.
- Add `renderHook` and pure-core tests; `ExpenseForm` is not wired yet (follow-up in #270).

## Test plan
- [x] `pnpm test` in `TravelCostApp/`
- [ ] CI green

Closes #278