### PR TITLE
Add update:production:bump for OTA publish + changelog bump

### DIFF
--- a/TravelCostApp/EAS_DEPLOYMENT_GUIDE.md
+++ b/TravelCostApp/EAS_DEPLOYMENT_GUIDE.md
@@ -178,10 +178,13 @@ Confirm in the EAS build log: **Spin up build environment** shows Xcode 26.x. Fo
 
 ```bash
 # Updates (no app store review needed)
-pnpm run update:dev "Message"        # → Development
-pnpm run update:staging "Message"    # → Internal testing
-pnpm run update:alpha "Message"      # → Beta testers
-pnpm run update:production "Message" # → All users
+pnpm run update:dev -- "Message"        # → Development
+pnpm run update:staging -- "Message"    # → Internal testing
+pnpm run update:alpha -- "Message"      # → Beta testers
+pnpm run update:production -- "Message" # → All users (message from changelog if omitted)
+pnpm run update:production:bump         # → Publish OTA + bump EAS changelog suffix (default note)
+pnpm run update:production:bump -- "Fix login"  # → Same, with custom changelog note
+pnpm run update:production:bump -- --dry-run    # → Preview publish + changelog bump only
 
 # Builds (requires app store review)
 pnpm run build:staging:all           # → Internal testing
@@ -195,6 +198,12 @@ pnpm run submit:production:android   # → Play Store
 ```
 
 ### 🎯 **Update Message Format**
+
+`update:production` without a message reads the newest `changelog.txt` block and publishes
+`{version}: {first bullet}` (for example `1.3.005c: Added restore feature`).
+
+`update:production:bump` publishes a plain note (default: `Bugfixes and performance improvements`)
+and then bumps the EAS suffix in `changelog.txt` with the same note.
 
 ```
 TYPE: Brief description

--- a/TravelCostApp/__tests__/scripts/eas-update-message.test.ts
+++ b/TravelCostApp/__tests__/scripts/eas-update-message.test.ts
@@ -1,0 +1,113 @@
+const {
+  parseEasUpdateArgs,
+  readMessageFromChangelogSource,
+  resolveUpdateMessage,
+  formatBumpRecoveryCommand,
+} = require("../../scripts/eas-update-message");
+
+describe("parseEasUpdateArgs", () => {
+  it("parses target, message, bump-changelog, and dry-run flags", () => {
+    expect(
+      parseEasUpdateArgs([
+        "--target",
+        "production",
+        "--bump-changelog",
+        "--dry-run",
+        "--message",
+        "Fix login",
+      ]),
+    ).toEqual({
+      target: "production",
+      message: "Fix login",
+      bumpChangelog: true,
+      dryRun: true,
+    });
+  });
+
+  it("accepts a trailing message after flags", () => {
+    expect(
+      parseEasUpdateArgs(["--target", "production", "--bump-changelog", "Fix login"]),
+    ).toEqual({
+      target: "production",
+      message: "Fix login",
+      bumpChangelog: true,
+      dryRun: false,
+    });
+  });
+});
+
+describe("readMessageFromChangelogSource", () => {
+  it("formats the newest changelog block as version plus first bullet", () => {
+    const source = [
+      "Changelog Travel Expense App",
+      "",
+      "__Newest Changes:",
+      "",
+      "1.3.005c",
+      "- Added restore feature after delete expense",
+      "",
+      "__Other Changes:",
+      "",
+      "1.3.005b",
+    ].join("\n");
+
+    expect(readMessageFromChangelogSource(source)).toBe(
+      "1.3.005c: Added restore feature after delete expense",
+    );
+  });
+
+  it("returns null when changelog markers are missing", () => {
+    expect(readMessageFromChangelogSource("no markers here")).toBeNull();
+  });
+});
+
+describe("resolveUpdateMessage", () => {
+  const context = {
+    defaultNote: "Bugfixes and performance improvements",
+    changelogMessage: "1.3.005c: Added restore feature after delete expense",
+  };
+
+  it("prefers an explicit message over bump defaults and changelog text", () => {
+    expect(
+      resolveUpdateMessage(
+        { message: "Fix login", bumpChangelog: true },
+        context,
+      ),
+    ).toBe("Fix login");
+  });
+
+  it("uses the default note when bump-changelog is set without a message", () => {
+    expect(
+      resolveUpdateMessage({ message: null, bumpChangelog: true }, context),
+    ).toBe("Bugfixes and performance improvements");
+  });
+
+  it("reads the changelog message when bump-changelog is not set", () => {
+    expect(
+      resolveUpdateMessage({ message: null, bumpChangelog: false }, context),
+    ).toBe("1.3.005c: Added restore feature after delete expense");
+  });
+
+  it("returns null when no message source is available", () => {
+    expect(
+      resolveUpdateMessage(
+        { message: null, bumpChangelog: false },
+        { defaultNote: "Bugfixes and performance improvements", changelogMessage: null },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("formatBumpRecoveryCommand", () => {
+  it("prints a version:bump:eas command with the same note", () => {
+    expect(formatBumpRecoveryCommand("Fix login")).toBe(
+      'pnpm version:bump:eas -- --notes "Fix login"',
+    );
+  });
+
+  it("escapes double quotes in recovery notes", () => {
+    expect(formatBumpRecoveryCommand('Say "hello"')).toBe(
+      'pnpm version:bump:eas -- --notes "Say \\"hello\\""',
+    );
+  });
+});

--- a/TravelCostApp/changelog.txt
+++ b/TravelCostApp/changelog.txt
@@ -2,10 +2,13 @@ Changelog Travel Expense App
 
 __Newest Changes:
 
-1.3.005c
-- Added restore feature after delete expense
+1.3.005d
+- Bugfixes and performance improvements
 
 __Other Changes:
+
+1.3.005c
+- Added restore feature after delete expense
 
 1.3.005b
 - Bugfixes and performance improvements

--- a/TravelCostApp/package.json
+++ b/TravelCostApp/package.json
@@ -9,6 +9,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "update:production": "node scripts/eas-update.js --target production",
+    "update:production:bump": "node scripts/eas-update.js --target production --bump-changelog",
     "update:alpha": "node scripts/eas-update.js --target alpha",
     "update:staging": "node scripts/eas-update.js --target staging",
     "update:dev": "node scripts/eas-update.js --target dev",

--- a/TravelCostApp/pipeline.md
+++ b/TravelCostApp/pipeline.md
@@ -193,6 +193,8 @@ pnpm run submit:alpha:ios
 pnpm run update:dev -- "Your message"
 pnpm run update:staging -- "Your message"
 pnpm run update:production -- "Your message"
+pnpm run update:production:bump -- "Your message"   # publish OTA + bump changelog suffix
+pnpm run update:production:bump -- --dry-run       # preview only
 ```
 
 ### Manual Testing Commands

