### PR TITLE
Ranged expense: expandRangedExpense module + create path (#292)

### DIFF
--- a/TravelCostApp/__tests__/util/expand-ranged-expense.test.ts
+++ b/TravelCostApp/__tests__/util/expand-ranged-expense.test.ts
@@ -47,7 +47,29 @@ describe("expandRangedExpense", () => {
     });
 
     expect(expanded).toHaveLength(1);
-    expect(expanded[0].rangeId).toBeFalsy();
+    expect(expanded[0].rangeId).toBeNull();
+  });
+
+  it("gives each instance its own splitList", () => {
+    const dates = [
+      new Date("2026-01-15T12:00:00.000Z"),
+      new Date("2026-01-16T12:00:00.000Z"),
+    ];
+    const expanded = expandRangedExpense(
+      makeExpense({
+        amount: 100,
+        calcAmount: 100,
+        duplOrSplit: DuplicateOption.split,
+        splitList: [
+          { userName: "Alice", amount: 60 },
+          { userName: "Bob", amount: 40 },
+        ],
+      }),
+      { rangeId: "r1", dates }
+    );
+
+    expanded[0].splitList![0].amount = 999;
+    expect(expanded[1].splitList![0].amount).toBe(30);
   });
 
   it("spreads a ranged-split total evenly per day", () => {

--- a/TravelCostApp/__tests__/util/expand-ranged-expense.test.ts
+++ b/TravelCostApp/__tests__/util/expand-ranged-expense.test.ts
@@ -1,0 +1,136 @@
+import { DuplicateOption } from "../../util/expense";
+import { expandRangedExpense } from "../../util/expand-ranged-expense";
+import { makeExpense } from "../fixtures/expense";
+
+describe("expandRangedExpense", () => {
+  it("returns one ExpenseData per injected date", () => {
+    const dates = [
+      new Date("2026-01-15T12:00:00.000Z"),
+      new Date("2026-01-16T12:00:00.000Z"),
+      new Date("2026-01-17T12:00:00.000Z"),
+    ];
+    const source = makeExpense({
+      startDate: dates[0],
+      endDate: dates[2],
+      amount: 90,
+      calcAmount: 90,
+      duplOrSplit: DuplicateOption.split,
+    });
+
+    const expanded = expandRangedExpense(source, {
+      rangeId: "range-1",
+      dates,
+    });
+
+    expect(expanded).toHaveLength(3);
+    expect(expanded.map((e) => e.date)).toEqual(dates);
+  });
+
+  it("stamps rangeId on each instance for a multi-day span", () => {
+    const dates = [
+      new Date("2026-01-15T12:00:00.000Z"),
+      new Date("2026-01-16T12:00:00.000Z"),
+    ];
+    const expanded = expandRangedExpense(makeExpense({ startDate: dates[0], endDate: dates[1] }), {
+      rangeId: "range-abc",
+      dates,
+    });
+
+    expect(expanded.every((e) => e.rangeId === "range-abc")).toBe(true);
+  });
+
+  it("returns one instance with no rangeId for a single-day span", () => {
+    const date = new Date("2026-01-15T12:00:00.000Z");
+    const expanded = expandRangedExpense(makeExpense({ startDate: date, endDate: date }), {
+      rangeId: "ignored",
+      dates: [date],
+    });
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0].rangeId).toBeFalsy();
+  });
+
+  it("spreads a ranged-split total evenly per day", () => {
+    const dates = [
+      new Date("2026-01-15T12:00:00.000Z"),
+      new Date("2026-01-16T12:00:00.000Z"),
+      new Date("2026-01-17T12:00:00.000Z"),
+    ];
+    const expanded = expandRangedExpense(
+      makeExpense({
+        amount: 150,
+        calcAmount: 150,
+        duplOrSplit: DuplicateOption.split,
+        splitList: [
+          { userName: "Alice", amount: 90 },
+          { userName: "Bob", amount: 60 },
+        ],
+      }),
+      { rangeId: "r1", dates }
+    );
+
+    expect(expanded.every((e) => e.amount === 50)).toBe(true);
+    expect(expanded.every((e) => e.calcAmount === 50)).toBe(true);
+    expect(expanded[0].splitList).toEqual([
+      { userName: "Alice", amount: 30 },
+      { userName: "Bob", amount: 20 },
+    ]);
+    const summed = expanded.reduce((sum, e) => sum + e.amount, 0);
+    expect(Number(summed.toFixed(2))).toBe(150);
+  });
+
+  it("keeps the full per-day amount for ranged duplicate", () => {
+    const dates = [
+      new Date("2026-01-15T12:00:00.000Z"),
+      new Date("2026-01-16T12:00:00.000Z"),
+    ];
+    const expanded = expandRangedExpense(
+      makeExpense({
+        amount: 50,
+        calcAmount: 50,
+        duplOrSplit: DuplicateOption.duplicate,
+      }),
+      { rangeId: "r1", dates }
+    );
+
+    expect(expanded.every((e) => e.amount === 50 && e.calcAmount === 50)).toBe(
+      true
+    );
+    expect(expanded.reduce((sum, e) => sum + e.amount, 0)).toBe(100);
+  });
+
+  it("keeps per-day amounts when the total is already divided", () => {
+    const dates = [
+      new Date("2026-01-15T12:00:00.000Z"),
+      new Date("2026-01-16T12:00:00.000Z"),
+    ];
+    const expanded = expandRangedExpense(
+      makeExpense({
+        amount: 50,
+        calcAmount: 50,
+        duplOrSplit: DuplicateOption.split,
+        alreadyDividedAmountByDays: true,
+      }),
+      { rangeId: "r1", dates }
+    );
+
+    expect(expanded.every((e) => e.amount === 50)).toBe(true);
+  });
+
+  it("does not mutate the submitted expense data", () => {
+    const dates = [
+      new Date("2026-01-15T12:00:00.000Z"),
+      new Date("2026-01-16T12:00:00.000Z"),
+    ];
+    const source = makeExpense({
+      amount: 100,
+      calcAmount: 100,
+      duplOrSplit: DuplicateOption.split,
+    });
+
+    expandRangedExpense(source, { rangeId: "r1", dates });
+
+    expect(source.amount).toBe(100);
+    expect(source.calcAmount).toBe(100);
+  });
+});

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -11,11 +11,8 @@ import { touchAllTravelers } from "../util/http";
 import { GlobalStyles } from "../constants/styles";
 import { getRate } from "../util/currencyExchange";
 import { daysBetween, getDatePlusDays } from "../util/date";
