### PR TITLE
Finder filter rows: symmetric layout and stable clear column

### DIFF
--- a/TravelCostApp/__tests__/screens/finder-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/finder-screen.test.tsx
@@ -50,6 +50,7 @@ jest.mock("../../components/UI/DatePickerModal", () => () => null);
 
 import FinderScreen from "../../screens/FinderScreen";
 import {
+  FINDER_FILTER_CLEAR_SLOT_WIDTH,
   FINDER_FILTER_CONTENT_WIDTH,
   finderFilterRowStyles,
 } from "../../styles/finder-filter-row-styles";
@@ -169,6 +170,50 @@ describe("Finder screen", () => {
       "finder-search-filter-clear-slot"
     ).width;
     expect(widthAfter).toBe(widthBefore);
-    expect(widthAfter).toBe(finderFilterRowStyles.clearColumn.width);
+    expect(widthAfter).toBe(FINDER_FILTER_CLEAR_SLOT_WIDTH);
+  });
+
+  it("keeps the date clear column width when the filter becomes active", async () => {
+    const screen = renderWithAppProviders(<FinderScreen />, {
+      wrapNavigation: false,
+      expenses: { expenses: [] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Finder")).toBeTruthy();
+    });
+
+    const widthBefore = flattenStyle(
+      screen,
+      "finder-date-filter-clear-slot"
+    ).width;
+
+    fireEvent.press(screen.getAllByRole("checkbox")[1]);
+
+    const widthAfter = flattenStyle(screen, "finder-date-filter-clear-slot")
+      .width;
+    expect(widthAfter).toBe(widthBefore);
+    expect(widthAfter).toBe(FINDER_FILTER_CLEAR_SLOT_WIDTH);
+  });
+
+  it("uses the same clear column width on search and date filter rows", async () => {
+    const screen = renderWithAppProviders(<FinderScreen />, {
+      wrapNavigation: false,
+      expenses: { expenses: [] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Finder")).toBeTruthy();
+    });
+
+    const searchClear = flattenStyle(
+      screen,
+      "finder-search-filter-clear-slot"
+    );
+    const dateClear = flattenStyle(screen, "finder-date-filter-clear-slot");
+
+    expect(searchClear.width).toBe(dateClear.width);
+    expect(searchClear.width).toBe(FINDER_FILTER_CLEAR_SLOT_WIDTH);
+    expect(searchClear.width).toBe(finderFilterRowStyles.clearColumn.width);
   });
 });

