### PR TITLE
Ranged expense: useRangedMode state machine

### DIFF
--- a/TravelCostApp/__tests__/hooks/use-ranged-mode.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-ranged-mode.test.ts
@@ -1,0 +1,162 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useRangedMode } from "../../hooks/useRangedMode";
+import { DuplicateOption } from "../../util/expense";
+import { buildRangedDuplOrSplitPromptString } from "../../util/expense-form-range";
+
+function renderRangedMode(
+  overrides: Partial<Parameters<typeof useRangedMode>[0]> = {}
+) {
+  return renderHook(() =>
+    useRangedMode({
+      isEditing: false,
+      ...overrides,
+    })
+  );
+}
+
+describe("useRangedMode", () => {
+  it("derives alreadyDivided when editing a ranged split expense", () => {
+    const { result } = renderRangedMode({
+      isEditing: true,
+      initialDuplOrSplit: DuplicateOption.split,
+    });
+
+    expect(result.current.mode).toBe("split");
+    expect(result.current.duplOrSplit).toBe(DuplicateOption.split);
+    expect(result.current.alreadyDividedAmountByDays).toBe(true);
+  });
+
+  it("clears alreadyDivided when the user picks ranged split from the range prompt before a mode was set", () => {
+    const { result } = renderRangedMode({
+      isEditing: true,
+      initialDuplOrSplit: DuplicateOption.null,
+    });
+
+    act(() => {
+      result.current.confirmSplit();
+    });
+
+    expect(result.current.mode).toBe("split");
+    expect(result.current.alreadyDividedAmountByDays).toBe(false);
+  });
+
+  it("keeps alreadyDivided when re-confirming ranged split on an already-divided edit", () => {
+    const { result } = renderRangedMode({
+      isEditing: true,
+      initialDuplOrSplit: DuplicateOption.split,
+    });
+
+    act(() => {
+      result.current.confirmSplit();
+    });
+
+    expect(result.current.alreadyDividedAmountByDays).toBe(true);
+  });
+
+  it("restores the total amount when collapsing an already-divided ranged split to one day", () => {
+    const { result } = renderRangedMode({
+      isEditing: true,
+      initialDuplOrSplit: DuplicateOption.split,
+    });
+
+    expect(
+      result.current.resolveCollapseToSingleDayAmount({
+        amount: 50,
+        inclusiveDayCount: 3,
+      })
+    ).toBe("150.00");
+  });
+
+  it("stores per-day amount when collapsing a new ranged split to one day", () => {
+    const { result } = renderRangedMode({
+      isEditing: false,
+      initialDuplOrSplit: DuplicateOption.null,
+    });
+
+    act(() => {
+      result.current.confirmSplit();
+    });
+
+    expect(
+      result.current.resolveCollapseToSingleDayAmount({
+        amount: 150,
+        inclusiveDayCount: 3,
+      })
+    ).toBe("50.00");
+  });
+
+  it("requests duplicate/split choice when a multi-day range is confirmed with no mode", () => {
+    const { result } = renderRangedMode({ isEditing: false });
+
+    act(() => {
+      result.current.onMultiDayRangeConfirmed();
+    });
+
+    expect(result.current.shouldPromptForMode).toBe(true);
+  });
+
+  it("maps ranged modes to existing DuplicateOption values at the persistence seam", () => {
+    const { result } = renderRangedMode({ isEditing: false });
+
+    act(() => {
+      result.current.confirmDuplicate();
+    });
+    expect(result.current.duplOrSplit).toBe(DuplicateOption.duplicate);
+
+    act(() => {
+      result.current.confirmSplit();
+    });
+    expect(result.current.duplOrSplit).toBe(DuplicateOption.split);
+
+    act(() => {
+      result.current.clearMode();
+    });
+    expect(result.current.duplOrSplit).toBe(DuplicateOption.null);
+  });
+
+  it("uses split prompt figures that match per-day amounts used when saving", () => {
+    const promptLabels = {
+      duplString1: "Duplicating",
+      duplString2: "over",
+      duplString3: "days",
+      duplString4: "Resulting in a",
+      splitString1: "Splitting up the",
+      splitString2: "over",
+      splitString3: "days, each",
+      total: "Total",
+    };
+    const formatAmount = (amount: number) => `$${amount.toFixed(2)}`;
+    const amount = 50;
+    const inclusiveDayCount = 3;
+
+    const { result } = renderRangedMode({
+      isEditing: true,
+      initialDuplOrSplit: DuplicateOption.split,
+    });
+
+    const splitPrompt = buildRangedDuplOrSplitPromptString(2, {
+      amount,
+      inclusiveDayCount,
+      alreadyDividedAmountByDays: result.current.alreadyDividedAmountByDays,
+      formatAmount,
+      labels: promptLabels,
+    });
+
+    expect(splitPrompt).toBe(
+      "Splitting up the $150.00\nover 3 days, each $50.00"
+    );
+
+    const duplicatePrompt = buildRangedDuplOrSplitPromptString(1, {
+      amount,
+      inclusiveDayCount,
+      alreadyDividedAmountByDays: result.current.alreadyDividedAmountByDays,
+      formatAmount,
+      labels: promptLabels,
+    });
+
+    expect(duplicatePrompt).toBe(
+      "Duplicating $50.00 over 3 days. \nResulting in a $150.00 Total"
+    );
+  });
+});

