### PR TITLE
Ranged expense: wire expansion into the edit path (editRangedData)

### DIFF
--- a/TravelCostApp/__tests__/util/plan-ranged-expense-edit.test.ts
+++ b/TravelCostApp/__tests__/util/plan-ranged-expense-edit.test.ts
@@ -4,6 +4,7 @@ import {
   planNonRangedToRangedInstances,
   planRangedExpenseInPlaceUpdates,
   planRangedExpenseReplacement,
+  shouldReplaceRangedExpenseInstances,
 } from "../../util/plan-ranged-expense-edit";
 import { makeExpense } from "../fixtures/expense";
 
@@ -98,6 +99,60 @@ describe("haveRangedExpenseSpanChanged", () => {
   });
 });
 
+describe("shouldReplaceRangedExpenseInstances", () => {
+  it("returns true when span endpoints match but stored instance count differs", () => {
+    const existing = [
+      makeExpense({
+        id: "e1",
+        rangeId: "r1",
+        date: DAY1,
+        startDate: DAY1,
+        endDate: DAY3,
+      }),
+      makeExpense({
+        id: "e3",
+        rangeId: "r1",
+        date: DAY3,
+        startDate: DAY1,
+        endDate: DAY3,
+      }),
+    ];
+    const submitted = makeExpense({ startDate: DAY1, endDate: DAY3 });
+
+    expect(haveRangedExpenseSpanChanged(existing, submitted)).toBe(false);
+    expect(shouldReplaceRangedExpenseInstances(existing, submitted)).toBe(true);
+  });
+
+  it("returns false when span and instance count both match", () => {
+    const existing = [
+      makeExpense({
+        id: "e1",
+        rangeId: "r1",
+        date: DAY1,
+        startDate: DAY1,
+        endDate: DAY3,
+      }),
+      makeExpense({
+        id: "e2",
+        rangeId: "r1",
+        date: DAY2,
+        startDate: DAY1,
+        endDate: DAY3,
+      }),
+      makeExpense({
+        id: "e3",
+        rangeId: "r1",
+        date: DAY3,
+        startDate: DAY1,
+        endDate: DAY3,
+      }),
+    ];
+    const submitted = makeExpense({ startDate: DAY1, endDate: DAY3 });
+
+    expect(shouldReplaceRangedExpenseInstances(existing, submitted)).toBe(false);
+  });
+});
+
 describe("planRangedExpenseReplacement", () => {
   it("expands a fresh instance set whose per-day amounts reconstruct the total", () => {
     const submitted = makeExpense({
@@ -115,6 +170,23 @@ describe("planRangedExpenseReplacement", () => {
     expect(instances.every((e) => e.amount === 50)).toBe(true);
     const summed = instances.reduce((sum, e) => sum + e.amount, 0);
     expect(Number(summed.toFixed(2))).toBe(150);
+  });
+
+  it("documents rounding drift when the total does not divide evenly", () => {
+    const submitted = makeExpense({
+      startDate: DAY1,
+      endDate: DAY3,
+      amount: 100,
+      calcAmount: 100,
+      duplOrSplit: DuplicateOption.split,
+    });
+
+    const instances = planRangedExpenseReplacement(submitted, "r-new");
+
+    expect(instances.map((e) => e.amount)).toEqual([33.33, 33.33, 33.33]);
+    expect(Number(instances.reduce((sum, e) => sum + e.amount, 0).toFixed(2))).toBe(
+      99.99
+    );
   });
 });
 

--- a/TravelCostApp/__tests__/util/plan-ranged-expense-edit.test.ts
+++ b/TravelCostApp/__tests__/util/plan-ranged-expense-edit.test.ts
@@ -1,0 +1,137 @@
+import { DuplicateOption } from "../../util/expense";
+import {
+  haveRangedExpenseSpanChanged,
+  planNonRangedToRangedInstances,
+  planRangedExpenseInPlaceUpdates,
+  planRangedExpenseReplacement,
+} from "../../util/plan-ranged-expense-edit";
+import { makeExpense } from "../fixtures/expense";
+
+const DAY1 = new Date("2026-01-15T12:00:00.000Z");
+const DAY2 = new Date("2026-01-16T12:00:00.000Z");
+const DAY3 = new Date("2026-01-17T12:00:00.000Z");
+
+describe("planRangedExpenseInPlaceUpdates", () => {
+  it("updates existing instances in place with per-day split distribution", () => {
+    const existing = [
+      makeExpense({
+        id: "e1",
+        rangeId: "r1",
+        date: DAY1,
+        startDate: DAY1,
+        endDate: DAY3,
+        amount: 40,
+        calcAmount: 40,
+      }),
+      makeExpense({
+        id: "e2",
+        rangeId: "r1",
+        date: DAY2,
+        startDate: DAY1,
+        endDate: DAY3,
+        amount: 40,
+        calcAmount: 40,
+      }),
+      makeExpense({
+        id: "e3",
+        rangeId: "r1",
+        date: DAY3,
+        startDate: DAY1,
+        endDate: DAY3,
+        amount: 40,
+        calcAmount: 40,
+      }),
+    ];
+    const submitted = makeExpense({
+      startDate: DAY1,
+      endDate: DAY3,
+      amount: 150,
+      calcAmount: 150,
+      duplOrSplit: DuplicateOption.split,
+      splitList: [
+        { userName: "Alice", amount: 90 },
+        { userName: "Bob", amount: 60 },
+      ],
+      description: "updated hotel",
+    });
+
+    const updates = planRangedExpenseInPlaceUpdates(submitted, existing);
+
+    expect(updates).toHaveLength(3);
+    expect(updates.map((u) => u.id)).toEqual(["e1", "e2", "e3"]);
+    expect(updates.every((u) => u.expenseData.rangeId === "r1")).toBe(true);
+    expect(updates.every((u) => u.expenseData.amount === 50)).toBe(true);
+    expect(updates.every((u) => u.expenseData.description === "updated hotel")).toBe(
+      true
+    );
+    const summed = updates.reduce((sum, u) => sum + u.expenseData.amount, 0);
+    expect(Number(summed.toFixed(2))).toBe(150);
+  });
+});
+
+describe("haveRangedExpenseSpanChanged", () => {
+  const existing = [
+    makeExpense({
+      id: "e1",
+      rangeId: "r1",
+      date: DAY1,
+      startDate: DAY1,
+      endDate: DAY2,
+    }),
+    makeExpense({
+      id: "e2",
+      rangeId: "r1",
+      date: DAY2,
+      startDate: DAY1,
+      endDate: DAY2,
+    }),
+  ];
+
+  it("returns false when start and end match the stored span", () => {
+    const submitted = makeExpense({ startDate: DAY1, endDate: DAY2 });
+    expect(haveRangedExpenseSpanChanged(existing, submitted)).toBe(false);
+  });
+
+  it("returns true when the submitted span differs", () => {
+    const submitted = makeExpense({ startDate: DAY1, endDate: DAY3 });
+    expect(haveRangedExpenseSpanChanged(existing, submitted)).toBe(true);
+  });
+});
+
+describe("planRangedExpenseReplacement", () => {
+  it("expands a fresh instance set whose per-day amounts reconstruct the total", () => {
+    const submitted = makeExpense({
+      startDate: DAY1,
+      endDate: DAY3,
+      amount: 150,
+      calcAmount: 150,
+      duplOrSplit: DuplicateOption.split,
+    });
+
+    const instances = planRangedExpenseReplacement(submitted, "r-new");
+
+    expect(instances).toHaveLength(3);
+    expect(instances.every((e) => e.rangeId === "r-new")).toBe(true);
+    expect(instances.every((e) => e.amount === 50)).toBe(true);
+    const summed = instances.reduce((sum, e) => sum + e.amount, 0);
+    expect(Number(summed.toFixed(2))).toBe(150);
+  });
+});
+
+describe("planNonRangedToRangedInstances", () => {
+  it("expands a single-day expense into per-day instances sharing one rangeId", () => {
+    const submitted = makeExpense({
+      startDate: DAY1,
+      endDate: DAY3,
+      amount: 90,
+      calcAmount: 90,
+      duplOrSplit: DuplicateOption.split,
+    });
+
+    const instances = planNonRangedToRangedInstances(submitted, "r-convert");
+
+    expect(instances).toHaveLength(3);
+    expect(instances.every((e) => e.rangeId === "r-convert")).toBe(true);
+    expect(instances.every((e) => e.amount === 30)).toBe(true);
+  });
+});

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -10,8 +10,14 @@ import { TripContext } from "../store/trip-context";
 import { touchAllTravelers } from "../util/http";
 import { GlobalStyles } from "../constants/styles";
 import { getRate } from "../util/currencyExchange";
-import { daysBetween, getDatePlusDays } from "../util/date";
 import { expandRangedExpense } from "../util/expand-ranged-expense";
+import {
+  buildRangedExpenseDatesFromSpan,
+  haveRangedExpenseSpanChanged,
+  planNonRangedToRangedInstances,
+  planRangedExpenseInPlaceUpdates,
+  planRangedExpenseReplacement,
+} from "../util/plan-ranged-expense-edit";
 import { isPaidString } from "../util/expense";
 import {
   deleteExpenseOnlineOffline,
@@ -42,7 +48,6 @@ import { trackEvent } from "../util/vexo-tracking";
 import { isConnectionFastEnoughAsBool } from "../util/connectionSpeed";
 import { dynamicScale } from "../util/scalingUtil";
 import { VexoEvents } from "../util/vexo-constants";
-import { DateTime } from "luxon";
 
 interface ManageExpenseProps {
   route: {
@@ -241,26 +246,11 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
     expenseCtx.addExpense(expenseToAdd);
   };
 
-  const createRangedData = async (expenseData: ExpenseData) => {
-    const rangeId =
-      Date.now().toString() + Math.random().toString(36).substring(2, 15);
+  const newRangeId = () =>
+    Date.now().toString() + Math.random().toString(36).substring(2, 15);
 
-    const day1 = new Date(expenseData.startDate);
-    const day2 = new Date(expenseData.endDate);
-    const days = daysBetween(day2, day1);
-    const isSingleDay = isSameDay(expenseData.endDate, expenseData.startDate);
-
-    const dates: Date[] = [];
-    for (let i = 0; i <= days; i++) {
-      const newDate = getDatePlusDays(day1, i) as Date;
-      newDate.setHours(new Date().getHours(), new Date().getMinutes());
-      dates.push(newDate);
-    }
-
-    const instances = expandRangedExpense(expenseData, {
-      rangeId: isSingleDay ? null : rangeId,
-      dates,
-    });
+  const persistNewRangedInstances = async (instances: ExpenseData[]) => {
+    const progressMax = Math.max(instances.length - 1, 0);
 
     for (let i = 0; i < instances.length; i++) {
       Toast.show({
@@ -269,9 +259,9 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
         text2: i18n.t("toastSaving2"),
         autoHide: false,
         props: {
-          progress: days === 0 ? 0 : i / days,
+          progress: progressMax === 0 ? 0 : i / progressMax,
           progressAt: i,
-          progressMax: days,
+          progressMax,
           size: "small",
         },
       });
@@ -294,6 +284,21 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
     }
   };
 
+  const createRangedData = async (expenseData: ExpenseData) => {
+    const rangeId = newRangeId();
+    const dates = buildRangedExpenseDatesFromSpan(
+      expenseData.startDate,
+      expenseData.endDate
+    );
+    const isSingleDay = isSameDay(expenseData.endDate, expenseData.startDate);
+    const instances = expandRangedExpense(expenseData, {
+      rangeId: isSingleDay ? null : rangeId,
+      dates,
+    });
+
+    await persistNewRangedInstances(instances);
+  };
+
   const editSingleData = async (expenseData: ExpenseData) => {
     expenseData.editedTimestamp = Date.now();
     const item: OfflineQueueManageExpenseItem = {
@@ -309,15 +314,13 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
     await updateExpenseOnlineOffline(item, isOnline);
   };
 
-  const editRangedData = async (expenseData) => {
-    // find all the expenses that have the same identifying rangeId
+  const editRangedData = async (expenseData: ExpenseData) => {
     const expensesInRange = expenseCtx.expenses.filter(
       (expense) =>
         expense.rangeId && expense.rangeId === selectedExpense?.rangeId
     );
-    // if we dont find any expenses, it must have been a non-ranged expense, so update it to a ranged expense
-    if (expensesInRange?.length === 0) {
-      // delete the original expense
+
+    if (expensesInRange.length === 0) {
       expenseCtx.deleteExpense(editedExpenseId);
       const item: OfflineQueueManageExpenseItem = {
         type: "delete",
@@ -328,25 +331,13 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
         },
       };
       await deleteExpenseOnlineOffline(item, isOnline);
-      await createRangedData(expenseData);
+
+      const instances = planNonRangedToRangedInstances(expenseData, newRangeId());
+      await persistNewRangedInstances(instances);
       return;
     }
-    // sort the expenses by date, oldest expense first
-    expensesInRange.sort((a, b) => {
-      return new Date(a.date).getTime() - new Date(b.date).getTime();
-    });
 
-    // check if the dates are the same, then update one by one or redo all
-    // get the first and last day from expenses in range
-    const oldStart = new Date(expensesInRange[0].date);
-    const oldEnd = new Date(expensesInRange[expensesInRange?.length - 1].date);
-    // get days from expenseData
-    const newStart = new Date(expenseData.startDate);
-    const newEnd = new Date(expenseData.endDate);
-    const differentDates =
-      !isSameDay(oldStart, newStart) || !isSameDay(oldEnd, newEnd);
-    if (differentDates) {
-      // Delete old expenses FIRST
+    if (haveRangedExpenseSpanChanged(expensesInRange, expenseData)) {
       await deleteAllExpensesByRangedId(
         tripid,
         selectedExpense,
@@ -354,55 +345,40 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
         expenseCtx,
         { showUndoToast: false },
       );
-      // Then create new expenses
-      await createRangedData(expenseData);
+
+      const instances = planRangedExpenseReplacement(expenseData, newRangeId());
+      await persistNewRangedInstances(instances);
       return;
     }
-    //else update the expenses one by one
-    for (let i = 0; i < expensesInRange?.length; i++) {
+
+    const updates = planRangedExpenseInPlaceUpdates(expenseData, expensesInRange);
+    const progressMax = updates.length;
+
+    for (let i = 0; i < updates.length; i++) {
       Toast.show({
         type: "loading",
         text1: i18n.t("toastSaving1"),
-        text2: i18n.t("toastSaving2"), //+ " " + (i + 1) + "/" + (expensesInRange?.length + 1)
+        text2: i18n.t("toastSaving2"),
         autoHide: false,
         props: {
-          progress: i / expensesInRange?.length,
+          progress: i / progressMax,
           progressAt: i,
-          progressMax: expensesInRange?.length,
+          progressMax,
           size: "small",
         },
       });
-      const expense = expensesInRange[i];
-      // set the correct new date
-      const newDate = getDatePlusDays(expenseData.startDate, i);
-      if (newDate instanceof Date) {
-        newDate.setHours(new Date().getHours(), new Date().getMinutes());
-      } else if (newDate instanceof DateTime) {
-        newDate.set({
-          hour: new Date().getHours(),
-          minute: new Date().getMinutes(),
-        });
-      }
-      // IMPORTANT: don't mutate the shared expenseData object inside the loop.
-      // Mutating can cause stale/incorrect state during rerenders (and can lead to loops),
-      // especially when toggling fields like paidBack on ranged expenses.
-      const updatedExpenseData: ExpenseData = {
-        ...expenseData,
-        date: newDate,
-        editedTimestamp: Date.now(),
-        // sanity fix
-        rangeId: expense.rangeId,
-      };
+
+      const { id, expenseData: updatedExpenseData } = updates[i];
       const item: OfflineQueueManageExpenseItem = {
         type: "update",
         expense: {
           tripid: tripid,
           uid: selectedExpenseAuthorUid,
           expenseData: updatedExpenseData,
-          id: expense.id,
+          id,
         },
       };
-      expenseCtx.updateExpense(expense.id, updatedExpenseData);
+      expenseCtx.updateExpense(id, updatedExpenseData);
       await updateExpenseOnlineOffline(item, isOnline);
     }
   };

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -13,10 +13,10 @@ import { getRate } from "../util/currencyExchange";
 import { expandRangedExpense } from "../util/expand-ranged-expense";
 import {
   buildRangedExpenseDatesFromSpan,
-  haveRangedExpenseSpanChanged,
   planNonRangedToRangedInstances,
   planRangedExpenseInPlaceUpdates,
   planRangedExpenseReplacement,
+  shouldReplaceRangedExpenseInstances,
 } from "../util/plan-ranged-expense-edit";
 import { isPaidString } from "../util/expense";
 import {
@@ -337,7 +337,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
       return;
     }
 
-    if (haveRangedExpenseSpanChanged(expensesInRange, expenseData)) {
+    if (shouldReplaceRangedExpenseInstances(expensesInRange, expenseData)) {
       await deleteAllExpensesByRangedId(
         tripid,
         selectedExpense,

--- a/TravelCostApp/util/plan-ranged-expense-edit.ts
+++ b/TravelCostApp/util/plan-ranged-expense-edit.ts
@@ -47,6 +47,24 @@ export function haveRangedExpenseSpanChanged(
   return !isSameDay(oldStart, newStart) || !isSameDay(oldEnd, newEnd);
 }
 
+/** Whether edit should delete and re-expand instead of pairwise in-place updates. */
+export function shouldReplaceRangedExpenseInstances(
+  existingInstances: ExpenseData[],
+  submitted: ExpenseData
+): boolean {
+  if (haveRangedExpenseSpanChanged(existingInstances, submitted)) {
+    return true;
+  }
+
+  const sorted = sortInstancesByDate(existingInstances);
+  const dayCount = buildRangedExpenseDatesFromSpan(
+    submitted.startDate,
+    submitted.endDate
+  ).length;
+
+  return sorted.length !== dayCount;
+}
+
 /** Pairwise in-place updates for an unchanged **Ranged expense** span. */
 export function planRangedExpenseInPlaceUpdates(
   submitted: ExpenseData,
@@ -59,6 +77,12 @@ export function planRangedExpenseInPlaceUpdates(
   );
   const rangeId = sorted[0]?.rangeId ?? null;
   const expanded = expandRangedExpense(submitted, { rangeId, dates });
+
+  if (sorted.length !== expanded.length) {
+    throw new Error(
+      "Ranged expense instance count does not match span; use replacement path"
+    );
+  }
 
   return expanded.map((expenseData, index) => ({
     id: sorted[index].id,

--- a/TravelCostApp/util/plan-ranged-expense-edit.ts
+++ b/TravelCostApp/util/plan-ranged-expense-edit.ts
@@ -1,0 +1,91 @@
+import { daysBetween, getDatePlusDays } from "./date";
+import type { ExpenseData } from "./expense";
+import { expandRangedExpense } from "./expand-ranged-expense";
+import { isSameDay } from "./dateTime";
+
+export type RangedExpenseInstanceUpdate = {
+  id: string;
+  expenseData: ExpenseData;
+};
+
+/** Inclusive per-day dates for a **Ranged expense** span (matches create/edit paths). */
+export function buildRangedExpenseDatesFromSpan(
+  startDate: Date,
+  endDate: Date
+): Date[] {
+  const day1 = new Date(startDate);
+  const day2 = new Date(endDate);
+  const days = daysBetween(day2, day1);
+  const dates: Date[] = [];
+
+  for (let i = 0; i <= days; i++) {
+    const newDate = getDatePlusDays(day1, i) as Date;
+    newDate.setHours(new Date().getHours(), new Date().getMinutes());
+    dates.push(newDate);
+  }
+
+  return dates;
+}
+
+function sortInstancesByDate(instances: ExpenseData[]): ExpenseData[] {
+  return [...instances].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+}
+
+/** Whether the submitted span differs from the stored per-day instances. */
+export function haveRangedExpenseSpanChanged(
+  existingInstances: ExpenseData[],
+  submitted: ExpenseData
+): boolean {
+  const sorted = sortInstancesByDate(existingInstances);
+  const oldStart = new Date(sorted[0].date);
+  const oldEnd = new Date(sorted[sorted.length - 1].date);
+  const newStart = new Date(submitted.startDate);
+  const newEnd = new Date(submitted.endDate);
+
+  return !isSameDay(oldStart, newStart) || !isSameDay(oldEnd, newEnd);
+}
+
+/** Pairwise in-place updates for an unchanged **Ranged expense** span. */
+export function planRangedExpenseInPlaceUpdates(
+  submitted: ExpenseData,
+  existingInstances: ExpenseData[]
+): RangedExpenseInstanceUpdate[] {
+  const sorted = sortInstancesByDate(existingInstances);
+  const dates = buildRangedExpenseDatesFromSpan(
+    submitted.startDate,
+    submitted.endDate
+  );
+  const rangeId = sorted[0]?.rangeId ?? null;
+  const expanded = expandRangedExpense(submitted, { rangeId, dates });
+
+  return expanded.map((expenseData, index) => ({
+    id: sorted[index].id,
+    expenseData: {
+      ...expenseData,
+      editedTimestamp: Date.now(),
+    },
+  }));
+}
+
+/** Fresh per-day instances after a span change (caller deletes old range first). */
+export function planRangedExpenseReplacement(
+  submitted: ExpenseData,
+  rangeId: string
+): ExpenseData[] {
+  const dates = buildRangedExpenseDatesFromSpan(
+    submitted.startDate,
+    submitted.endDate
+  );
+
+  return expandRangedExpense(submitted, { rangeId, dates });
+}
+
+/** Expands a single-day **Expense** into a new **Ranged expense** instance set. */
+export function planNonRangedToRangedInstances(
+  submitted: ExpenseData,
+  rangeId: string
+): ExpenseData[] {
+  return planRangedExpenseReplacement(submitted, rangeId);
+}


### PR DESCRIPTION
## Summary
- Add `plan-ranged-expense-edit` so create and edit share `expandRangedExpense` for per-day distribution and shaping.
- Wire `editRangedData` to plan in-place updates, span replacements, and non-ranged→ranged conversion while keeping toast/offline/context writes in the screen.
- Remove inline amount/split division from the edit loop; unchanged-span edits now preserve instance ids and distribute split totals correctly.

## Test plan
- [x] `pnpm test` (373 tests pass)
- [ ] Edit a ranged-split expense without changing dates — per-day amounts update, ids preserved
- [ ] Edit a ranged expense with new start/end — old instances replaced, total reconstructs
- [ ] Edit a single-day expense into a multi-day span — expands with shared `rangeId`

Closes #293