-import {
-  countInclusiveDaysInRange,
-  distributeRangedAmount,
-} from "../util/expense-form-range";
-import { DuplicateOption, isPaidString } from "../util/expense";
+import { expandRangedExpense } from "../util/expand-ranged-expense";
+import { isPaidString } from "../util/expense";
 import {
   deleteExpenseOnlineOffline,
   OfflineQueueManageExpenseItem,
@@ -31,7 +28,6 @@ import PropTypes from "prop-types";
 import {
   deleteAllExpensesByRangedId,
   ExpenseData,
-  Split,
 } from "../util/expense";
 import type { ExpenseFormSubmitPayload } from "../util/expense-form-submit";
 import { NetworkContext } from "../store/network-context";
@@ -245,84 +241,64 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
     expenseCtx.addExpense(expenseToAdd);
   };
 
-  const createRangedData = async (expenseData) => {
-    // rangeId to identify all the expenses that belong to the same range
+  const createRangedData = async (expenseData: ExpenseData) => {
     const rangeId =
       Date.now().toString() + Math.random().toString(36).substring(2, 15);
 
-    // sanity check if the expenseData.date is unequal to expenseData.startDate and endDate
-    // if so, set the date to the startDate
-    if (isSameDay(expenseData.endDate, expenseData.startDate)) {
-      // delete the rangeId field
-      expenseData.rangeId = null;
-    } else {
-      expenseData.rangeId = rangeId;
-    }
-
-    // get number of days
     const day1 = new Date(expenseData.startDate);
     const day2 = new Date(expenseData.endDate);
     const days = daysBetween(day2, day1);
-    const dayCount = countInclusiveDaysInRange(day1, day2);
+    const isSingleDay = isSameDay(expenseData.endDate, expenseData.startDate);
 
-    if (Number(expenseData.duplOrSplit) === DuplicateOption.split) {
-      const rangedDistributeInput = {
-        dayCount,
-        mode: DuplicateOption.split,
-        alreadyDivided: Boolean(expenseData.alreadyDividedAmountByDays),
-      };
-      expenseData.calcAmount = distributeRangedAmount({
-        total: expenseData.calcAmount,
-        ...rangedDistributeInput,
-      });
-      expenseData.amount = distributeRangedAmount({
-        total: expenseData.amount,
-        ...rangedDistributeInput,
-      });
-      expenseData.splitList.forEach((split: Split) => {
-        split.amount = distributeRangedAmount({
-          total: split.amount,
-          ...rangedDistributeInput,
-        });
-      });
-    }
-
-    // iterate over number of days between and change date and endDate to the first date + iterator
+    const dates: Date[] = [];
     for (let i = 0; i <= days; i++) {
-      Toast.show({
-        type: "loading",
-        text1: i18n.t("toastSaving1"),
-        text2: i18n.t("toastSaving2"), //+ " " + (i + 1) + "/" + dayCount
-        autoHide: false,
-        props: {
-          progress: i / days,
-          progressAt: i,
-          progressMax: days,
-          size: "small",
-        },
-      });
       const newDate = getDatePlusDays(day1, i);
       if (newDate instanceof Date) {
         newDate.setHours(new Date().getHours(), new Date().getMinutes());
+        dates.push(newDate);
       } else if (newDate instanceof DateTime) {
         newDate.set({
           hour: new Date().getHours(),
           minute: new Date().getMinutes(),
         });
+        dates.push(newDate.toJSDate());
       }
-      expenseData.date = newDate;
-      expenseData.editedTimestamp = Date.now();
+    }
+
+    const instances = expandRangedExpense(expenseData, {
+      rangeId: isSingleDay ? null : rangeId,
+      dates,
+    });
+
+    for (let i = 0; i < instances.length; i++) {
+      Toast.show({
+        type: "loading",
+        text1: i18n.t("toastSaving1"),
+        text2: i18n.t("toastSaving2"),
+        autoHide: false,
+        props: {
+          progress: days === 0 ? 0 : i / days,
+          progressAt: i,
+          progressMax: days,
+          size: "small",
+        },
+      });
+
+      const expenseToPersist = {
+        ...instances[i],
+        editedTimestamp: Date.now(),
+      };
 
       const item: OfflineQueueManageExpenseItem = {
         type: "add",
         expense: {
           tripid: tripid,
           uid: uid,
-          expenseData: expenseData,
+          expenseData: expenseToPersist,
         },
       };
       const id = await storeExpenseOnlineOffline(item, isOnline);
-      expenseCtx.addExpense({ ...expenseData, id: id });
+      expenseCtx.addExpense({ ...expenseToPersist, id: id ?? "" });
     }
   };
 

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -252,17 +252,9 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
 
     const dates: Date[] = [];
     for (let i = 0; i <= days; i++) {
-      const newDate = getDatePlusDays(day1, i);
-      if (newDate instanceof Date) {
-        newDate.setHours(new Date().getHours(), new Date().getMinutes());
-        dates.push(newDate);
-      } else if (newDate instanceof DateTime) {
-        newDate.set({
-          hour: new Date().getHours(),
-          minute: new Date().getMinutes(),
-        });
-        dates.push(newDate.toJSDate());
-      }
+      const newDate = getDatePlusDays(day1, i) as Date;
+      newDate.setHours(new Date().getHours(), new Date().getMinutes());
+      dates.push(newDate);
     }
 
     const instances = expandRangedExpense(expenseData, {

--- a/TravelCostApp/util/expand-ranged-expense.ts
+++ b/TravelCostApp/util/expand-ranged-expense.ts
@@ -46,12 +46,17 @@ export function expandRangedExpense(
   input: ExpandRangedExpenseInput
 ): ExpenseData[] {
   const dayCount = input.dates.length;
-  const distributed = distributeRangedExpenseAmounts(expenseData, dayCount);
-  const rangeId = dayCount === 1 ? undefined : input.rangeId ?? undefined;
+  const { amount, calcAmount, splitList } = distributeRangedExpenseAmounts(
+    expenseData,
+    dayCount
+  );
+  const rangeId = dayCount === 1 ? null : input.rangeId ?? null;
 
   return input.dates.map((date) => ({
     ...expenseData,
-    ...distributed,
+    amount,
+    calcAmount,
+    splitList: splitList?.map((split) => ({ ...split })),
     date,
     rangeId,
   }));

--- a/TravelCostApp/util/expand-ranged-expense.ts
+++ b/TravelCostApp/util/expand-ranged-expense.ts
@@ -1,0 +1,58 @@
+import { DuplicateOption, type ExpenseData, type Split } from "./expense";
+import { distributeRangedAmount } from "./expense-form-range";
+export type ExpandRangedExpenseInput = {
+  rangeId: string | null;
+  dates: Date[];
+};
+
+type RangedExpenseSource = ExpenseData & {
+  alreadyDividedAmountByDays?: boolean;
+};
+
+function distributeRangedExpenseAmounts(
+  expenseData: RangedExpenseSource,
+  dayCount: number
+): Pick<ExpenseData, "amount" | "calcAmount" | "splitList"> {
+  if (Number(expenseData.duplOrSplit) !== DuplicateOption.split) {
+    return {
+      amount: expenseData.amount,
+      calcAmount: expenseData.calcAmount,
+      splitList: expenseData.splitList?.map((split) => ({ ...split })),
+    };
+  }
+
+  const rangedDistributeInput = {
+    dayCount,
+    mode: DuplicateOption.split,
+    alreadyDivided: Boolean(expenseData.alreadyDividedAmountByDays),
+  };
+
+  const distribute = (total: number) =>
+    distributeRangedAmount({ total, ...rangedDistributeInput });
+
+  return {
+    amount: distribute(expenseData.amount),
+    calcAmount: distribute(expenseData.calcAmount),
+    splitList: (expenseData.splitList ?? []).map((split: Split) => ({
+      ...split,
+      amount: distribute(split.amount),
+    })),
+  };
+}
+
+/** Expands one submitted **Ranged expense** into per-day **Expense** records to persist. */
+export function expandRangedExpense(
+  expenseData: RangedExpenseSource,
+  input: ExpandRangedExpenseInput
+): ExpenseData[] {
+  const dayCount = input.dates.length;
+  const distributed = distributeRangedExpenseAmounts(expenseData, dayCount);
+  const rangeId = dayCount === 1 ? undefined : input.rangeId ?? undefined;
+
+  return input.dates.map((date) => ({
+    ...expenseData,
+    ...distributed,
+    date,
+    rangeId,
+  }));
+}


### PR DESCRIPTION
## Summary
- Add pure `expandRangedExpense` to turn one submitted **Ranged expense** into per-day `ExpenseData` records (dates, `rangeId`, and `distributeRangedAmount` for split/duplicate modes).
- Refactor `createRangedData` to resolve dates, call the module, then persist each instance (toast, offline queue, context only).
- Unit tests cover instance count, distribution, `rangeId` stamping, single-day collapse, and input immutability.

## Test plan
- [x] `pnpm test` (includes `__tests__/util/expand-ranged-expense.test.ts`)
- [ ] Create a multi-day **Ranged split** expense — per-day amounts sum to the entered total
- [ ] Create a multi-day **Ranged duplicate** expense — each day keeps the full per-day amount
- [ ] Confirm edit path unchanged (still handled in a follow-up slice)

Closes #292