--- a/TravelCostApp/__tests__/hooks/use-ranged-mode.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-ranged-mode.test.ts
@@ -2,7 +2,10 @@ import { act, renderHook } from "@testing-library/react-native";
 
 import { useRangedMode } from "../../hooks/useRangedMode";
 import { DuplicateOption } from "../../util/expense";
-import { buildRangedDuplOrSplitPromptString } from "../../util/expense-form-range";
+import {
+  buildRangedDuplOrSplitPromptString,
+  distributeRangedAmount,
+} from "../../util/expense-form-range";
 
 function renderRangedMode(
   overrides: Partial<Parameters<typeof useRangedMode>[0]> = {}
@@ -94,6 +97,63 @@ describe("useRangedMode", () => {
     });
 
     expect(result.current.shouldPromptForMode).toBe(true);
+  });
+
+  it.each([
+    ["duplicate", DuplicateOption.duplicate],
+    ["split", DuplicateOption.split],
+  ])(
+    "does not request duplicate/split choice when multi-day range is confirmed with ranged %s mode",
+    (_label, initialDuplOrSplit) => {
+      const { result } = renderRangedMode({
+        isEditing: false,
+        initialDuplOrSplit,
+      });
+
+      act(() => {
+        result.current.onMultiDayRangeConfirmed();
+      });
+
+      expect(result.current.shouldPromptForMode).toBe(false);
+    }
+  );
+
+  it("keeps per-day amount for split recalc when editing an already-divided ranged split", () => {
+    const { result } = renderRangedMode({
+      isEditing: true,
+      initialDuplOrSplit: DuplicateOption.split,
+    });
+    const perDayInField = 50;
+    const dayCount = 3;
+
+    expect(
+      distributeRangedAmount({
+        total: perDayInField,
+        dayCount,
+        mode: result.current.duplOrSplit,
+        alreadyDivided: result.current.alreadyDividedAmountByDays,
+      })
+    ).toBe(50);
+  });
+
+  it("divides total across days after freshly confirming ranged split", () => {
+    const { result } = renderRangedMode({
+      isEditing: true,
+      initialDuplOrSplit: DuplicateOption.null,
+    });
+
+    act(() => {
+      result.current.confirmSplit();
+    });
+
+    expect(
+      distributeRangedAmount({
+        total: 150,
+        dayCount: 3,
+        mode: result.current.duplOrSplit,
+        alreadyDivided: result.current.alreadyDividedAmountByDays,
+      })
+    ).toBe(50);
   });
 
   it("maps ranged modes to existing DuplicateOption values at the persistence seam", () => {

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -50,6 +50,7 @@ import {
   validateSplitListWithEditOrder,
 } from "../../util/split";
 import { useSplitEditor } from "../../hooks/useSplitEditor";
+import { useRangedMode } from "../../hooks/useRangedMode";
 import { useExpenseFx } from "../../hooks/useExpenseFx";
 import { useExpenseFormInputs } from "../../hooks/useExpenseFormInputs";
 import {
@@ -104,8 +105,6 @@ import {
 import {
   buildRangedDuplOrSplitPromptString,
   countInclusiveDaysInRange,
-  resolveAlreadyDividedAmountByDays,
-  resolveAmountWhenCollapsingRangeToSingleDay,
 } from "../../util/expense-form-range";
 import { NetworkContext } from "../../store/network-context";
 import { SettingsContext } from "../../store/settings-context";
@@ -267,9 +266,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   const [loadingTravellers, setLoadingTravellers] = useState(
     !tripCtx.travellers && tripCtx.travellers?.length < 1
   );
-
-  const [confirmedRange, setConfirmedRange] = useState(false);
-  const [helperStateForDividing, setHelperStateForDividing] = useState(false);
 
   const extractUserNames = useCallback(
     (travellers: string[] | Traveller[] | undefined): string[] => {
@@ -437,15 +433,25 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       ? countInclusiveDaysInRange(new Date(startDate), new Date(endDate))
       : 1;
 
-  const [duplOrSplit, setDuplOrSplit] = useState<DuplicateOption>(
-    editingValues ? Number(editingValues.duplOrSplit) : DuplicateOption.null
-  );
-
-  const alreadyDividedAmountByDays = resolveAlreadyDividedAmountByDays(
+  const rangedMode = useRangedMode({
     isEditing,
+    initialDuplOrSplit: editingValues
+      ? Number(editingValues.duplOrSplit)
+      : DuplicateOption.null,
+  });
+
+  const {
     duplOrSplit,
-    helperStateForDividing
-  );
+    alreadyDividedAmountByDays,
+    shouldPromptForMode,
+    onMultiDayRangeConfirmed,
+    consumeModePrompt,
+    confirmDuplicate,
+    confirmSplit,
+    clearMode,
+    setModeFromDuplOrSplit,
+    resolveCollapseToSingleDayAmount,
+  } = rangedMode;
 
   const splitEditor = useSplitEditor({
     initialSplitList: resetEditOrder(editingValues?.splitList ?? []),
@@ -619,25 +625,23 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     // no range
     if (startDateFormat === endDateFormat) {
       inputChangedHandler("date", startDateFormat);
-      const adjustedAmount = resolveAmountWhenCollapsingRangeToSingleDay({
+      const adjustedAmount = resolveCollapseToSingleDayAmount({
         amount: Number(amountValue),
         inclusiveDayCount: daysBeween,
-        duplOrSplit,
-        alreadyDividedAmountByDays,
       });
       if (adjustedAmount !== null) {
         inputChangedHandler("amount", adjustedAmount);
       }
-      setDuplOrSplit(DuplicateOption.null);
+      clearMode();
       return;
     }
-    if (duplOrSplit == DuplicateOption.null) setConfirmedRange(true);
+    onMultiDayRangeConfirmed();
 
     // TODO: make this structured
   };
   useLayoutEffect(() => {
-    if (!confirmedRange) return;
-    setConfirmedRange(false);
+    if (!shouldPromptForMode) return;
+    consumeModePrompt();
     Alert.alert(
       `${i18n.t("duplicateExpenses")} / ${i18n.t("splitUpExpenses")}`, //i18n.t("duplOrSplit"),
       `${i18n.t("duplicateExpenses")}: ${duplOrSplitString(1)}\n\n ${i18n.t(
@@ -648,15 +652,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
           text: i18n.t("duplicateExpenses"), //i18n.t("duplicate"),
           onPress: () => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-            setDuplOrSplit(DuplicateOption.duplicate);
+            confirmDuplicate();
           },
         },
         {
           text: i18n.t("splitUpExpenses"), //i18n.t("split"),
           onPress: () => {
-            if (duplOrSplit !== 2) setHelperStateForDividing(true);
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-            setDuplOrSplit(DuplicateOption.split);
+            confirmSplit();
           },
         },
       ],
@@ -668,9 +671,11 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     amountValue,
     inputs.currency.value,
     daysBeween,
-    duplOrSplit,
-    confirmedRange,
+    shouldPromptForMode,
     duplOrSplitString,
+    consumeModePrompt,
+    confirmDuplicate,
+    confirmSplit,
   ]);
 
   useEffect(() => {
@@ -976,7 +981,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
                 setSplitList(restored.splitList);
               }
               if (restored.duplOrSplit !== undefined) {
-                setDuplOrSplit(restored.duplOrSplit);
+                setModeFromDuplOrSplit(restored.duplOrSplit);
               }
               if (restored.paidBack) {
                 setPaidBack(restored.paidBack);

--- a/TravelCostApp/hooks/useRangedMode.ts
+++ b/TravelCostApp/hooks/useRangedMode.ts
@@ -1,0 +1,112 @@
+import { useCallback, useState } from "react";
+
+import { DuplicateOption } from "../util/expense";
+import {
+  resolveAlreadyDividedAmountByDays,
+  resolveAmountWhenCollapsingRangeToSingleDay,
+} from "../util/expense-form-range";
+
+export type RangedMode = "none" | "duplicate" | "split";
+
+export function rangedModeToDuplOrSplit(mode: RangedMode): DuplicateOption {
+  if (mode === "duplicate") return DuplicateOption.duplicate;
+  if (mode === "split") return DuplicateOption.split;
+  return DuplicateOption.null;
+}
+
+export function duplOrSplitToRangedMode(
+  duplOrSplit: DuplicateOption | number | undefined
+): RangedMode {
+  const n = Number(duplOrSplit ?? DuplicateOption.null);
+  if (n === DuplicateOption.duplicate) return "duplicate";
+  if (n === DuplicateOption.split) return "split";
+  return "none";
+}
+
+export type UseRangedModeParams = {
+  isEditing: boolean;
+  initialDuplOrSplit?: DuplicateOption | number;
+};
+
+export function useRangedMode({
+  isEditing,
+  initialDuplOrSplit = DuplicateOption.null,
+}: UseRangedModeParams) {
+  const [mode, setMode] = useState<RangedMode>(() =>
+    duplOrSplitToRangedMode(initialDuplOrSplit)
+  );
+  const [pendingFreshSplitDivision, setPendingFreshSplitDivision] =
+    useState(false);
+  const [shouldPromptForMode, setShouldPromptForMode] = useState(false);
+
+  const duplOrSplit = rangedModeToDuplOrSplit(mode);
+  const alreadyDividedAmountByDays = resolveAlreadyDividedAmountByDays(
+    isEditing,
+    duplOrSplit,
+    pendingFreshSplitDivision
+  );
+
+  const clearMode = useCallback(() => {
+    setMode("none");
+    setPendingFreshSplitDivision(false);
+    setShouldPromptForMode(false);
+  }, []);
+
+  const setModeFromDuplOrSplit = useCallback(
+    (value: DuplicateOption | number | undefined) => {
+      setMode(duplOrSplitToRangedMode(value));
+      setPendingFreshSplitDivision(false);
+      setShouldPromptForMode(false);
+    },
+    []
+  );
+
+  const onMultiDayRangeConfirmed = useCallback(() => {
+    if (mode === "none") {
+      setShouldPromptForMode(true);
+    }
+  }, [mode]);
+
+  const consumeModePrompt = useCallback(() => {
+    setShouldPromptForMode(false);
+  }, []);
+
+  const confirmDuplicate = useCallback(() => {
+    setMode("duplicate");
+    setPendingFreshSplitDivision(false);
+    setShouldPromptForMode(false);
+  }, []);
+
+  const confirmSplit = useCallback(() => {
+    if (mode !== "split") {
+      setPendingFreshSplitDivision(true);
+    }
+    setMode("split");
+    setShouldPromptForMode(false);
+  }, [mode]);
+
+  const resolveCollapseToSingleDayAmount = useCallback(
+    (input: { amount: number; inclusiveDayCount: number }) =>
+      resolveAmountWhenCollapsingRangeToSingleDay({
+        amount: input.amount,
+        inclusiveDayCount: input.inclusiveDayCount,
+        duplOrSplit,
+        alreadyDividedAmountByDays,
+      }),
+    [alreadyDividedAmountByDays, duplOrSplit]
+  );
+
+  return {
+    mode,
+    duplOrSplit,
+    alreadyDividedAmountByDays,
+    shouldPromptForMode,
+    onMultiDayRangeConfirmed,
+    consumeModePrompt,
+    confirmDuplicate,
+    confirmSplit,
+    clearMode,
+    setModeFromDuplOrSplit,
+    resolveCollapseToSingleDayAmount,
+  };
+}

--- a/TravelCostApp/hooks/useRangedMode.ts
+++ b/TravelCostApp/hooks/useRangedMode.ts
@@ -1,6 +1,13 @@
 import { useCallback, useState } from "react";
 
 import { DuplicateOption } from "../util/expense";
+
+/**
+ * Ranged duplicate/split mode for the expense form.
+ * Owns mode transitions, derived alreadyDivided, and collapse amount rules.
+ * The duplicate/split Alert UI lives in ExpenseForm; per-day split recalc uses
+ * distributeRangedAmount in useSplitEditor, fed by this hook's outputs.
+ */
 import {
   resolveAlreadyDividedAmountByDays,
   resolveAmountWhenCollapsingRangeToSingleDay,

--- a/TravelCostApp/util/expense-form-range.ts
+++ b/TravelCostApp/util/expense-form-range.ts
@@ -52,11 +52,11 @@ export function distributeRangedAmount(
 export function resolveAlreadyDividedAmountByDays(
   isEditing: boolean,
   duplOrSplit: DuplicateOption | number,
-  helperStateForDividing: boolean
+  pendingFreshSplitDivision: boolean
 ): boolean {
   let alreadyDividedAmountByDays =
     isEditing && Number(duplOrSplit) === DuplicateOption.split;
-  if (helperStateForDividing) alreadyDividedAmountByDays = false;
+  if (pendingFreshSplitDivision) alreadyDividedAmountByDays = false;
   return alreadyDividedAmountByDays;
 }
 


### PR DESCRIPTION
## Summary

- Add `useRangedMode` with `RangedMode` (`none | duplicate | split`), derived `alreadyDividedAmountByDays`, and transitions for the duplicate/split prompt, collapse-to-single-day amount, and `DuplicateOption` persistence mapping.
- Wire `ExpenseForm` to the hook instead of four loosely coordinated booleans (`duplOrSplit`, `helperStateForDividing`, `alreadyDividedAmountByDays`, `confirmedRange`).
- Add hook tests for mode transitions, collapse amounts, and split/duplicate prompt figures.

## Test plan

- [x] `pnpm test` in `TravelCostApp`
- [ ] Pick a multi-day range on a new expense → duplicate/split alert → confirm each mode; amounts and summary copy look correct
- [ ] Edit an existing ranged split → change amount; splits are not divided twice
- [ ] Collapse a ranged split back to one day → amount restores correctly

Closes #294