### PR TITLE
Fix latent ExpenseForm bugs from #271

### DIFF
--- a/TravelCostApp/__tests__/hooks/use-expense-fx.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-expense-fx.test.ts
@@ -63,11 +63,12 @@ describe("useExpenseFx", () => {
     });
   });
 
-  it("mutates split.rate in place and exposes per-split converted amounts", async () => {
+  it("does not mutate splitList entries when computing converted amounts", async () => {
     const splitList = [
       makeSplit({ userName: "A", amount: 100 }),
       makeSplit({ userName: "B", amount: 50 }),
     ];
+    const splitListBefore = splitList.map((split) => ({ ...split }));
     const getRate = jest.fn(async () => 2);
 
     const { result } = renderHook(() =>
@@ -84,7 +85,6 @@ describe("useExpenseFx", () => {
       expect(result.current.splitListCalcAmounts).toEqual(["50.00", "25.00"]);
     });
 
-    expect(splitList[0].rate).toBe(2);
-    expect(splitList[1].rate).toBe(2);
+    expect(splitList).toEqual(splitListBefore);
   });
 });

--- a/TravelCostApp/__tests__/util/expense-form-draft.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-draft.test.ts
@@ -13,6 +13,7 @@ import {
   summarizeDraftChanges,
   toExpenseDraft,
 } from "../../util/expense-form-draft";
+import { buildExpenseData } from "../../util/expense-form-submit";
 
 function dateFromIso(iso: string): Date {
   return DateTime.fromISO(iso).toJSDate();
@@ -41,7 +42,7 @@ describe("toExpenseDraft", () => {
     expect(draft.endDate).toEqual(dateFromIso("2026-01-16"));
   });
 
-  it("keeps display amount separate from resolved calcAmount when amountInput differs", () => {
+  it("uses resolved amountValue for amount and calcAmount when quick-sum differs from field text", () => {
     const draft = toExpenseDraft(
       makeExpenseFormSnapshot({
         amountInput: "10",
@@ -49,8 +50,19 @@ describe("toExpenseDraft", () => {
       })
     );
 
-    expect(draft.amount).toBe(10);
+    expect(draft.amount).toBe(25);
     expect(draft.calcAmount).toBe(25);
+  });
+
+  it("persists the same resolved amount that advanced submit validates", () => {
+    const snapshot = makeExpenseFormSnapshot({
+      amountInput: "10",
+      amountValue: 25,
+    });
+
+    expect(toExpenseDraft(snapshot).amount).toBe(
+      buildExpenseData(snapshot).amount
+    );
   });
 });
 
@@ -99,7 +111,7 @@ describe("draft round-trip", () => {
     });
     const restored = applyDraftToForm(toExpenseDraft(snapshot));
 
-    expect(restored.inputs?.amount?.value).toBe("10");
+    expect(restored.inputs?.amount?.value).toBe("25");
     expect(restored.inputs?.description?.value).toBe(snapshot.description);
     expect(restored.inputs?.category?.value).toBe(snapshot.categoryInput);
     expect(restored.inputs?.country?.value).toBe(snapshot.country);

--- a/TravelCostApp/__tests__/util/expense-form-submit.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-submit.test.ts
@@ -115,7 +115,7 @@ describe("buildExpenseData", () => {
 });
 
 describe("buildFastExpenseData", () => {
-  it("assembles fast-path ExpenseData with deliberate omissions", () => {
+  it("assembles fast-path ExpenseData with the same core fields as advanced submit", () => {
     const snapshot = makeExpenseFormSnapshot({
       pickedCat: "food",
       lastCountry: "FR",
@@ -129,11 +129,13 @@ describe("buildFastExpenseData", () => {
     expect(built).toEqual({
       uid: "u1",
       amount: 42.5,
+      calcAmount: 42.5,
       date: rangeStart,
       startDate: rangeStart,
       endDate: dateFromIso("2026-01-16"),
       description: getCatLocalized("food"),
       category: "food",
+      categoryString: getCatLocalized("food"),
       country: "FR",
       currency: "USD",
       whoPaid: "Bob",
@@ -144,10 +146,8 @@ describe("buildFastExpenseData", () => {
       paidBack: "not paid",
       isSpecialExpense: false,
       duplOrSplit: 0,
+      alreadyDividedAmountByDays: false,
     });
-    expect(built).not.toHaveProperty("calcAmount");
-    expect(built).not.toHaveProperty("categoryString");
-    expect(built).not.toHaveProperty("alreadyDividedAmountByDays");
   });
 
   it("uses empty country when lastCountry is unset", () => {

--- a/TravelCostApp/hooks/useExpenseFx.ts
+++ b/TravelCostApp/hooks/useExpenseFx.ts
@@ -46,8 +46,7 @@ export function useExpenseFx({
 
       if (splitList?.length > 0) {
         splitList.forEach((split) => {
-          split.rate = rate;
-          splitConvertedAmounts.push((split.amount / split.rate).toFixed(2));
+          splitConvertedAmounts.push((split.amount / rate).toFixed(2));
         });
       }
 

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -429,10 +429,8 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
   };
 
   async function confirmHandler(payload: ExpenseFormSubmitPayload): Promise<void> {
-    // Fast submit omits categoryString/calcAmount; this handler completes the shape.
-    const expenseData = payload as ExpenseData;
+    const expenseData = payload;
     try {
-      // set the category to the corresponting catstring
       expenseData.categoryString = getCatLocalized(expenseData.category);
 
       // calc calcAmount from amount, currency and TripCtx.tripCurrency and add it to expenseData

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -431,9 +431,9 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
   async function confirmHandler(payload: ExpenseFormSubmitPayload): Promise<void> {
     const expenseData = payload;
     try {
+      // Normalize localized category label and trip-currency calcAmount (FX) on every submit path.
       expenseData.categoryString = getCatLocalized(expenseData.category);
 
-      // calc calcAmount from amount, currency and TripCtx.tripCurrency and add it to expenseData
       const base = tripCtx.tripCurrency;
       const target = expenseData.currency;
       const rate = await getRate(base, target);

--- a/TravelCostApp/util/expense-form-draft.ts
+++ b/TravelCostApp/util/expense-form-draft.ts
@@ -38,13 +38,12 @@ export function toExpenseDraft(
   snapshot: ExpenseFormSnapshot,
   overrides: Partial<ExpenseData> = {}
 ): ExpenseData {
-  const amountInput = snapshot.amountInput ?? snapshot.amountValue;
   const resolvedAmount = +snapshot.amountValue;
 
   return {
     category: snapshot.categoryInput,
     description: snapshot.description,
-    amount: +amountInput,
+    amount: resolvedAmount,
     date: createSafeDate(snapshot.dateIso),
     startDate: createSafeDate(snapshot.startDateIso),
     endDate: createSafeDate(snapshot.endDateIso),

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -11,7 +11,7 @@ import { splitType } from "./split";
 
 export type ExpenseFormSnapshot = {
   uid: string;
-  /** Raw amount field text; defaults to {@link amountValue} when omitted (draft save path). */
+  /** Raw amount field text from the form input; submit and draft persistence use {@link amountValue}. */
   amountInput?: string | number;
   amountValue: string | number;
   dateIso: string;

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -52,16 +52,8 @@ export type BuiltAdvancedExpenseData = ExpenseData & {
   alreadyDividedAmountByDays: boolean;
 };
 
-/** Fast submit deliberately omits these fields (see issue #270). */
-export type BuiltFastExpenseData = Omit<
-  ExpenseData,
-  "calcAmount" | "categoryString" | "alreadyDividedAmountByDays"
->;
-
-/** Payload from ExpenseForm before ManageExpense fills FX/category fields. */
-export type ExpenseFormSubmitPayload =
-  | BuiltAdvancedExpenseData
-  | BuiltFastExpenseData;
+/** Payload from ExpenseForm before ManageExpense applies FX conversion on submit. */
+export type ExpenseFormSubmitPayload = BuiltAdvancedExpenseData;
 
 function sharedExpenseCore(snapshot: ExpenseFormSnapshot) {
   return {
@@ -112,7 +104,7 @@ export function buildExpenseData(
 
 export function buildFastExpenseData(
   snapshot: ExpenseFormSnapshot
-): BuiltFastExpenseData {
+): BuiltAdvancedExpenseData {
   const rangeDate = DateTime.fromISO(snapshot.startDateIso).toJSDate();
 
   return {
@@ -122,10 +114,13 @@ export function buildFastExpenseData(
     endDate: DateTime.fromISO(snapshot.endDateIso).toJSDate(),
     description: getCatLocalized(snapshot.pickedCat),
     category: snapshot.pickedCat,
+    categoryString: getCatLocalized(snapshot.pickedCat),
+    calcAmount: +snapshot.amountValue,
     country: snapshot.lastCountry ? snapshot.lastCountry : "",
     currency: snapshot.lastCurrency,
     whoPaid: snapshot.userName,
     listEQUAL: snapshot.listEQUAL,
+    alreadyDividedAmountByDays: snapshot.alreadyDividedAmountByDays,
   };
 }
 


### PR DESCRIPTION
## Summary
- Persist resolved `amountValue` in expense drafts so quick-sum totals match submit validation
- Include `calcAmount`, `categoryString`, and `alreadyDividedAmountByDays` in fast-submit payloads
- Stop `useExpenseFx` from mutating `splitList` entries during FX preview (rates still set at submit in `ManageExpense`)

## Deferred (not in this PR)
- **EXACT_SHARING unreachable branch** (#274 comment on #271): investigated — `nextModal` is never called while `modalFlow === EXACT_SHARING`; wiring `onClose` through the reducer would reopen the traveller picker. Follow-up issue recommended before treating as dead code.

## Test plan
- [x] `pnpm test` (259 tests passing)
- [ ] Fast-add expense with quick-sum amount — saved amount matches displayed total
- [ ] Fast submit with foreign currency — expense persists with correct `calcAmount` after FX
- [ ] Edit expense with splits in foreign currency — split preview updates without side effects on split state

Closes #271