--- a/TravelCostApp/scripts/bump-app-version.js
+++ b/TravelCostApp/scripts/bump-app-version.js
@@ -253,4 +253,8 @@ function main() {
   bumpAppRelease(options);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { bumpEasUpdate, DEFAULT_NOTES };

--- a/TravelCostApp/scripts/eas-update-message.js
+++ b/TravelCostApp/scripts/eas-update-message.js
@@ -1,0 +1,71 @@
+const VERSION_PARSE_RE = /^(\d+)\.(\d+)\.(\d+)([a-z]*)$/i;
+
+function parseEasUpdateArgs(argv) {
+  const opts = {
+    target: null,
+    message: null,
+    bumpChangelog: false,
+    dryRun: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--target") opts.target = argv[++i];
+    else if (arg === "--message") opts.message = argv[++i];
+    else if (arg === "--bump-changelog") opts.bumpChangelog = true;
+    else if (arg === "--dry-run") opts.dryRun = true;
+  }
+
+  if (!opts.message) {
+    const extras = argv.filter((a) => !a.startsWith("--") && a !== opts.target);
+    if (extras.length > 0) {
+      opts.message = extras.join(" ").trim();
+    }
+  }
+
+  return opts;
+}
+
+function readMessageFromChangelogSource(source) {
+  const newestMarker = "__Newest Changes:";
+  const otherMarker = "__Other Changes:";
+  const newestIdx = source.indexOf(newestMarker);
+  const otherIdx = source.indexOf(otherMarker);
+  if (newestIdx === -1 || otherIdx === -1 || otherIdx <= newestIdx) {
+    return null;
+  }
+
+  const newestBody = source
+    .slice(newestIdx + newestMarker.length, otherIdx)
+    .trim();
+  const lines = newestBody.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (lines.length === 0) return null;
+
+  const version = lines[0];
+  if (!VERSION_PARSE_RE.test(version)) {
+    return lines.join(" ");
+  }
+
+  const firstBullet = lines.find((line) => line.startsWith("- "));
+  if (firstBullet) {
+    return `${version}: ${firstBullet.slice(2)}`;
+  }
+  return `OTA ${version}`;
+}
+
+function resolveUpdateMessage(opts, context) {
+  if (opts.message) return opts.message;
+  if (opts.bumpChangelog) return context.defaultNote;
+  return context.changelogMessage;
+}
+
+function formatBumpRecoveryCommand(message) {
+  const escaped = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `pnpm version:bump:eas -- --notes "${escaped}"`;
+}
+
+module.exports = {
+  parseEasUpdateArgs,
+  readMessageFromChangelogSource,
+  resolveUpdateMessage,
+  formatBumpRecoveryCommand,
+};

--- a/TravelCostApp/scripts/eas-update.js
+++ b/TravelCostApp/scripts/eas-update.js
@@ -4,14 +4,17 @@
  *
  * Usage:
  *   pnpm run update:production -- "Fix login"
+ *   pnpm run update:production:bump -- "Fix login"
  *   node scripts/eas-update.js --target production --message "Fix login"
  *   node scripts/eas-update.js --target production   # message from changelog newest block
+ *   node scripts/eas-update.js --target production --bump-changelog [--message "Fix login"]
  */
 
 const fs = require("fs");
 const path = require("path");
 const { spawnSync } = require("child_process");
 const { getUpdateTarget } = require("./eas-profiles");
+const { bumpEasUpdate, DEFAULT_NOTES } = require("./bump-app-version");
 
 const ROOT = path.join(__dirname, "..");
 const CHANGELOG = path.join(ROOT, "changelog.txt");
@@ -23,10 +26,11 @@ function usageAndExit(message) {
   console.error(
     [
       "Usage:",
-      "  node scripts/eas-update.js --target <production|alpha|staging|dev> [--message <text>]",
+      "  node scripts/eas-update.js --target <production|alpha|staging|dev> [--message <text>] [--bump-changelog]",
       "",
       "Examples:",
       '  pnpm run update:production -- "Fix login"',
+      "  pnpm run update:production:bump",
       "  node scripts/eas-update.js --target production",
     ].join("\n"),
   );
@@ -34,11 +38,12 @@ function usageAndExit(message) {
 }
 
 function parseArgs(argv) {
-  const opts = { target: null, message: null };
+  const opts = { target: null, message: null, bumpChangelog: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--target") opts.target = argv[++i];
     else if (arg === "--message") opts.message = argv[++i];
+    else if (arg === "--bump-changelog") opts.bumpChangelog = true;
   }
 
   if (!opts.message) {
@@ -110,18 +115,28 @@ function runUpdate(target, message) {
   }
 }
 
+function resolveUpdateMessage(opts) {
+  if (opts.message) return opts.message;
+  if (opts.bumpChangelog) return DEFAULT_NOTES[0];
+  return readDefaultMessageFromChangelog();
+}
+
 function main() {
   const opts = parseArgs(process.argv.slice(2));
   if (!opts.target) {
     usageAndExit("Missing --target.");
   }
 
-  const message = opts.message ?? readDefaultMessageFromChangelog();
+  const message = resolveUpdateMessage(opts);
   if (!message) {
     usageAndExit("Missing update message. Pass --message or add a __Newest Changes__ block in changelog.txt.");
   }
 
   runUpdate(opts.target, message);
+
+  if (opts.bumpChangelog) {
+    bumpEasUpdate({ notes: [message] });
+  }
 }
 
 main();

--- a/TravelCostApp/scripts/eas-update.js
+++ b/TravelCostApp/scripts/eas-update.js
@@ -8,6 +8,7 @@
  *   node scripts/eas-update.js --target production --message "Fix login"
  *   node scripts/eas-update.js --target production   # message from changelog newest block
  *   node scripts/eas-update.js --target production --bump-changelog [--message "Fix login"]
+ *   node scripts/eas-update.js --target production --bump-changelog --dry-run
  */
 
 const fs = require("fs");
@@ -15,81 +16,53 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 const { getUpdateTarget } = require("./eas-profiles");
 const { bumpEasUpdate, DEFAULT_NOTES } = require("./bump-app-version");
+const {
+  parseEasUpdateArgs,
+  readMessageFromChangelogSource,
+  resolveUpdateMessage,
+  formatBumpRecoveryCommand,
+} = require("./eas-update-message");
 
 const ROOT = path.join(__dirname, "..");
 const CHANGELOG = path.join(ROOT, "changelog.txt");
-
-const VERSION_PARSE_RE = /^(\d+)\.(\d+)\.(\d+)([a-z]*)$/i;
 
 function usageAndExit(message) {
   if (message) console.error(message);
   console.error(
     [
       "Usage:",
-      "  node scripts/eas-update.js --target <production|alpha|staging|dev> [--message <text>] [--bump-changelog]",
+      "  node scripts/eas-update.js --target <production|alpha|staging|dev> [--message <text>] [--bump-changelog] [--dry-run]",
       "",
       "Examples:",
       '  pnpm run update:production -- "Fix login"',
       "  pnpm run update:production:bump",
-      "  node scripts/eas-update.js --target production",
+      "  node scripts/eas-update.js --target production --bump-changelog --dry-run",
     ].join("\n"),
   );
   process.exit(1);
 }
 
-function parseArgs(argv) {
-  const opts = { target: null, message: null, bumpChangelog: false };
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    if (arg === "--target") opts.target = argv[++i];
-    else if (arg === "--message") opts.message = argv[++i];
-    else if (arg === "--bump-changelog") opts.bumpChangelog = true;
-  }
-
-  if (!opts.message) {
-    const extras = argv.filter((a) => !a.startsWith("--") && a !== opts.target);
-    if (extras.length > 0) {
-      opts.message = extras.join(" ").trim();
-    }
-  }
-
-  return opts;
-}
-
 function readDefaultMessageFromChangelog() {
   const source = fs.readFileSync(CHANGELOG, "utf8");
-  const newestMarker = "__Newest Changes:";
-  const otherMarker = "__Other Changes:";
-  const newestIdx = source.indexOf(newestMarker);
-  const otherIdx = source.indexOf(otherMarker);
-  if (newestIdx === -1 || otherIdx === -1 || otherIdx <= newestIdx) {
-    return null;
-  }
-
-  const newestBody = source
-    .slice(newestIdx + newestMarker.length, otherIdx)
-    .trim();
-  const lines = newestBody.split("\n").map((line) => line.trim()).filter(Boolean);
-  if (lines.length === 0) return null;
-
-  const version = lines[0];
-  if (!VERSION_PARSE_RE.test(version)) {
-    return lines.join(" ");
-  }
-
-  const firstBullet = lines.find((line) => line.startsWith("- "));
-  if (firstBullet) {
-    return `${version}: ${firstBullet.slice(2)}`;
-  }
-  return `OTA ${version}`;
+  return readMessageFromChangelogSource(source);
 }
 
-function runUpdate(target, message) {
+function runUpdate(target, message, dryRun) {
   let config;
   try {
     config = getUpdateTarget(target);
   } catch (err) {
     usageAndExit(err.message);
+  }
+
+  console.log(
+    `Publishing EAS update → branch ${config.branch}, environment ${config.environment}`,
+  );
+  console.log(`Message: ${message}`);
+
+  if (dryRun) {
+    console.log("Dry run — skipping eas update publish.");
+    return;
   }
 
   const args = [
@@ -103,11 +76,6 @@ function runUpdate(target, message) {
     message,
   ];
 
-  console.log(
-    `Publishing EAS update → branch ${config.branch}, environment ${config.environment}`,
-  );
-  console.log(`Message: ${message}`);
-
   const res = spawnSync("eas", args, { stdio: "inherit", cwd: ROOT });
   if (res.error) throw res.error;
   if (typeof res.status === "number" && res.status !== 0) {
@@ -115,27 +83,41 @@ function runUpdate(target, message) {
   }
 }
 
-function resolveUpdateMessage(opts) {
-  if (opts.message) return opts.message;
-  if (opts.bumpChangelog) return DEFAULT_NOTES[0];
-  return readDefaultMessageFromChangelog();
+function runChangelogBump(message, dryRun) {
+  try {
+    bumpEasUpdate({ notes: [message], dryRun });
+  } catch (err) {
+    console.error(
+      dryRun
+        ? "\nDry run changelog bump failed:"
+        : "\nEAS update published but changelog bump failed:",
+    );
+    console.error(err instanceof Error ? err.message : String(err));
+    if (!dryRun) {
+      console.error(`Recovery: ${formatBumpRecoveryCommand(message)}`);
+    }
+    process.exit(1);
+  }
 }
 
 function main() {
-  const opts = parseArgs(process.argv.slice(2));
+  const opts = parseEasUpdateArgs(process.argv.slice(2));
   if (!opts.target) {
     usageAndExit("Missing --target.");
   }
 
-  const message = resolveUpdateMessage(opts);
+  const message = resolveUpdateMessage(opts, {
+    defaultNote: DEFAULT_NOTES[0],
+    changelogMessage: readDefaultMessageFromChangelog(),
+  });
   if (!message) {
     usageAndExit("Missing update message. Pass --message or add a __Newest Changes__ block in changelog.txt.");
   }
 
-  runUpdate(opts.target, message);
+  runUpdate(opts.target, message, opts.dryRun);
 
   if (opts.bumpChangelog) {
-    bumpEasUpdate({ notes: [message] });
+    runChangelogBump(message, opts.dryRun);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `pnpm run update:production:bump` to publish a production EAS update and bump the EAS changelog suffix in one step
- Reuse `bumpEasUpdate` from `bump-app-version.js` via a new `--bump-changelog` flag on `eas-update.js`
- Update message and changelog notes stay in sync (defaults to "Bugfixes and performance improvements")

## Test plan
- [x] `node -e "require('./TravelCostApp/scripts/bump-app-version')"` exports `DEFAULT_NOTES`
- [x] `node scripts/bump-app-version.js --eas --dry-run` still works from `TravelCostApp/`
- [ ] `pnpm run update:production:bump --dry-run` equivalent: verify message resolution with and without trailing notes
- [ ] Run `pnpm run update:production:bump` on a real OTA when ready