### PR TITLE
Fix ExpenseForm util TypeScript types (#270)

### DIFF
--- a/TravelCostApp/__tests__/util/expense-form-draft.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-draft.test.ts
@@ -122,6 +122,21 @@ describe("draft round-trip", () => {
       dateFromIso(snapshot.dateIso).toISOString()
     );
   });
+
+  it("restores dates after MMKV-style JSON round-trip (ISO strings)", () => {
+    const draft = toExpenseDraft(makeExpenseFormSnapshot());
+    const fromStorage = JSON.parse(
+      JSON.stringify(draft)
+    ) as typeof draft;
+
+    const restored = applyDraftToForm(fromStorage);
+
+    expect(restored.inputs?.date?.value).toBe(
+      dateFromIso("2026-01-15").toISOString()
+    );
+    expect(restored.startDate).toBe(dateFromIso("2026-01-15").toISOString());
+    expect(restored.endDate).toBe(dateFromIso("2026-01-16").toISOString());
+  });
 });
 
 describe("summarizeDraftChanges", () => {

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -58,6 +58,7 @@ import {
   buildFastExpenseData,
   validateExpenseData,
   type ExpenseFormSnapshot,
+  type ExpenseFormSubmitPayload,
 } from "../../util/expense-form-submit";
 import type { ExpenseFormInputsState } from "../../util/expense-form-inputs";
 import {
@@ -150,7 +151,7 @@ const splitTypes: { [key: string]: splitType } & {
 
 export type ExpenseFormProps = {
   onCancel: () => void;
-  onSubmit: (expenseData: ExpenseData) => Promise<void>;
+  onSubmit: (expenseData: ExpenseFormSubmitPayload) => Promise<void>;
   submitButtonLabel: string;
   isEditing: boolean;
   defaultValues: ExpenseData;

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -29,6 +29,7 @@ import {
   ExpenseData,
   Split,
 } from "../util/expense";
+import type { ExpenseFormSubmitPayload } from "../util/expense-form-submit";
 import { NetworkContext } from "../store/network-context";
 import { Toast } from "react-native-toast-message/lib/src/Toast";
 import * as Haptics from "expo-haptics";
@@ -427,7 +428,9 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
     }
   };
 
-  async function confirmHandler(expenseData: ExpenseData): Promise<void> {
+  async function confirmHandler(payload: ExpenseFormSubmitPayload): Promise<void> {
+    // Fast submit omits categoryString/calcAmount; this handler completes the shape.
+    const expenseData = payload as ExpenseData;
     try {
       // set the category to the corresponting catstring
       expenseData.categoryString = getCatLocalized(expenseData.category);

--- a/TravelCostApp/util/expense-form-draft.ts
+++ b/TravelCostApp/util/expense-form-draft.ts
@@ -64,16 +64,10 @@ export function toExpenseDraft(
 }
 
 function convertToISOString(dateValue: DateOrDateTime): string {
-  if (typeof dateValue === "string") {
-    return dateValue;
-  }
   if (dateValue instanceof Date) {
     return dateValue.toISOString();
   }
-  if (dateValue && typeof (dateValue as { toJSDate?: () => Date }).toJSDate === "function") {
-    return (dateValue as { toJSDate: () => Date }).toJSDate().toISOString();
-  }
-  return new Date(dateValue as string | number).toISOString();
+  return dateValue.toJSDate().toISOString();
 }
 
 function readDraftPaidBack(

--- a/TravelCostApp/util/expense-form-draft.ts
+++ b/TravelCostApp/util/expense-form-draft.ts
@@ -63,7 +63,13 @@ export function toExpenseDraft(
   };
 }
 
-function convertToISOString(dateValue: DateOrDateTime): string {
+/** MMKV JSON persistence stores dates as ISO strings at runtime. */
+type DraftDateValue = DateOrDateTime | string;
+
+function convertToISOString(dateValue: DraftDateValue): string {
+  if (typeof dateValue === "string") {
+    return dateValue;
+  }
   if (dateValue instanceof Date) {
     return dateValue.toISOString();
   }

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -52,6 +52,12 @@ export type BuiltAdvancedExpenseData = ExpenseData & {
   alreadyDividedAmountByDays: boolean;
 };
 
+/** Fast submit deliberately omits these fields (see issue #270). */
+export type BuiltFastExpenseData = Omit<
+  ExpenseData,
+  "calcAmount" | "categoryString" | "alreadyDividedAmountByDays"
+>;
+
 function sharedExpenseCore(snapshot: ExpenseFormSnapshot) {
   return {
     uid: snapshot.uid,
@@ -101,7 +107,7 @@ export function buildExpenseData(
 
 export function buildFastExpenseData(
   snapshot: ExpenseFormSnapshot
-): ExpenseData {
+): BuiltFastExpenseData {
   const rangeDate = DateTime.fromISO(snapshot.startDateIso).toJSDate();
 
   return {

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -58,6 +58,11 @@ export type BuiltFastExpenseData = Omit<
   "calcAmount" | "categoryString" | "alreadyDividedAmountByDays"
 >;
 
+/** Payload from ExpenseForm before ManageExpense fills FX/category fields. */
+export type ExpenseFormSubmitPayload =
+  | BuiltAdvancedExpenseData
+  | BuiltFastExpenseData;
+
 function sharedExpenseCore(snapshot: ExpenseFormSnapshot) {
   return {
     uid: snapshot.uid,


### PR DESCRIPTION
## Summary
- Add `BuiltFastExpenseData` so `buildFastExpenseData` return type matches the deliberate fast-path omissions already covered by characterization tests.
- Simplify draft `convertToISOString` for `Date | DateTime` (Luxon) without unsafe casts.

Completes the remaining type-check gaps from the #270 refactor; behavior unchanged.

## Test plan
- [x] `pnpm test -- __tests__/util/expense-form-submit.test.ts __tests__/util/expense-form-draft.test.ts`
- [x] `pnpm test` (full suite)

Closes #270