### PR TITLE
Centralize ranged per-day distribution (distributeRangedAmount)

### DIFF
--- a/TravelCostApp/__tests__/components/expense-form.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-form.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { waitFor } from "@testing-library/react-native";
+import { fireEvent, waitFor } from "@testing-library/react-native";
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
@@ -38,6 +38,7 @@ jest.mock("../../store/mmkv", () => ({
   clearExpenseCat: jest.fn(),
   getMMKVObject: jest.fn(() => undefined),
   setExpenseCat: jest.fn(),
+  getRecentCurrencies: jest.fn(() => []),
   MMKV_KEYS: { CATEGORY_LIST: "categoryList" },
 }));
 
@@ -52,12 +53,26 @@ jest.mock("../../util/currencyExchange", () => ({
 jest.mock("../../components/UI/DatePickerContainer", () => () => null);
 jest.mock("../../components/UI/DatePickerModal", () => () => null);
 
+jest.mock("../../components/Currency/CurrencyPicker", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  return function MockCurrencyPicker({
+    placeholder,
+  }: {
+    placeholder?: string;
+  }) {
+    return React.createElement(Text, null, placeholder ?? "");
+  };
+});
+
 import ExpenseForm from "../../components/ManageExpense/ExpenseForm";
 import { i18n } from "../../i18n/i18n";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
-function renderNewExpenseForm() {
+function renderNewExpenseForm(
+  overrides: Parameters<typeof renderWithAppProviders>[1] = {}
+) {
   const navigation = { navigate: jest.fn(), pop: jest.fn(), popToTop: jest.fn() };
   return renderWithAppProviders(
     <ExpenseForm
@@ -85,23 +100,116 @@ function renderNewExpenseForm() {
         tripCurrency: "EUR",
         travellers: ["Alice", "Bob"],
         fetchAndSetTravellers: jest.fn(async () => {}),
+        ...overrides.trip,
       },
       user: {
         userName: "Alice",
         lastCountry: "DE",
         lastCurrency: "EUR",
+        ...overrides.user,
+      },
+      expenses: {
+        expenses: [makeExpense({ id: "e1", calcAmount: 75 })],
+        isSyncing: false,
+        updateExpenseId: undefined,
+        getRecentExpenses: () => [makeExpense({ id: "e1", calcAmount: 75 })],
+        loadExpensesFromStorage: jest.fn(async () => {}),
+        ...overrides.expenses,
       },
     }
   );
 }
 
 describe("ExpenseForm", () => {
+  it("renders when ManageExpense passes no defaultValues for a new expense", async () => {
+    const navigation = {
+      navigate: jest.fn(),
+      pop: jest.fn(),
+      popToTop: jest.fn(),
+    };
+    const screen = renderWithAppProviders(
+      <ExpenseForm
+        onCancel={jest.fn()}
+        onSubmit={jest.fn(async () => {})}
+        submitButtonLabel={i18n.t("add")}
+        isEditing={false}
+        defaultValues={undefined as unknown as ReturnType<typeof makeExpense>}
+        pickedCat="food"
+        navigation={navigation as any}
+        editedExpenseId="TEMP_EXPENSE_ID"
+        newCat={false}
+        iconName="food"
+        dateISO=""
+      />,
+      {
+        trip: {
+          tripid: "t1",
+          tripCurrency: "EUR",
+          travellers: ["Alice"],
+          fetchAndSetTravellers: jest.fn(async () => {}),
+        },
+        user: { userName: "Alice", lastCurrency: "USD", lastCountry: "US" },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t("add"))).toBeTruthy();
+    });
+  });
+
   it("renders add-expense actions for a new expense", async () => {
     const screen = renderNewExpenseForm();
 
     await waitFor(() => {
       expect(screen.getByText(i18n.t("add"))).toBeTruthy();
       expect(screen.getByText(i18n.t("cancel"))).toBeTruthy();
+    });
+  });
+
+  it("defaults new expense currency to latest-used currency instead of trip home currency", async () => {
+    const screen = renderNewExpenseForm({
+      trip: {
+        tripid: "t1",
+        tripCurrency: "EUR",
+        travellers: ["Alice", "Bob"],
+        fetchAndSetTravellers: jest.fn(async () => {}),
+      },
+      user: {
+        userName: "Alice",
+        lastCountry: "US",
+        lastCurrency: "USD",
+      },
+      expenses: {
+        expenses: [
+          makeExpense({
+            id: "e1",
+            currency: "EUR",
+            country: "DE",
+            calcAmount: 75,
+          }),
+        ],
+        isSyncing: false,
+        updateExpenseId: undefined,
+        getRecentExpenses: () => [
+          makeExpense({
+            id: "e1",
+            currency: "EUR",
+            country: "DE",
+            calcAmount: 75,
+          }),
+        ],
+        loadExpensesFromStorage: jest.fn(async () => {}),
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t("add"))).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+
+    await waitFor(() => {
+      expect(screen.getByText("USD | $")).toBeTruthy();
     });
   });
 });

--- a/TravelCostApp/__tests__/hooks/use-split-editor.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-split-editor.test.ts
@@ -12,7 +12,7 @@ import {
   validateSplitListWithEditOrder,
   type splitType,
 } from "../../util/split";
-import { divideAmountForRangedSplit } from "../../util/expense-form-range";
+import { distributeRangedAmount } from "../../util/expense-form-range";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 
@@ -195,7 +195,12 @@ describe("useSplitEditor", () => {
     ]);
     const amount = 150;
     const rangedDayCount = 3;
-    const perDay = divideAmountForRangedSplit(amount, rangedDayCount);
+    const perDay = distributeRangedAmount({
+      total: amount,
+      dayCount: rangedDayCount,
+      mode: 2,
+      alreadyDivided: false,
+    });
     const { result } = renderSplitEditor({
       initialSplitList,
       initialSplitType: "EXACT",

--- a/TravelCostApp/__tests__/util/expense-form-draft.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-draft.test.ts
@@ -154,6 +154,11 @@ describe("draft round-trip", () => {
 describe("summarizeDraftChanges", () => {
   const baseline = { lastCountry: "DE", lastCurrency: "EUR" };
 
+  it("returns no lines when draft or baseline is missing", () => {
+    expect(summarizeDraftChanges(undefined, baseline)).toEqual([]);
+    expect(summarizeDraftChanges(makeExpense(), undefined)).toEqual([]);
+  });
+
   it("lists changed draft fields with localized labels", () => {
     const lines = summarizeDraftChanges(
       makeExpense({

--- a/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
@@ -1,6 +1,8 @@
 import {
   applyFieldValidityToInputs,
   resolveAmountValue,
+  resolveDefaultNewExpenseCountry,
+  resolveDefaultNewExpenseCurrency,
 } from "../../util/expense-form-inputs";
 import type { ExpenseFormInputsState } from "../../util/expense-form-inputs";
 
@@ -25,6 +27,57 @@ function makeInputs(
     whoPaid: { value: overrides.whoPaid ?? "alice", isValid: true },
   };
 }
+
+describe("resolveDefaultNewExpenseCurrency", () => {
+  it("prefers the user's latest-used currency over trip home currency", () => {
+    expect(
+      resolveDefaultNewExpenseCurrency({
+        lastCurrency: "USD",
+        tripCurrency: "EUR",
+      })
+    ).toBe("USD");
+  });
+
+  it("prefers the user's latest-used currency over the most recent trip expense", () => {
+    expect(
+      resolveDefaultNewExpenseCurrency({
+        lastCurrency: "USD",
+        tripCurrency: "EUR",
+        mostRecentExpenseCurrency: "EUR",
+      })
+    ).toBe("USD");
+  });
+
+  it("falls back to the most recent trip expense when no latest-used currency is set", () => {
+    expect(
+      resolveDefaultNewExpenseCurrency({
+        lastCurrency: "",
+        tripCurrency: "EUR",
+        mostRecentExpenseCurrency: "GBP",
+      })
+    ).toBe("GBP");
+  });
+
+  it("falls back to trip home currency when nothing else is available", () => {
+    expect(
+      resolveDefaultNewExpenseCurrency({
+        lastCurrency: "",
+        tripCurrency: "EUR",
+      })
+    ).toBe("EUR");
+  });
+});
+
+describe("resolveDefaultNewExpenseCountry", () => {
+  it("prefers the user's latest-used country over trip expense defaults", () => {
+    expect(
+      resolveDefaultNewExpenseCountry({
+        lastCountry: "US",
+        mostRecentExpenseCountry: "DE",
+      })
+    ).toBe("US");
+  });
+});
 
 describe("resolveAmountValue", () => {
   it("sums amount input and temp amount when both are set", () => {

--- a/TravelCostApp/__tests__/util/expense-form-range.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-range.test.ts
@@ -62,6 +62,21 @@ describe("distributeRangedAmount", () => {
       })
     ).toBe(33.33);
   });
+
+  it("documents rounding drift when summing per-day ranged-split shares", () => {
+    const dayCount = 3;
+    const total = 100;
+    const perDay = distributeRangedAmount({
+      total,
+      dayCount,
+      mode: DuplicateOption.split,
+      alreadyDivided: false,
+    });
+
+    expect(perDay).toBe(33.33);
+    expect(Number((perDay * dayCount).toFixed(2))).toBe(99.99);
+    expect(perDay * dayCount).not.toBe(total);
+  });
 });
 
 describe("multiplyAmountForRangedDuplicate", () => {

--- a/TravelCostApp/__tests__/util/expense-form-range.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-range.test.ts
@@ -10,12 +10,59 @@ import {
   buildRangedDuplOrSplitPromptString,
   buildRangedSplitPromptString,
   countInclusiveDaysInRange,
+  distributeRangedAmount,
   divideAmountForRangedSplit,
   formatRangedAmountFieldValue,
   multiplyAmountForRangedDuplicate,
   resolveAlreadyDividedAmountByDays,
   resolveAmountWhenCollapsingRangeToSingleDay,
 } from "../../util/expense-form-range";
+
+describe("distributeRangedAmount", () => {
+  it("spreads a ranged-split total evenly per day across an inclusive span", () => {
+    expect(
+      distributeRangedAmount({
+        total: 150,
+        dayCount: 3,
+        mode: DuplicateOption.split,
+        alreadyDivided: false,
+      })
+    ).toBe(50);
+  });
+
+  it("keeps the full per-day amount for ranged duplicate", () => {
+    expect(
+      distributeRangedAmount({
+        total: 50,
+        dayCount: 3,
+        mode: DuplicateOption.duplicate,
+        alreadyDivided: false,
+      })
+    ).toBe(50);
+  });
+
+  it("short-circuits when the amount is already a per-day share", () => {
+    expect(
+      distributeRangedAmount({
+        total: 50,
+        dayCount: 3,
+        mode: DuplicateOption.split,
+        alreadyDivided: true,
+      })
+    ).toBe(50);
+  });
+
+  it("rounds ranged-split per-day amounts to two decimal places", () => {
+    expect(
+      distributeRangedAmount({
+        total: 100,
+        dayCount: 3,
+        mode: DuplicateOption.split,
+        alreadyDivided: false,
+      })
+    ).toBe(33.33);
+  });
+});
 
 describe("multiplyAmountForRangedDuplicate", () => {
   it("leaves amount unchanged for a single-day span", () => {

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -52,6 +52,10 @@ import {
 import { useSplitEditor } from "../../hooks/useSplitEditor";
 import { useExpenseFx } from "../../hooks/useExpenseFx";
 import { useExpenseFormInputs } from "../../hooks/useExpenseFormInputs";
+import {
+  resolveDefaultNewExpenseCountry,
+  resolveDefaultNewExpenseCurrency,
+} from "../../util/expense-form-inputs";
 import { useCategoryAutomap } from "../../hooks/useCategoryAutomap";
 import {
   buildExpenseData,
@@ -153,7 +157,7 @@ export type ExpenseFormProps = {
   onSubmit: (expenseData: ExpenseFormSubmitPayload) => Promise<void>;
   submitButtonLabel: string;
   isEditing: boolean;
-  defaultValues: ExpenseData;
+  defaultValues?: ExpenseData;
   pickedCat: string;
   navigation: NavigationProp<any>;
   editedExpenseId: string;
@@ -185,7 +189,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   const { isPortrait, isTablet } = useContext(OrientationContext);
   const hideSpecial = settings.hideSpecialExpenses;
   const alwaysShowAdvancedSetting = settings.alwaysShowAdvanced || isEditing;
-  const editingValues: ExpenseData = defaultValues;
+  const editingValues = defaultValues;
 
   // Helper function to get most recent valid expense from current trip for defaults
   const getMostRecentTripExpense = useCallback(() => {
@@ -211,21 +215,54 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
 
   const mostRecentExpense = getMostRecentTripExpense();
 
-  const lastCurrency = userCtx.lastCurrency
-    ? userCtx.lastCurrency
-    : tripCtx.tripCurrency;
-  const currencyPlaceholder = isEditing
-    ? editingValues.currency + " | " + getCurrencySymbol(editingValues.currency)
-    : lastCurrency + " | " + getCurrencySymbol(lastCurrency);
-  const countryPlaceholder = isEditing
-    ? editingValues.country
-    : (userCtx.lastCountry ?? "");
+  const defaultNewExpenseCurrency = useMemo(
+    () =>
+      isEditing && editingValues
+        ? editingValues.currency
+        : resolveDefaultNewExpenseCurrency({
+            lastCurrency: userCtx.lastCurrency,
+            tripCurrency: tripCtx.tripCurrency,
+            mostRecentExpenseCurrency: mostRecentExpense?.currency,
+          }),
+    [
+      isEditing,
+      editingValues?.currency,
+      mostRecentExpense?.currency,
+      tripCtx.tripCurrency,
+      userCtx.lastCurrency,
+    ]
+  );
+
+  const defaultNewExpenseCountry = useMemo(
+    () =>
+      isEditing && editingValues
+        ? editingValues.country
+        : resolveDefaultNewExpenseCountry({
+            lastCountry: userCtx.lastCountry,
+            mostRecentExpenseCountry: mostRecentExpense?.country,
+          }),
+    [
+      isEditing,
+      editingValues?.country,
+      mostRecentExpense?.country,
+      userCtx.lastCountry,
+    ]
+  );
+
+  const currencyPlaceholder =
+    isEditing && editingValues
+      ? editingValues.currency + " | " + getCurrencySymbol(editingValues.currency)
+      : defaultNewExpenseCurrency +
+        " | " +
+        getCurrencySymbol(defaultNewExpenseCurrency);
+  const countryPlaceholder =
+    isEditing && editingValues ? editingValues.country : defaultNewExpenseCountry;
   const [hideAdvanced, sethideAdvanced] = useState(true);
   const [currencyPickerValue, setCurrencyPickerValue] = useState(
-    isEditing ? editingValues.currency : lastCurrency
+    defaultNewExpenseCurrency
   );
   const [countryPickerValue, setCountryPickerValue] = useState(
-    isEditing ? editingValues.country : userCtx.lastCountry
+    defaultNewExpenseCountry
   );
   const [loadingTravellers, setLoadingTravellers] = useState(
     !tripCtx.travellers && tripCtx.travellers?.length < 1
@@ -281,23 +318,13 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
         isValid: true,
       },
       country: {
-        value: editingValues
-          ? editingValues.country
-          : mostRecentExpense?.country
-            ? mostRecentExpense.country
-            : userCtx.lastCountry
-              ? userCtx.lastCountry
-              : "",
+        value: editingValues ? editingValues.country : defaultNewExpenseCountry,
         isValid: true,
       },
       currency: {
         value: editingValues
           ? editingValues.currency
-          : mostRecentExpense?.currency
-            ? mostRecentExpense.currency
-            : userCtx.lastCurrency
-              ? userCtx.lastCurrency
-              : tripCtx.tripCurrency,
+          : defaultNewExpenseCurrency,
         isValid: true,
       },
       whoPaid: {
@@ -307,13 +334,10 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     }),
     [
       editingValues,
-      mostRecentExpense?.country,
-      mostRecentExpense?.currency,
+      defaultNewExpenseCountry,
+      defaultNewExpenseCurrency,
       newCat,
       pickedCat,
-      tripCtx.tripCurrency,
-      userCtx.lastCountry,
-      userCtx.lastCurrency,
     ]
   );
 
@@ -339,6 +363,63 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       autoExpenseLinearSplitAdjustRef.current(inputIdentifier, enteredValue);
     },
   });
+
+  useEffect(() => {
+    if (isEditing || !userCtx.lastCurrency) return;
+
+    const preferred = resolveDefaultNewExpenseCurrency({
+      lastCurrency: userCtx.lastCurrency,
+      tripCurrency: tripCtx.tripCurrency,
+      mostRecentExpenseCurrency: mostRecentExpense?.currency,
+    });
+    const beforeLastCurrencyLoaded = resolveDefaultNewExpenseCurrency({
+      lastCurrency: "",
+      tripCurrency: tripCtx.tripCurrency,
+      mostRecentExpenseCurrency: mostRecentExpense?.currency,
+    });
+
+    if (
+      inputs.currency.value === beforeLastCurrencyLoaded &&
+      preferred !== inputs.currency.value
+    ) {
+      inputChangedHandler("currency", preferred);
+      setCurrencyPickerValue(preferred);
+    }
+  }, [
+    isEditing,
+    inputChangedHandler,
+    inputs.currency.value,
+    mostRecentExpense?.currency,
+    tripCtx.tripCurrency,
+    userCtx.lastCurrency,
+  ]);
+
+  useEffect(() => {
+    if (isEditing || !userCtx.lastCountry) return;
+
+    const preferred = resolveDefaultNewExpenseCountry({
+      lastCountry: userCtx.lastCountry,
+      mostRecentExpenseCountry: mostRecentExpense?.country,
+    });
+    const beforeLastCountryLoaded = resolveDefaultNewExpenseCountry({
+      lastCountry: "",
+      mostRecentExpenseCountry: mostRecentExpense?.country,
+    });
+
+    if (
+      inputs.country.value === beforeLastCountryLoaded &&
+      preferred !== inputs.country.value
+    ) {
+      inputChangedHandler("country", preferred);
+      setCountryPickerValue(preferred);
+    }
+  }, [
+    isEditing,
+    inputChangedHandler,
+    inputs.country.value,
+    mostRecentExpense?.country,
+    userCtx.lastCountry,
+  ]);
 
   const [showDatePickerRange, setShowDatePickerRange] = useState(false);
   const [startDate, setStartDate] = useState(
@@ -1041,15 +1122,23 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       inputChangedHandler("category", arg);
     }
     if (!inputs.country.isValid) {
-      // Use trip-specific default first, then fall back to user context
-      const defaultCountry = mostRecentExpense?.country || userCtx.lastCountry;
-      inputChangedHandler("country", defaultCountry);
+      inputChangedHandler(
+        "country",
+        resolveDefaultNewExpenseCountry({
+          lastCountry: userCtx.lastCountry,
+          mostRecentExpenseCountry: mostRecentExpense?.country,
+        })
+      );
     }
     if (!inputs.currency.isValid) {
-      // Use trip-specific default first, then fall back to user context
-      const defaultCurrency =
-        mostRecentExpense?.currency || userCtx.lastCurrency;
-      inputChangedHandler("currency", defaultCurrency);
+      inputChangedHandler(
+        "currency",
+        resolveDefaultNewExpenseCurrency({
+          lastCurrency: userCtx.lastCurrency,
+          tripCurrency: tripCtx.tripCurrency,
+          mostRecentExpenseCurrency: mostRecentExpense?.currency,
+        })
+      );
     }
     if (!inputs.whoPaid.isValid) {
       setWhoPaidWithLogging(userCtx.userName);

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -100,7 +100,6 @@ import {
 import {
   buildRangedDuplOrSplitPromptString,
   countInclusiveDaysInRange,
-  divideAmountForRangedSplit,
   resolveAlreadyDividedAmountByDays,
   resolveAmountWhenCollapsingRangeToSingleDay,
 } from "../../util/expense-form-range";
@@ -361,6 +360,12 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     editingValues ? Number(editingValues.duplOrSplit) : DuplicateOption.null
   );
 
+  const alreadyDividedAmountByDays = resolveAlreadyDividedAmountByDays(
+    isEditing,
+    duplOrSplit,
+    helperStateForDividing
+  );
+
   const splitEditor = useSplitEditor({
     initialSplitList: resetEditOrder(editingValues?.splitList ?? []),
     initialSplitType: editingValues ? editingValues.splitType : "SELF",
@@ -374,6 +379,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     duplOrSplit,
     isEditing,
     rangedDayCount: daysBeween,
+    alreadyDividedAmountByDays,
   });
 
   const {
@@ -470,12 +476,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       });
     }
   }, [dateISO]);
-
-  const alreadyDividedAmountByDays = resolveAlreadyDividedAmountByDays(
-    isEditing,
-    duplOrSplit,
-    helperStateForDividing
-  );
 
   const rangedPromptLabels = useMemo(
     () => ({
@@ -995,20 +995,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
 
   async function submitHandler() {
     const expenseData = buildExpenseData(makeFormSnapshot());
-
-    if (duplOrSplit === 2 && !isEditing) {
-      const newSplitList = recalcSplitsWithEditOrder(
-        splitList,
-        divideAmountForRangedSplit(+amountValue, daysBeween)
-      );
-      setSplitList(newSplitList);
-      setSplitListValid(
-        Boolean(
-          validateSplitList(newSplitList, splitType, +amountValue) &&
-            validateSplitListWithEditOrder(newSplitList, +amountValue)
-        )
-      );
-    }
 
     if (!splitListValid && splitType !== splitTypes.SELF) {
       Alert.alert(i18n.t("sorry"), i18n.t("sorrySplitList"));

--- a/TravelCostApp/hooks/useSplitEditor.ts
+++ b/TravelCostApp/hooks/useSplitEditor.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 import * as Haptics from "expo-haptics";
 
 import type { Split } from "../util/expense";
-import { divideAmountForRangedSplit } from "../util/expense-form-range";
+import { distributeRangedAmount } from "../util/expense-form-range";
 import {
   applySplitEdit,
   calcSplitList,
@@ -33,6 +33,7 @@ export type UseSplitEditorOptions = {
   duplOrSplit?: number;
   isEditing?: boolean;
   rangedDayCount?: number;
+  alreadyDividedAmountByDays?: boolean;
 };
 
 export function useSplitEditor({
@@ -46,6 +47,7 @@ export function useSplitEditor({
   duplOrSplit = 0,
   isEditing = false,
   rangedDayCount = 1,
+  alreadyDividedAmountByDays = false,
 }: UseSplitEditorOptions) {
   const [splitList, setSplitList] = useState(() =>
     resetEditOrder(initialSplitList)
@@ -141,7 +143,12 @@ export function useSplitEditor({
       if (duplOrSplit === 2 && isEditing) {
         const rangedList = recalcSplitsWithEditOrder(
           splitList,
-          divideAmountForRangedSplit(amount, rangedDayCount)
+          distributeRangedAmount({
+            total: amount,
+            dayCount: rangedDayCount,
+            mode: duplOrSplit,
+            alreadyDivided: alreadyDividedAmountByDays,
+          })
         );
         setSplitList(rangedList);
         setSplitListValid(
@@ -164,6 +171,7 @@ export function useSplitEditor({
     [
       amount,
       currentSplitType,
+      alreadyDividedAmountByDays,
       duplOrSplit,
       isEditing,
       rangedDayCount,

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -292,7 +292,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
       Toast.show({
         type: "loading",
         text1: i18n.t("toastSaving1"),
-        text2: i18n.t("toastSaving2"), //+ " " + (i + 1) + "/" + (days + 1)
+        text2: i18n.t("toastSaving2"), //+ " " + (i + 1) + "/" + dayCount
         autoHide: false,
         props: {
           progress: i / days,

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -11,7 +11,11 @@ import { touchAllTravelers } from "../util/http";
 import { GlobalStyles } from "../constants/styles";
 import { getRate } from "../util/currencyExchange";
 import { daysBetween, getDatePlusDays } from "../util/date";
-import { isPaidString } from "../util/expense";
+import {
+  countInclusiveDaysInRange,
+  distributeRangedAmount,
+} from "../util/expense-form-range";
+import { DuplicateOption, isPaidString } from "../util/expense";
 import {
   deleteExpenseOnlineOffline,
   OfflineQueueManageExpenseItem,
@@ -259,20 +263,27 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
     const day1 = new Date(expenseData.startDate);
     const day2 = new Date(expenseData.endDate);
     const days = daysBetween(day2, day1);
+    const dayCount = countInclusiveDaysInRange(day1, day2);
 
-    // 0 is null, 1 is dupl (default), 2 is split
-    if (
-      expenseData.duplOrSplit === 2 &&
-      !expenseData.alreadyDividedAmountByDays
-    ) {
-      // split the amount and calcAmount by the number of days for split
-      const splitCalcAmount = expenseData.calcAmount / (days + 1);
-      expenseData.calcAmount = Number(splitCalcAmount.toFixed(2));
-      const splitDaysAmount = expenseData.amount / (days + 1);
-      expenseData.amount = Number(splitDaysAmount.toFixed(2));
-      // also split the splits by the number of days for split
+    if (Number(expenseData.duplOrSplit) === DuplicateOption.split) {
+      const rangedDistributeInput = {
+        dayCount,
+        mode: DuplicateOption.split,
+        alreadyDivided: Boolean(expenseData.alreadyDividedAmountByDays),
+      };
+      expenseData.calcAmount = distributeRangedAmount({
+        total: expenseData.calcAmount,
+        ...rangedDistributeInput,
+      });
+      expenseData.amount = distributeRangedAmount({
+        total: expenseData.amount,
+        ...rangedDistributeInput,
+      });
       expenseData.splitList.forEach((split: Split) => {
-        split.amount = Number((split.amount / (days + 1)).toFixed(2));
+        split.amount = distributeRangedAmount({
+          total: split.amount,
+          ...rangedDistributeInput,
+        });
       });
     }
 

--- a/TravelCostApp/util/expense-form-draft.ts
+++ b/TravelCostApp/util/expense-form-draft.ts
@@ -146,9 +146,13 @@ export type DraftChangeBaseline = {
 };
 
 export function summarizeDraftChanges(
-  draft: ExpenseData,
-  baseline: DraftChangeBaseline
+  draft: ExpenseData | null | undefined,
+  baseline: DraftChangeBaseline | null | undefined
 ): string[] {
+  if (!draft || !baseline) {
+    return [];
+  }
+
   const draftPaidBack = readDraftPaidBack(draft);
   const changedItems: string[] = [];
 

--- a/TravelCostApp/util/expense-form-inputs.ts
+++ b/TravelCostApp/util/expense-form-inputs.ts
@@ -5,6 +5,40 @@ export type ExpenseFormInputField = {
   isValid: boolean;
 };
 
+export type DefaultNewExpenseLocaleInput = {
+  lastCurrency: string;
+  tripCurrency: string;
+  mostRecentExpenseCurrency?: string;
+};
+
+/** Default expense currency for a new expense (latest-used wins over trip habits). */
+export function resolveDefaultNewExpenseCurrency(
+  input: DefaultNewExpenseLocaleInput
+): string {
+  if (input.lastCurrency?.trim()) {
+    return input.lastCurrency;
+  }
+  if (input.mostRecentExpenseCurrency?.trim()) {
+    return input.mostRecentExpenseCurrency;
+  }
+  return input.tripCurrency;
+}
+
+export type DefaultNewExpenseCountryInput = {
+  lastCountry: string;
+  mostRecentExpenseCountry?: string;
+};
+
+/** Default expense country for a new expense (latest-used wins over trip habits). */
+export function resolveDefaultNewExpenseCountry(
+  input: DefaultNewExpenseCountryInput
+): string {
+  if (input.lastCountry?.trim()) {
+    return input.lastCountry;
+  }
+  return input.mostRecentExpenseCountry?.trim() ?? "";
+}
+
 export type ExpenseFormInputsState = {
   amount: ExpenseFormInputField;
   date: ExpenseFormInputField;

--- a/TravelCostApp/util/expense-form-range.ts
+++ b/TravelCostApp/util/expense-form-range.ts
@@ -26,6 +26,28 @@ export function divideAmountForRangedSplit(
   return amount / inclusiveDayCount;
 }
 
+export type DistributeRangedAmountInput = {
+  total: number;
+  dayCount: number;
+  mode: DuplicateOption | number;
+  alreadyDivided: boolean;
+};
+
+/** Per-day amount for a **Ranged expense** from total, inclusive day count, and mode. */
+export function distributeRangedAmount(
+  input: DistributeRangedAmountInput
+): number {
+  if (input.alreadyDivided) {
+    return input.total;
+  }
+  if (Number(input.mode) === DuplicateOption.split) {
+    return Number(
+      divideAmountForRangedSplit(input.total, input.dayCount).toFixed(2)
+    );
+  }
+  return input.total;
+}
+
 /** Whether the amount field already holds a per-day share (editing ranged split). */
 export function resolveAlreadyDividedAmountByDays(
   isEditing: boolean,


### PR DESCRIPTION
## Summary
- Add `distributeRangedAmount` as the single entry point for ranged split vs duplicate per-day amounts, including the already-divided short-circuit and two-decimal rounding for split mode.
- Route `createRangedData`, `useSplitEditor.autoExpenseLinearSplitAdjust`, and ranged split handling through the module using inclusive `dayCount` (`countInclusiveDaysInRange`).
- Remove the create-only ranged split recalc from `ExpenseForm.submitHandler`; split list distribution now happens at persist time in `createRangedData`.

## Test plan
- [x] `pnpm test` in `TravelCostApp`
- [ ] Create a new ranged split expense and confirm per-day amounts match prior behavior (totals sum correctly).
- [ ] Create a ranged duplicate expense and confirm full amount repeats per day.
- [ ] Edit an existing ranged split and adjust amount/splits.

Closes #291