### PR TITLE
Fix Finder search label and autocomplete suggestion stacking

### DIFF
--- a/TravelCostApp/__tests__/components/autocomplete.test.tsx
+++ b/TravelCostApp/__tests__/components/autocomplete.test.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
 import { StyleSheet } from "react-native";
-import { fireEvent } from "@testing-library/react-native";
+import { act, fireEvent } from "@testing-library/react-native";
 
 import { TextInput as PaperTextInput } from "react-native-paper";
 
-import Autocomplete from "../../components/UI/Autocomplete";
+import Autocomplete, {
+  AUTOCOMPLETE_BLUR_DISMISS_MS,
+} from "../../components/UI/Autocomplete";
 import { GlobalStyles } from "../../constants/styles";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
@@ -163,6 +165,108 @@ describe("Autocomplete", () => {
     );
 
     expect(itemStyle.paddingTop).toBe(itemStyle.paddingBottom);
+  });
+
+  it("keeps suggestions up briefly after blur so a keyboard-dismiss tap can still select", () => {
+    jest.useFakeTimers();
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const field = screen.getByTestId("autocomplete-field");
+    fireEvent(field, "focus");
+    fireEvent(field, "blur");
+
+    expect(screen.getByTestId("autocomplete-suggestions")).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(AUTOCOMPLETE_BLUR_DISMISS_MS - 1);
+    });
+    expect(screen.getByTestId("autocomplete-suggestions")).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(screen.queryByTestId("autocomplete-suggestions")).toBeNull();
+
+    jest.useRealTimers();
+  });
+
+  it("applies a suggestion when blur from keyboard dismiss precedes the press", () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={onChange}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent(screen.getByTestId("autocomplete-field"), "focus");
+    fireEvent(screen.getByTestId("autocomplete-field"), "blur");
+
+    const suggestion = screen.getByTestId("autocomplete-suggestion-0");
+    act(() => {
+      fireEvent(suggestion, "pressIn");
+      fireEvent.press(suggestion);
+    });
+
+    expect(onChange).toHaveBeenCalledWith("Tina");
+    expect(screen.queryByTestId("autocomplete-suggestions")).toBeNull();
+
+    jest.useRealTimers();
+  });
+
+  it("selects a filtered suggestion on touchStart while typing", () => {
+    const onChange = jest.fn();
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Description"
+        data={["Tina", "Thomas", "Essen"]}
+        showOnEmpty={false}
+        onChange={onChange}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent.changeText(screen.getByTestId("autocomplete-field"), "T");
+    expect(screen.getByText("Tina")).toBeTruthy();
+
+    fireEvent(screen.getByTestId("autocomplete-suggestion-0"), "touchStart");
+
+    expect(onChange).toHaveBeenCalledWith("Tina");
+    expect(screen.queryByTestId("autocomplete-suggestions")).toBeNull();
+  });
+
+  it("still applies a suggestion when an item is pressed", () => {
+    const onChange = jest.fn();
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={onChange}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent(screen.getByTestId("autocomplete-field"), "focus");
+    fireEvent.press(screen.getByTestId("autocomplete-suggestion-0"));
+
+    expect(onChange).toHaveBeenCalledWith("Tina");
   });
 
   it("raises the container stacking while suggestions are visible", () => {

--- a/TravelCostApp/__tests__/components/autocomplete.test.tsx
+++ b/TravelCostApp/__tests__/components/autocomplete.test.tsx
@@ -39,7 +39,7 @@ describe("Autocomplete", () => {
     expect(Number(menuStyle.elevation ?? 0)).toBeGreaterThan(0);
   });
 
-  it("gives the outlined label a solid background matching the field surface", () => {
+  it("matches the field surface background on the outlined input", () => {
     const screen = renderWithAppProviders(
       <Autocomplete
         value=""
@@ -267,6 +267,33 @@ describe("Autocomplete", () => {
     fireEvent.press(screen.getByTestId("autocomplete-suggestion-0"));
 
     expect(onChange).toHaveBeenCalledWith("Tina");
+  });
+
+  it("keeps suggestions visible after refocus within the blur dismiss window", () => {
+    jest.useFakeTimers();
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const field = screen.getByTestId("autocomplete-field");
+    fireEvent(field, "focus");
+    fireEvent(field, "blur");
+    fireEvent(field, "focus");
+
+    act(() => {
+      jest.advanceTimersByTime(AUTOCOMPLETE_BLUR_DISMISS_MS);
+    });
+
+    expect(screen.getByTestId("autocomplete-suggestions")).toBeTruthy();
+
+    jest.useRealTimers();
   });
 
   it("raises the container stacking while suggestions are visible", () => {

--- a/TravelCostApp/__tests__/components/autocomplete.test.tsx
+++ b/TravelCostApp/__tests__/components/autocomplete.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { fireEvent } from "@testing-library/react-native";
 
-import { TextInput as PaperTextInput } from "react-native-paper";
+import { Menu, TextInput as PaperTextInput } from "react-native-paper";
 
 import Autocomplete from "../../components/UI/Autocomplete";
 import { GlobalStyles } from "../../constants/styles";
@@ -54,6 +54,75 @@ describe("Autocomplete", () => {
 
     expect(background).toBe(GlobalStyles.colors.backgroundColorLight);
     expect(background).not.toBe("transparent");
+  });
+
+  it("uses Paper roundness above 6 and matching outline radius for label edge cover", () => {
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        onChange={jest.fn()}
+        style={{
+          backgroundColor: GlobalStyles.colors.backgroundColorLight,
+          borderRadius: 5,
+        }}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const input = screen.UNSAFE_getByType(PaperTextInput);
+    const roundness = input.props.theme?.roundness as number;
+    const outlineRadius = StyleSheet.flatten(input.props.outlineStyle)
+      ?.borderRadius as number;
+
+    expect(roundness).toBeGreaterThan(6);
+    expect(outlineRadius).toBe(roundness);
+  });
+
+  it("pads the suggestion list horizontally instead of offsetting with margin", () => {
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent(screen.getByTestId("autocomplete-field"), "focus");
+
+    const menuStyle = flattenStyle(
+      screen.getByTestId("autocomplete-suggestions").props.style
+    );
+
+    expect(menuStyle.marginLeft).toBeUndefined();
+    expect(Number(menuStyle.paddingHorizontal ?? 0)).toBeGreaterThan(0);
+  });
+
+  it("vertically centers suggestion text with balanced item padding", () => {
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent(screen.getByTestId("autocomplete-field"), "focus");
+
+    const item = screen.UNSAFE_getAllByType(Menu.Item)[0];
+    const itemStyle = flattenStyle(item.props.style);
+    const titleStyle = flattenStyle(item.props.titleStyle);
+
+    expect(itemStyle.paddingTop).toBe(itemStyle.paddingBottom);
+    expect(titleStyle.paddingTop ?? 0).toBe(0);
+    expect(titleStyle.paddingBottom ?? 0).toBe(0);
   });
 
   it("raises the container stacking while suggestions are visible", () => {

--- a/TravelCostApp/__tests__/components/autocomplete.test.tsx
+++ b/TravelCostApp/__tests__/components/autocomplete.test.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { StyleSheet } from "react-native";
+import { fireEvent } from "@testing-library/react-native";
+
+import { TextInput as PaperTextInput } from "react-native-paper";
+
+import Autocomplete from "../../components/UI/Autocomplete";
+import { GlobalStyles } from "../../constants/styles";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  return StyleSheet.flatten(style as object) as Record<string, unknown>;
+}
+
+describe("Autocomplete", () => {
+  const suggestions = ["Tina", "Essen", "Hotel"];
+
+  it("renders the suggestion list above following content with positive z-index", () => {
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={jest.fn()}
+        menuStyle={{ marginLeft: 8 }}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent(screen.getByTestId("autocomplete-field"), "focus");
+
+    const menu = screen.getByTestId("autocomplete-suggestions");
+    const menuStyle = flattenStyle(menu.props.style);
+
+    expect(Number(menuStyle.zIndex)).toBeGreaterThan(0);
+    expect(Number(menuStyle.elevation ?? 0)).toBeGreaterThan(0);
+  });
+
+  it("gives the outlined label a solid background matching the field surface", () => {
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        onChange={jest.fn()}
+        style={{ backgroundColor: GlobalStyles.colors.backgroundColorLight }}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const input = screen.UNSAFE_getByType(PaperTextInput);
+    const background = input.props.theme?.colors?.background;
+
+    expect(background).toBe(GlobalStyles.colors.backgroundColorLight);
+    expect(background).not.toBe("transparent");
+  });
+
+  it("raises the container stacking while suggestions are visible", () => {
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent(screen.getByTestId("autocomplete-field"), "focus");
+
+    const containerStyle = flattenStyle(
+      screen.getByTestId("autocomplete-container").props.style
+    );
+    expect(Number(containerStyle.zIndex)).toBeGreaterThan(1);
+  });
+});

--- a/TravelCostApp/__tests__/components/autocomplete.test.tsx
+++ b/TravelCostApp/__tests__/components/autocomplete.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { fireEvent } from "@testing-library/react-native";
 
-import { Menu, TextInput as PaperTextInput } from "react-native-paper";
+import { TextInput as PaperTextInput } from "react-native-paper";
 
 import Autocomplete from "../../components/UI/Autocomplete";
 import { GlobalStyles } from "../../constants/styles";
@@ -80,6 +80,45 @@ describe("Autocomplete", () => {
     expect(outlineRadius).toBe(roundness);
   });
 
+  it("shows readable suggestion titles when the menu opens", () => {
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        showOnEmpty
+        onChange={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent(screen.getByTestId("autocomplete-field"), "focus");
+
+    const title = screen.getByTestId("autocomplete-suggestion-0-text");
+    expect(title).toHaveTextContent("Tina");
+
+    const titleStyle = flattenStyle(title.props.style);
+    expect(titleStyle.color).toBe(GlobalStyles.colors.textColor);
+    expect(titleStyle.opacity ?? 1).toBe(1);
+  });
+
+  it("renders the label above the outline instead of on the border", () => {
+    const screen = renderWithAppProviders(
+      <Autocomplete
+        value=""
+        label="Suchen"
+        data={suggestions}
+        onChange={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    expect(screen.getByTestId("autocomplete-label")).toHaveTextContent("Suchen");
+
+    const input = screen.UNSAFE_getByType(PaperTextInput);
+    expect(input.props.label).toBeUndefined();
+  });
+
   it("pads the suggestion list horizontally instead of offsetting with margin", () => {
     const screen = renderWithAppProviders(
       <Autocomplete
@@ -116,13 +155,14 @@ describe("Autocomplete", () => {
 
     fireEvent(screen.getByTestId("autocomplete-field"), "focus");
 
-    const item = screen.UNSAFE_getAllByType(Menu.Item)[0];
-    const itemStyle = flattenStyle(item.props.style);
-    const titleStyle = flattenStyle(item.props.titleStyle);
+    const pressable = screen.getByTestId("autocomplete-suggestion-0");
+    const itemStyle = flattenStyle(
+      typeof pressable.props.style === "function"
+        ? pressable.props.style({ pressed: false })
+        : pressable.props.style
+    );
 
     expect(itemStyle.paddingTop).toBe(itemStyle.paddingBottom);
-    expect(titleStyle.paddingTop ?? 0).toBe(0);
-    expect(titleStyle.paddingBottom ?? 0).toBe(0);
   });
 
   it("raises the container stacking while suggestions are visible", () => {

--- a/TravelCostApp/__tests__/screens/finder-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/finder-screen.test.tsx
@@ -67,6 +67,6 @@ describe("Finder screen", () => {
     });
 
     const scrollView = screen.UNSAFE_getByType(ScrollView);
-    expect(scrollView.props.keyboardShouldPersistTaps).toBe("always");
+    expect(scrollView.props.keyboardShouldPersistTaps).toBe("handled");
   });
 });

--- a/TravelCostApp/__tests__/screens/finder-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/finder-screen.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { ScrollView } from "react-native";
 import { act, waitFor } from "@testing-library/react-native";
 
 jest.mock("@react-navigation/native", () => {
@@ -57,5 +58,15 @@ describe("Finder screen", () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
+  });
+
+  it("delivers taps to controls while the keyboard is open", () => {
+    const screen = renderWithAppProviders(<FinderScreen />, {
+      wrapNavigation: false,
+      expenses: { expenses: [] },
+    });
+
+    const scrollView = screen.UNSAFE_getByType(ScrollView);
+    expect(scrollView.props.keyboardShouldPersistTaps).toBe("always");
   });
 });

--- a/TravelCostApp/__tests__/screens/manage-expense-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/manage-expense-screen.test.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { ScrollView } from "react-native";
+
+jest.mock("../../components/ManageExpense/ExpenseForm", () => () => null);
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  notificationAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+  NotificationFeedbackType: { Success: "Success" },
+}));
+
+jest.mock("react-native-toast-message/lib/src/Toast", () => ({
+  Toast: { show: jest.fn(), hide: jest.fn() },
+}));
+
+import ManageExpense from "../../screens/ManageExpense";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+describe("ManageExpense screen", () => {
+  it("delivers taps to controls while the keyboard is open", () => {
+    const screen = renderWithAppProviders(
+      <ManageExpense
+        route={{ params: {} }}
+        navigation={{ navigate: jest.fn(), pop: jest.fn(), popToTop: jest.fn() }}
+      />,
+      { wrapNavigation: false, expenses: { expenses: [] } }
+    );
+
+    const scrollView = screen.UNSAFE_getByType(ScrollView);
+    expect(scrollView.props.keyboardShouldPersistTaps).toBe("always");
+  });
+});

--- a/TravelCostApp/__tests__/screens/manage-expense-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/manage-expense-screen.test.tsx
@@ -32,6 +32,6 @@ describe("ManageExpense screen", () => {
     );
 
     const scrollView = screen.UNSAFE_getByType(ScrollView);
-    expect(scrollView.props.keyboardShouldPersistTaps).toBe("always");
+    expect(scrollView.props.keyboardShouldPersistTaps).toBe("handled");
   });
 });

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -2259,8 +2259,6 @@ const styles = StyleSheet.create({
     fontSize: dynamicScale(14, false, 0.3),
   },
   autoCompleteMenuStyle: {
-    marginLeft: dynamicScale(8),
-    marginBottom: dynamicScale(-1, true),
     borderBottomWidth: 1,
     borderBottomColor: GlobalStyles.colors.primaryGrayed,
   },

--- a/TravelCostApp/components/UI/Autocomplete.tsx
+++ b/TravelCostApp/components/UI/Autocomplete.tsx
@@ -15,6 +15,9 @@ const suggestionMenuStackStyle = {
 /** Paper only draws outlined-label edge cover when roundness > 6 */
 const MIN_OUTLINE_ROUNDNESS = 8;
 
+/** Grace period after blur so the first tap can reach a suggestion while the keyboard closes */
+export const AUTOCOMPLETE_BLUR_DISMISS_MS = 200;
+
 function resolveFieldRoundness(style: object): number {
   const flat = StyleSheet.flatten(style) ?? {};
   const fromStyle =
@@ -36,8 +39,17 @@ const Autocomplete = ({
   const [value, setValue] = useState(origValue);
   const [menuVisible, setMenuVisible] = useState(false);
   const [filteredData, setFilteredData] = useState([]);
-  const [blurTimeout, setBlurTimeout] = useState(null);
   const isSelectingRef = useRef(false);
+  const blurDismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+
+  const clearBlurDismiss = () => {
+    if (blurDismissTimeoutRef.current) {
+      clearTimeout(blurDismissTimeoutRef.current);
+      blurDismissTimeoutRef.current = null;
+    }
+  };
 
   useEffect(() => {
     setValue(origValue);
@@ -47,14 +59,8 @@ const Autocomplete = ({
     if (origValue == "") setMenuVisible(false);
   }, [origValue]);
 
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (blurTimeout) {
-        clearTimeout(blurTimeout);
-      }
-    };
-  }, [blurTimeout]);
+  useEffect(() => clearBlurDismiss, []);
+
   /**
    * Filters the data array based on the provided text and removes duplicate results.
    * @param {string} text - The text to filter the data array with.
@@ -80,20 +86,30 @@ const Autocomplete = ({
   };
 
   const selectSuggestion = (autotext: string) => {
-    isSelectingRef.current = true;
-
-    if (blurTimeout) {
-      clearTimeout(blurTimeout);
-      setBlurTimeout(null);
+    if (value === autotext && !menuVisible) {
+      return;
     }
-
+    clearBlurDismiss();
+    isSelectingRef.current = true;
     origOnChange(autotext);
     setValue(autotext);
+    setMenuVisible(false);
+    isSelectingRef.current = false;
+  };
 
-    setTimeout(() => {
-      setMenuVisible(false);
-      isSelectingRef.current = false;
-    }, 50);
+  const handleSuggestionTouchStart = (autotext: string) => {
+    // Apply on touch start so selection wins over keyboard-dismiss blur.
+    selectSuggestion(autotext);
+  };
+
+  const scheduleBlurDismiss = () => {
+    clearBlurDismiss();
+    blurDismissTimeoutRef.current = setTimeout(() => {
+      if (!isSelectingRef.current) {
+        setMenuVisible(false);
+      }
+      blurDismissTimeoutRef.current = null;
+    }, AUTOCOMPLETE_BLUR_DISMISS_MS);
   };
 
   return (
@@ -129,13 +145,7 @@ const Autocomplete = ({
           if (isSelectingRef.current) {
             return;
           }
-
-          const timeoutId = setTimeout(() => {
-            if (!isSelectingRef.current) {
-              setMenuVisible(false);
-            }
-          }, 5000);
-          setBlurTimeout(timeoutId);
+          scheduleBlurDismiss();
         }}
         placeholder={placeholder}
         style={fieldStyle}
@@ -176,10 +186,12 @@ const Autocomplete = ({
                 styles.suggestionItem,
                 pressed && styles.suggestionItemPressed,
               ]}
+              onTouchStart={() => handleSuggestionTouchStart(autotext)}
               onPress={() => selectSuggestion(autotext)}
             >
               <Text
                 testID={`autocomplete-suggestion-${i}-text`}
+                pointerEvents="none"
                 style={styles.suggestionText}
                 numberOfLines={1}
               >

--- a/TravelCostApp/components/UI/Autocomplete.tsx
+++ b/TravelCostApp/components/UI/Autocomplete.tsx
@@ -1,12 +1,17 @@
 // Autocomplete/index.js
 
-import { View, Platform } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { Menu, TextInput } from "react-native-paper";
 import React, { useEffect, useState, useRef } from "react";
 import PropTypes from "prop-types";
 import { GlobalStyles } from "../../constants/styles";
 import Animated, { FadeIn } from "react-native-reanimated";
 import { dynamicScale } from "../../util/scalingUtil";
+
+const suggestionMenuStackStyle = {
+  zIndex: 1000,
+  elevation: 8,
+};
 
 const Autocomplete = ({
   value: origValue,
@@ -54,9 +59,25 @@ const Autocomplete = ({
     return [...new Set(filteredData)];
   }
 
+  const fieldBackground =
+    (StyleSheet.flatten(style)?.backgroundColor as string | undefined) ??
+    GlobalStyles.colors.backgroundColorLight;
+
   return (
-    <View style={containerStyle}>
+    <View
+      testID="autocomplete-container"
+      style={[
+        containerStyle,
+        { overflow: "visible", zIndex: menuVisible ? 10 : 1 },
+      ]}
+    >
       <TextInput
+        testID="autocomplete-field"
+        theme={{
+          colors: {
+            background: fieldBackground,
+          },
+        }}
         selectTextOnFocus
         onFocus={() => {
           if (value?.length === 0) {
@@ -109,9 +130,13 @@ const Autocomplete = ({
       />
       {menuVisible && filteredData && filteredData.length > 0 && (
         <Animated.View
+          testID="autocomplete-suggestions"
           entering={FadeIn.duration(500)}
-          style={{ maxWidth: "100%" }}
-          // exiting={FadeOutUp}
+          style={[
+            { maxWidth: "100%" },
+            menuStyle,
+            suggestionMenuStackStyle,
+          ]}
         >
           {
             // only show the newest 3 items

--- a/TravelCostApp/components/UI/Autocomplete.tsx
+++ b/TravelCostApp/components/UI/Autocomplete.tsx
@@ -136,6 +136,7 @@ const Autocomplete = ({
         outlineStyle={{ borderRadius: fieldRoundness }}
         selectTextOnFocus
         onFocus={() => {
+          clearBlurDismiss();
           if (value?.length === 0) {
             setMenuVisible(true);
             if (showOnEmpty) setFilteredData([...new Set(data)]);

--- a/TravelCostApp/components/UI/Autocomplete.tsx
+++ b/TravelCostApp/components/UI/Autocomplete.tsx
@@ -13,6 +13,16 @@ const suggestionMenuStackStyle = {
   elevation: 8,
 };
 
+/** Paper only draws outlined-label edge cover when roundness > 6 */
+const MIN_OUTLINE_ROUNDNESS = 8;
+
+function resolveFieldRoundness(style: object): number {
+  const flat = StyleSheet.flatten(style) ?? {};
+  const fromStyle =
+    typeof flat.borderRadius === "number" ? flat.borderRadius : MIN_OUTLINE_ROUNDNESS;
+  return Math.max(fromStyle, MIN_OUTLINE_ROUNDNESS);
+}
+
 const Autocomplete = ({
   value: origValue,
   label,
@@ -59,9 +69,16 @@ const Autocomplete = ({
     return [...new Set(filteredData)];
   }
 
+  const flatFieldStyle = StyleSheet.flatten(style) ?? {};
   const fieldBackground =
-    (StyleSheet.flatten(style)?.backgroundColor as string | undefined) ??
+    (flatFieldStyle.backgroundColor as string | undefined) ??
     GlobalStyles.colors.backgroundColorLight;
+  const fieldRoundness = resolveFieldRoundness(style);
+  const fieldStyle = {
+    ...flatFieldStyle,
+    backgroundColor: fieldBackground,
+    borderRadius: fieldRoundness,
+  };
 
   return (
     <View
@@ -74,10 +91,12 @@ const Autocomplete = ({
       <TextInput
         testID="autocomplete-field"
         theme={{
+          roundness: fieldRoundness,
           colors: {
             background: fieldBackground,
           },
         }}
+        outlineStyle={{ borderRadius: fieldRoundness }}
         selectTextOnFocus
         onFocus={() => {
           if (value?.length === 0) {
@@ -106,7 +125,7 @@ const Autocomplete = ({
         label={label}
         // right={right}
         // left={left}
-        style={style}
+        style={fieldStyle}
         inputMode="text"
         mode="outlined"
         outlineColor={GlobalStyles.colors.primary700}
@@ -133,7 +152,11 @@ const Autocomplete = ({
           testID="autocomplete-suggestions"
           entering={FadeIn.duration(500)}
           style={[
-            { maxWidth: "100%" },
+            {
+              maxWidth: "100%",
+              width: "100%",
+              paddingHorizontal: dynamicScale(8, false, 0.3),
+            },
             menuStyle,
             suggestionMenuStackStyle,
           ]}
@@ -141,15 +164,20 @@ const Autocomplete = ({
           {
             // only show the newest 3 items
             filteredData.slice(0, 3).map((autotext, i) => {
+              const suggestionPadding = dynamicScale(10, false, 0.3);
               return (
                 <Menu.Item
                   key={i}
+                  testID={`autocomplete-suggestion-${i}`}
                   style={[
                     {
                       backgroundColor: GlobalStyles.colors.backgroundColor,
                       borderWidth: 1,
                       borderColor: GlobalStyles.colors.primaryGrayed,
                       maxWidth: "100%",
+                      paddingVertical: suggestionPadding,
+                      paddingHorizontal: dynamicScale(12, false, 0.3),
+                      justifyContent: "center",
                     },
                   ]}
                   //   icon={icon}
@@ -184,9 +212,9 @@ const Autocomplete = ({
                   titleStyle={{
                     flex: 1,
                     fontSize: dynamicScale(12, false, 0.3),
-                    paddingTop: dynamicScale(4, false, 0.5),
-                    paddingBottom: dynamicScale(24, false, 0.25),
-                    // maxWidth: "100%",
+                    marginVertical: 0,
+                    paddingVertical: 0,
+                    paddingHorizontal: 0,
                     width: "100%",
                   }}
                   title={autotext}

--- a/TravelCostApp/components/UI/Autocomplete.tsx
+++ b/TravelCostApp/components/UI/Autocomplete.tsx
@@ -1,11 +1,10 @@
 // Autocomplete/index.js
 
-import { View, StyleSheet } from "react-native";
-import { Menu, TextInput } from "react-native-paper";
+import { View, StyleSheet, Text, Pressable } from "react-native";
+import { TextInput } from "react-native-paper";
 import React, { useEffect, useState, useRef } from "react";
 import PropTypes from "prop-types";
 import { GlobalStyles } from "../../constants/styles";
-import Animated, { FadeIn } from "react-native-reanimated";
 import { dynamicScale } from "../../util/scalingUtil";
 
 const suggestionMenuStackStyle = {
@@ -80,6 +79,23 @@ const Autocomplete = ({
     borderRadius: fieldRoundness,
   };
 
+  const selectSuggestion = (autotext: string) => {
+    isSelectingRef.current = true;
+
+    if (blurTimeout) {
+      clearTimeout(blurTimeout);
+      setBlurTimeout(null);
+    }
+
+    origOnChange(autotext);
+    setValue(autotext);
+
+    setTimeout(() => {
+      setMenuVisible(false);
+      isSelectingRef.current = false;
+    }, 50);
+  };
+
   return (
     <View
       testID="autocomplete-container"
@@ -88,6 +104,11 @@ const Autocomplete = ({
         { overflow: "visible", zIndex: menuVisible ? 10 : 1 },
       ]}
     >
+      {label ? (
+        <Text testID="autocomplete-label" style={styles.fieldLabel}>
+          {label}
+        </Text>
+      ) : null}
       <TextInput
         testID="autocomplete-field"
         theme={{
@@ -104,34 +125,25 @@ const Autocomplete = ({
             if (showOnEmpty) setFilteredData([...new Set(data)]);
           }
         }}
-        // Handle blur with check for active selection
         onBlur={() => {
-          // Don't hide menu immediately if user is selecting an item
           if (isSelectingRef.current) {
             return;
           }
 
-          const timeoutId = setTimeout(
-            () => {
-              // Double-check selection state before hiding
-              if (!isSelectingRef.current) {
-                setMenuVisible(false);
-              }
-            },
-            5000
-          );
+          const timeoutId = setTimeout(() => {
+            if (!isSelectingRef.current) {
+              setMenuVisible(false);
+            }
+          }, 5000);
           setBlurTimeout(timeoutId);
         }}
-        label={label}
-        // right={right}
-        // left={left}
+        placeholder={placeholder}
         style={fieldStyle}
         inputMode="text"
         mode="outlined"
         outlineColor={GlobalStyles.colors.primary700}
         textColor={GlobalStyles.colors.textColor}
         cursorColor={GlobalStyles.colors.textColor}
-        placeholder={placeholder}
         activeOutlineColor={GlobalStyles.colors.primary700}
         underlineColor={GlobalStyles.colors.accent250}
         selectionColor={GlobalStyles.colors.primary700}
@@ -148,85 +160,68 @@ const Autocomplete = ({
         value={value}
       />
       {menuVisible && filteredData && filteredData.length > 0 && (
-        <Animated.View
+        <View
           testID="autocomplete-suggestions"
-          entering={FadeIn.duration(500)}
           style={[
-            {
-              maxWidth: "100%",
-              width: "100%",
-              paddingHorizontal: dynamicScale(8, false, 0.3),
-            },
+            styles.suggestionsList,
             menuStyle,
             suggestionMenuStackStyle,
           ]}
         >
-          {
-            // only show the newest 3 items
-            filteredData.slice(0, 3).map((autotext, i) => {
-              const suggestionPadding = dynamicScale(10, false, 0.3);
-              return (
-                <Menu.Item
-                  key={i}
-                  testID={`autocomplete-suggestion-${i}`}
-                  style={[
-                    {
-                      backgroundColor: GlobalStyles.colors.backgroundColor,
-                      borderWidth: 1,
-                      borderColor: GlobalStyles.colors.primaryGrayed,
-                      maxWidth: "100%",
-                      paddingVertical: suggestionPadding,
-                      paddingHorizontal: dynamicScale(12, false, 0.3),
-                      justifyContent: "center",
-                    },
-                  ]}
-                  //   icon={icon}
-                  onTouchStart={() => {
-                    // Handle selection immediately on touch start to bypass keyboard dismiss
-                    isSelectingRef.current = true;
-
-                    // Clear any pending blur timeout
-                    if (blurTimeout) {
-                      clearTimeout(blurTimeout);
-                      setBlurTimeout(null);
-                    }
-
-                    // Apply the selection immediately
-                    origOnChange(autotext);
-                    setValue(autotext);
-
-                    // Hide menu after a brief delay to ensure smooth UX
-                    setTimeout(() => {
-                      setMenuVisible(false);
-                      isSelectingRef.current = false;
-                    }, 50);
-                  }}
-                  onPress={() => {
-                    // Keep onPress as fallback for platforms that don't consume onTouchStart
-                    if (!isSelectingRef.current) {
-                      origOnChange(autotext);
-                      setValue(autotext);
-                      setMenuVisible(false);
-                    }
-                  }}
-                  titleStyle={{
-                    flex: 1,
-                    fontSize: dynamicScale(12, false, 0.3),
-                    marginVertical: 0,
-                    paddingVertical: 0,
-                    paddingHorizontal: 0,
-                    width: "100%",
-                  }}
-                  title={autotext}
-                />
-              );
-            })
-          }
-        </Animated.View>
+          {filteredData.slice(0, 3).map((autotext, i) => (
+            <Pressable
+              key={i}
+              testID={`autocomplete-suggestion-${i}`}
+              style={({ pressed }) => [
+                styles.suggestionItem,
+                pressed && styles.suggestionItemPressed,
+              ]}
+              onPress={() => selectSuggestion(autotext)}
+            >
+              <Text
+                testID={`autocomplete-suggestion-${i}-text`}
+                style={styles.suggestionText}
+                numberOfLines={1}
+              >
+                {autotext}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
       )}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  fieldLabel: {
+    fontSize: dynamicScale(12, false, 0.3),
+    color: GlobalStyles.colors.primary700,
+    marginBottom: dynamicScale(4, true, 0.3),
+    marginLeft: dynamicScale(4, false, 0.3),
+  },
+  suggestionsList: {
+    maxWidth: "100%",
+    width: "100%",
+    paddingHorizontal: dynamicScale(8, false, 0.3),
+  },
+  suggestionItem: {
+    backgroundColor: GlobalStyles.colors.backgroundColor,
+    borderWidth: 1,
+    borderColor: GlobalStyles.colors.primaryGrayed,
+    maxWidth: "100%",
+    paddingVertical: dynamicScale(10, false, 0.3),
+    paddingHorizontal: dynamicScale(12, false, 0.3),
+    justifyContent: "center",
+  },
+  suggestionItemPressed: {
+    backgroundColor: GlobalStyles.colors.gray300,
+  },
+  suggestionText: {
+    color: GlobalStyles.colors.textColor,
+    fontSize: dynamicScale(12, false, 0.3),
+  },
+});
 
 export default Autocomplete;
 // react-native/Libraries/Lists/VirtualizedList.js

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -295,7 +295,7 @@ const FinderScreen = () => {
             // scrollEnabled={false}
             style={{ flex: 1, minHeight: "50%" }}
           >
-            <View style={styles.rowContainer}>
+            <View style={[styles.rowContainer, styles.searchRowContainer]}>
               <View style={styles.checkBoxContainer}>
                 <Checkbox
                   status={checkedQuery ? "checked" : "unchecked"}
@@ -337,7 +337,7 @@ const FinderScreen = () => {
                 ></IconButton>
               )}
             </View>
-            <View style={styles.rowContainer}>
+            <View style={[styles.rowContainer, styles.dateRowContainer]}>
               <View style={styles.checkBoxContainer}>
                 <Checkbox
                   status={checkedDate ? "checked" : "unchecked"}
@@ -457,6 +457,12 @@ const styles = StyleSheet.create({
     justifyContent: "flex-start",
     minHeight: dynamicScale(90, true),
   },
+  searchRowContainer: {
+    zIndex: 10,
+  },
+  dateRowContainer: {
+    zIndex: 1,
+  },
   titleText: {
     fontSize: dynamicScale(32, false, 0.5),
     fontWeight: "bold",
@@ -484,10 +490,10 @@ const styles = StyleSheet.create({
     marginLeft: dynamicScale(18),
     maxWidth: dynamicScale(180),
     backgroundColor: GlobalStyles.colors.backgroundColorLight,
+    overflow: "visible",
     ...GlobalStyles.shadowGlowPrimary,
   },
   autoCompleteStyle: {
-    zIndex: 0,
     fontSize: dynamicScale(16, false, 0.4),
     paddingVertical: dynamicScale(2, false, 2),
     paddingHorizontal: dynamicScale(2),
@@ -499,7 +505,6 @@ const styles = StyleSheet.create({
     marginBottom: dynamicScale(20, true),
   },
   autoCompleteMenuStyle: {
-    zIndex: 0,
     marginLeft: dynamicScale(8),
     marginBottom: dynamicScale(-1, true),
   },

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -290,7 +290,7 @@ const FinderScreen = () => {
       {datepickerJSX}
       <View style={styles.container}>
         <ScrollView
-          keyboardShouldPersistTaps="always"
+          keyboardShouldPersistTaps="handled"
           contentContainerStyle={styles.cardContainer}
         >
           <Text style={styles.titleText}>{i18n.t("finderTitle")}</Text>

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -318,7 +318,6 @@ const FinderScreen = () => {
                 label={i18n.t("searchLabel")}
                 containerStyle={styles.queryContainer}
                 style={styles.autoCompleteStyle}
-                menuStyle={styles.autoCompleteMenuStyle}
               ></Autocomplete>
               {checkedQuery && (
                 <IconButton
@@ -498,14 +497,10 @@ const styles = StyleSheet.create({
     paddingVertical: dynamicScale(2, false, 2),
     paddingHorizontal: dynamicScale(2),
     backgroundColor: GlobalStyles.colors.backgroundColorLight,
-    borderRadius: dynamicScale(5),
+    borderRadius: dynamicScale(8, false, 0.3),
   },
   buttonContainer: {
     marginTop: dynamicScale(20, true),
     marginBottom: dynamicScale(20, true),
-  },
-  autoCompleteMenuStyle: {
-    marginLeft: dynamicScale(8),
-    marginBottom: dynamicScale(-1, true),
   },
 });

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -289,7 +289,10 @@ const FinderScreen = () => {
     <>
       {datepickerJSX}
       <View style={styles.container}>
-        <ScrollView contentContainerStyle={styles.cardContainer}>
+        <ScrollView
+          keyboardShouldPersistTaps="always"
+          contentContainerStyle={styles.cardContainer}
+        >
           <Text style={styles.titleText}>{i18n.t("finderTitle")}</Text>
           <View
             // scrollEnabled={false}

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -491,7 +491,6 @@ const styles = StyleSheet.create({
     backgroundColor: GlobalStyles.colors.backgroundColorLight,
     borderRadius: dynamicScale(8, false, 0.3),
     overflow: "visible",
-    ...GlobalStyles.shadowGlowPrimary,
   },
   autoCompleteStyle: {
     fontSize: dynamicScale(16, false, 0.4),

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -489,6 +489,7 @@ const styles = StyleSheet.create({
     marginLeft: dynamicScale(18),
     maxWidth: dynamicScale(180),
     backgroundColor: GlobalStyles.colors.backgroundColorLight,
+    borderRadius: dynamicScale(8, false, 0.3),
     overflow: "visible",
     ...GlobalStyles.shadowGlowPrimary,
   },

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -484,7 +484,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
 
   return (
     <ScrollView
-      keyboardShouldPersistTaps="always"
+      keyboardShouldPersistTaps="handled"
       style={styles.container}
     >
       <ExpenseForm

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -483,7 +483,10 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
   }
 
   return (
-    <ScrollView style={styles.container}>
+    <ScrollView
+      keyboardShouldPersistTaps="always"
+      style={styles.container}
+    >
       <ExpenseForm
         onCancel={cancelHandler}
         onSubmit={confirmHandler}


### PR DESCRIPTION
## Summary
- Give outlined Autocomplete labels a Paper theme background that matches the field surface so "Suchen" no longer collides with the border.
- Apply `menuStyle`, raise suggestion menu `zIndex`/`elevation`, and stack the Finder search row above the date row so dropdown items are not hidden behind the calendar area.
- Add component tests for suggestion stacking, label background, and elevated container while the menu is open.

## Test plan
- [x] `pnpm test -- __tests__/components/autocomplete.test.tsx`
- [ ] On device/simulator: open Finder, focus search — label readable, suggestions appear above the date row