--- a/TravelCostApp/__tests__/screens/finder-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/finder-screen.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { ScrollView } from "react-native";
-import { act, waitFor } from "@testing-library/react-native";
+import { ScrollView, StyleSheet } from "react-native";
+import { act, fireEvent, waitFor } from "@testing-library/react-native";
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
@@ -33,15 +33,34 @@ jest.mock("react-native-toast-message/lib/src/Toast", () => ({
 
 jest.mock("../../components/UI/Autocomplete", () => {
   const React = require("react");
-  const { Text } = require("react-native");
-  return () => <Text testID="mock-autocomplete" />;
+  const { View } = require("react-native");
+  return function MockAutocomplete(props: { containerStyle?: object }) {
+    return <View testID="mock-autocomplete" style={props.containerStyle} />;
+  };
 });
 
-jest.mock("../../components/UI/DatePickerContainer", () => () => null);
+jest.mock("../../components/UI/DatePickerContainer", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return function MockDatePickerContainer(props: { containerStyle?: object }) {
+    return <View testID="mock-date-picker" style={props.containerStyle} />;
+  };
+});
 jest.mock("../../components/UI/DatePickerModal", () => () => null);
 
 import FinderScreen from "../../screens/FinderScreen";
+import {
+  FINDER_FILTER_CONTENT_WIDTH,
+  finderFilterRowStyles,
+} from "../../styles/finder-filter-row-styles";
 import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function flattenStyle(screen: { getByTestId: (id: string) => any }, testID: string) {
+  return StyleSheet.flatten(screen.getByTestId(testID).props.style) as Record<
+    string,
+    unknown
+  >;
+}
 
 describe("Finder screen", () => {
   it("shows the Finder title and empty-results state", async () => {
@@ -68,5 +87,88 @@ describe("Finder screen", () => {
 
     const scrollView = screen.UNSAFE_getByType(ScrollView);
     expect(scrollView.props.keyboardShouldPersistTaps).toBe("handled");
+  });
+
+  it("reserves a clear column on both Finder filter rows when filters are inactive", async () => {
+    const screen = renderWithAppProviders(<FinderScreen />, {
+      wrapNavigation: false,
+      expenses: { expenses: [] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Finder")).toBeTruthy();
+    });
+
+    expect(screen.getByTestId("finder-search-filter-clear-slot")).toBeTruthy();
+    expect(screen.getByTestId("finder-date-filter-clear-slot")).toBeTruthy();
+  });
+
+  it("gives search and date filter content the same fixed width", async () => {
+    const screen = renderWithAppProviders(<FinderScreen />, {
+      wrapNavigation: false,
+      expenses: { expenses: [] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Finder")).toBeTruthy();
+    });
+
+    const searchContent = flattenStyle(screen, "finder-search-filter-content");
+    const dateContent = flattenStyle(screen, "finder-date-filter-content");
+
+    expect(searchContent.width).toBe(FINDER_FILTER_CONTENT_WIDTH);
+    expect(dateContent.width).toBe(FINDER_FILTER_CONTENT_WIDTH);
+    expect(searchContent.width).toBe(
+      finderFilterRowStyles.filterContentColumn.width
+    );
+  });
+
+  it("vertically centers filter row checkbox and clear with content", async () => {
+    const screen = renderWithAppProviders(<FinderScreen />, {
+      wrapNavigation: false,
+      expenses: { expenses: [] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Finder")).toBeTruthy();
+    });
+
+    expect(flattenStyle(screen, "finder-search-filter").alignItems).toBe(
+      "center"
+    );
+    expect(flattenStyle(screen, "finder-date-filter").alignItems).toBe(
+      "center"
+    );
+    expect(
+      flattenStyle(screen, "finder-search-filter-checkbox").marginTop
+    ).toBeUndefined();
+    expect(
+      flattenStyle(screen, "finder-date-filter-checkbox").marginTop
+    ).toBeUndefined();
+  });
+
+  it("keeps the search clear column width when the filter becomes active", async () => {
+    const screen = renderWithAppProviders(<FinderScreen />, {
+      wrapNavigation: false,
+      expenses: { expenses: [] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Finder")).toBeTruthy();
+    });
+
+    const widthBefore = flattenStyle(
+      screen,
+      "finder-search-filter-clear-slot"
+    ).width;
+
+    fireEvent.press(screen.getAllByRole("checkbox")[0]);
+
+    const widthAfter = flattenStyle(
+      screen,
+      "finder-search-filter-clear-slot"
+    ).width;
+    expect(widthAfter).toBe(widthBefore);
+    expect(widthAfter).toBe(finderFilterRowStyles.clearColumn.width);
   });
 });

--- a/TravelCostApp/components/Finder/FinderFilterRow.tsx
+++ b/TravelCostApp/components/Finder/FinderFilterRow.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { View } from "react-native";
+import { Checkbox } from "react-native-paper";
+import IconButton from "../UI/IconButton";
+import { GlobalStyles } from "../../constants/styles";
+import { finderFilterRowStyles } from "../../styles/finder-filter-row-styles";
+import { dynamicScale } from "../../util/scalingUtil";
+
+type FinderFilterRowProps = {
+  testID: string;
+  rowStyle?: object;
+  checked: boolean;
+  onToggleChecked: () => void;
+  showClear: boolean;
+  onClear: () => void;
+  children: React.ReactNode;
+};
+
+const FinderFilterRow = ({
+  testID,
+  rowStyle,
+  checked,
+  onToggleChecked,
+  showClear,
+  onClear,
+  children,
+}: FinderFilterRowProps) => {
+  return (
+    <View
+      testID={testID}
+      style={[finderFilterRowStyles.row, rowStyle]}
+    >
+      <View
+        testID={`${testID}-checkbox`}
+        style={finderFilterRowStyles.checkboxColumn}
+      >
+        <Checkbox status={checked ? "checked" : "unchecked"} onPress={onToggleChecked} />
+      </View>
+      <View
+        testID={`${testID}-content`}
+        style={finderFilterRowStyles.filterContentColumn}
+      >
+        {children}
+      </View>
+      <View
+        testID={`${testID}-clear-slot`}
+        style={finderFilterRowStyles.clearColumn}
+      >
+        {showClear ? (
+          <IconButton
+            icon="close-outline"
+            size={dynamicScale(26, false, 0.5)}
+            color={GlobalStyles.colors.textColor}
+            onPressStyle={{
+              backgroundColor: GlobalStyles.colors.gray500,
+              borderRadius: 99,
+            }}
+            onPress={onClear}
+          />
+        ) : (
+          <View style={finderFilterRowStyles.clearPlaceholder} />
+        )}
+      </View>
+    </View>
+  );
+};
+
+export default FinderFilterRow;

--- a/TravelCostApp/components/UI/DatePickerContainer.tsx
+++ b/TravelCostApp/components/UI/DatePickerContainer.tsx
@@ -13,10 +13,15 @@ const DatePickerContainer = ({
   dateIsRanged,
   hideBottomBorder = false,
   narrow = false,
+  containerStyle,
 }) => {
   return (
     <View
-      style={[styles.dateContainer, !hideBottomBorder && styles.bottomBorder]}
+      style={[
+        styles.dateContainer,
+        !hideBottomBorder && styles.bottomBorder,
+        containerStyle,
+      ]}
     >
       <View style={styles.dateIconContainer}>
         <IconButton
@@ -55,6 +60,7 @@ DatePickerContainer.propTypes = {
   dateIsRanged: PropTypes.bool.isRequired,
   hideBottomBorder: PropTypes.bool,
   narrow: PropTypes.bool,
+  containerStyle: PropTypes.object,
 };
 
 const styles = StyleSheet.create({

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -15,11 +15,11 @@ import { i18n } from "../i18n/i18n";
 
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import * as Haptics from "expo-haptics";
-import { Checkbox } from "react-native-paper";
 import { Toast } from "react-native-toast-message/lib/src/Toast";
+import FinderFilterRow from "../components/Finder/FinderFilterRow";
 import Autocomplete from "../components/UI/Autocomplete";
+import { finderFilterRowStyles } from "../styles/finder-filter-row-styles";
 import GradientButton from "../components/UI/GradientButton";
-import IconButton from "../components/UI/IconButton";
 import { GlobalStyles } from "../constants/styles";
 import {
   asyncStoreGetItem,
@@ -298,87 +298,63 @@ const FinderScreen = () => {
             // scrollEnabled={false}
             style={{ flex: 1, minHeight: "50%" }}
           >
-            <View style={[styles.rowContainer, styles.searchRowContainer]}>
-              <View style={styles.checkBoxContainer}>
-                <Checkbox
-                  status={checkedQuery ? "checked" : "unchecked"}
-                  onPress={() => {
-                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                    const newValue = !checkedQuery;
-                    setCheckedQuery(newValue);
-                    trackEvent(VexoEvents.SEARCH_QUERY_CHECKBOX_TOGGLED, {
-                      enabled: newValue,
-                    });
-                  }}
-                />
-              </View>
+            <FinderFilterRow
+              testID="finder-search-filter"
+              rowStyle={finderFilterRowStyles.searchRow}
+              checked={checkedQuery}
+              showClear={checkedQuery}
+              onToggleChecked={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                const newValue = !checkedQuery;
+                setCheckedQuery(newValue);
+                trackEvent(VexoEvents.SEARCH_QUERY_CHECKBOX_TOGGLED, {
+                  enabled: newValue,
+                });
+              }}
+              onClear={() => {
+                setSearchQuery("");
+                setCheckedQuery(false);
+              }}
+            >
               <Autocomplete
                 value={searchQuery}
                 onChange={onChangeSearch}
                 data={suggestions}
                 showOnEmpty
-                // placeholder="Search for descriptions, categories, traveller names..."
                 label={i18n.t("searchLabel")}
-                containerStyle={styles.queryContainer}
+                containerStyle={styles.autocompleteInFilterRow}
                 style={styles.autoCompleteStyle}
-              ></Autocomplete>
-              {checkedQuery && (
-                <IconButton
-                  icon="close-outline"
-                  size={dynamicScale(26, false, 0.5)}
-                  color={GlobalStyles.colors.textColor}
-                  buttonStyle={{ marginTop: dynamicScale(14, true, 0.5) }}
-                  onPressStyle={{
-                    backgroundColor: GlobalStyles.colors.gray500,
-                    borderRadius: 99,
-                  }}
-                  onPress={() => {
-                    setSearchQuery("");
-                    setCheckedQuery(false);
-                  }}
-                ></IconButton>
-              )}
-            </View>
-            <View style={[styles.rowContainer, styles.dateRowContainer]}>
-              <View style={styles.checkBoxContainer}>
-                <Checkbox
-                  status={checkedDate ? "checked" : "unchecked"}
-                  onPress={() => {
-                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                    const newValue = !checkedDate;
-                    setCheckedDate(newValue);
-                    trackEvent(VexoEvents.DATE_FILTER_TOGGLED, {
-                      enabled: newValue,
-                    });
-                  }}
-                />
-              </View>
+              />
+            </FinderFilterRow>
+            <FinderFilterRow
+              testID="finder-date-filter"
+              rowStyle={finderFilterRowStyles.dateRow}
+              checked={checkedDate}
+              showClear={checkedDate}
+              onToggleChecked={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                const newValue = !checkedDate;
+                setCheckedDate(newValue);
+                trackEvent(VexoEvents.DATE_FILTER_TOGGLED, {
+                  enabled: newValue,
+                });
+              }}
+              onClear={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                setCheckedDate(false);
+                setStartDate(getFormattedDate(DateTime.now()));
+                setEndDate(getFormattedDate(DateTime.now()));
+              }}
+            >
               {DatePickerContainer({
                 openDatePickerRange,
                 startDate,
                 endDate,
                 dateIsRanged,
                 narrow: true,
+                containerStyle: styles.finderDatePickerContainer,
               })}
-              {checkedDate && (
-                <IconButton
-                  icon="close-outline"
-                  color={GlobalStyles.colors.textColor}
-                  size={dynamicScale(26, false, 0.5)}
-                  buttonStyle={{ marginTop: dynamicScale(14, true) }}
-                  onPressStyle={{
-                    backgroundColor: GlobalStyles.colors.gray500,
-                    borderRadius: 99,
-                  }}
-                  onPress={() => {
-                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                    setCheckedDate(false);
-                    setStartDate(getFormattedDate(DateTime.now()));
-                    setEndDate(getFormattedDate(DateTime.now()));
-                  }}
-                ></IconButton>
-              )}
-            </View>
+            </FinderFilterRow>
             <Text style={styles.queryText}>
               {(queryString || dateString) && i18n.t("finding")} :{queryString}{" "}
               {dateString}
@@ -438,32 +414,17 @@ const styles = StyleSheet.create({
       },
     }),
   },
-  checkBoxContainer: {
-    borderRadius: dynamicScale(99, false, 0.5),
-    marginRight: dynamicScale(8),
-    marginTop: dynamicScale(20, true),
-    ...Platform.select({
-      ios: { borderWidth: 1 },
-    }),
-  },
   headerContainer: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "flex-start",
     minHeight: dynamicScale(90, true),
   },
-  rowContainer: {
-    flex: 1,
-    flexDirection: "row",
-    alignItems: "flex-start",
-    justifyContent: "flex-start",
-    minHeight: dynamicScale(90, true),
-  },
-  searchRowContainer: {
-    zIndex: 10,
-  },
-  dateRowContainer: {
-    zIndex: 1,
+  finderDatePickerContainer: {
+    marginTop: 0,
+    marginRight: 0,
+    marginLeft: 0,
+    paddingBottom: 0,
   },
   titleText: {
     fontSize: dynamicScale(32, false, 0.5),
@@ -486,13 +447,8 @@ const styles = StyleSheet.create({
     marginHorizontal: dynamicScale(65),
     borderRadius: 99,
   },
-  queryContainer: {
-    flex: 1,
-    marginTop: dynamicScale(10, true),
-    marginLeft: dynamicScale(18),
-    maxWidth: dynamicScale(180),
-    backgroundColor: GlobalStyles.colors.backgroundColorLight,
-    borderRadius: dynamicScale(8, false, 0.3),
+  autocompleteInFilterRow: {
+    alignSelf: "stretch",
     overflow: "visible",
   },
   autoCompleteStyle: {

--- a/TravelCostApp/styles/finder-filter-row-styles.ts
+++ b/TravelCostApp/styles/finder-filter-row-styles.ts
@@ -1,0 +1,46 @@
+import { Platform, StyleSheet } from "react-native";
+import { GlobalStyles } from "../constants/styles";
+import { dynamicScale } from "../util/scalingUtil";
+
+export const FINDER_FILTER_CONTENT_WIDTH = dynamicScale(180, false, 0.5);
+export const FINDER_FILTER_CLEAR_SLOT_WIDTH = dynamicScale(40, false, 0.5);
+const CLEAR_ICON_SIZE = dynamicScale(26, false, 0.5);
+
+export const finderFilterRowStyles = StyleSheet.create({
+  row: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    minHeight: dynamicScale(90, true),
+  },
+  searchRow: {
+    zIndex: 10,
+  },
+  dateRow: {
+    zIndex: 1,
+  },
+  checkboxColumn: {
+    borderRadius: dynamicScale(99, false, 0.5),
+    marginRight: dynamicScale(8),
+    justifyContent: "center",
+    ...Platform.select({
+      ios: { borderWidth: 1 },
+    }),
+  },
+  filterContentColumn: {
+    width: FINDER_FILTER_CONTENT_WIDTH,
+    backgroundColor: GlobalStyles.colors.backgroundColorLight,
+    borderRadius: dynamicScale(8, false, 0.3),
+    overflow: "visible",
+  },
+  clearColumn: {
+    width: FINDER_FILTER_CLEAR_SLOT_WIDTH,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  clearPlaceholder: {
+    width: CLEAR_ICON_SIZE,
+    height: CLEAR_ICON_SIZE,
+  },
+});


### PR DESCRIPTION
## Summary
- Introduce `FinderFilterRow` with a shared `[checkbox] [content] [clear]` layout for Finder search and date filters
- Use a fixed content width and always-reserved clear column so controls stay aligned when filters toggle
- Vertically center checkbox and clear with row content; remove ad-hoc `marginTop` offsets on the search row

## Test plan
- [x] `pnpm test -- __tests__/screens/finder-screen.test.tsx`
- [ ] Finder screen on iOS: toggle search/date filters, clear each, confirm no horizontal shift
- [ ] Finder screen on Android: same checks; autocomplete and date picker still work

Closes #309