### PR TITLE
Traveller budget overview as real modal

### DIFF
--- a/TravelCostApp/__tests__/components/expenses-summary.test.tsx
+++ b/TravelCostApp/__tests__/components/expenses-summary.test.tsx
@@ -9,14 +9,29 @@ jest.mock("expo-haptics", () => ({
   ImpactFeedbackStyle: { Light: "Light" },
 }));
 
+const mockToastShow = jest.fn();
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: {
+    show: (...args: unknown[]) => mockToastShow(...args),
+    hide: jest.fn(),
+  },
+}));
+
+import { fireEvent } from "@testing-library/react-native";
 import { StyleSheet } from "react-native";
 
+import { i18n } from "../../i18n/i18n";
 import ExpensesSummary from "../../components/ExpensesOutput/ExpensesSummary";
 import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
 describe("ExpensesSummary", () => {
+  beforeEach(() => {
+    mockToastShow.mockClear();
+  });
+
   it("shows the period expense total in Trip currency", () => {
     const expenses = [makeExpense({ calcAmount: 75, amount: 75 })];
 
@@ -63,5 +78,78 @@ describe("ExpensesSummary", () => {
     expect(flat.maxWidth).toBe(dropdownChrome.maxWidth);
     expect(flat.alignItems).toBe("center");
     expect(flat.paddingTop).toBeUndefined();
+  });
+
+  it("opens the budget overview modal on press and dismisses via close", () => {
+    const expenses = [makeExpense({ calcAmount: 75, amount: 75 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="month" />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+      },
+    );
+
+    expect(screen.queryByText(i18n.t("overview"))).toBeNull();
+
+    fireEvent.press(screen.getByTestId("expenses-summary-pressable"));
+
+    expect(screen.getByText(i18n.t("overview"))).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId("budget-overview-close"));
+
+    expect(screen.queryByText(i18n.t("overview"))).toBeNull();
+  });
+
+  it("shows per-traveller budget bars in the overview modal", () => {
+    const expenses = [makeExpense({ calcAmount: 75, amount: 75 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="month" />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+      },
+    );
+
+    fireEvent.press(screen.getByTestId("expenses-summary-pressable"));
+
+    expect(
+      screen.getByText(new RegExp(i18n.t("budgetPerTraveller"))),
+    ).toBeTruthy();
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+    expect(
+      mockToastShow.mock.calls.some(
+        (call) => (call[0] as { type?: string }).type === "budgetOverview",
+      ),
+    ).toBe(false);
+  });
+
+  it("dismisses the budget overview modal when the backdrop is pressed", () => {
+    const expenses = [makeExpense({ calcAmount: 75, amount: 75 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="month" />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+      },
+    );
+
+    fireEvent.press(screen.getByTestId("expenses-summary-pressable"));
+    fireEvent.press(screen.getByTestId("budget-overview-backdrop"));
+
+    expect(screen.queryByText(i18n.t("overview"))).toBeNull();
   });
 });

--- a/TravelCostApp/__tests__/components/expenses-summary.test.tsx
+++ b/TravelCostApp/__tests__/components/expenses-summary.test.tsx
@@ -19,7 +19,7 @@ jest.mock("react-native-toast-message", () => ({
 }));
 
 import { fireEvent } from "@testing-library/react-native";
-import { StyleSheet } from "react-native";
+import { Modal, StyleSheet } from "react-native";
 
 import { i18n } from "../../i18n/i18n";
 import ExpensesSummary from "../../components/ExpensesOutput/ExpensesSummary";
@@ -149,6 +149,76 @@ describe("ExpensesSummary", () => {
 
     fireEvent.press(screen.getByTestId("expenses-summary-pressable"));
     fireEvent.press(screen.getByTestId("budget-overview-backdrop"));
+
+    expect(screen.queryByText(i18n.t("overview"))).toBeNull();
+  });
+
+  it("shows overview without per-traveller list for a single traveller", () => {
+    const expenses = [makeExpense({ calcAmount: 50, amount: 50 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="month" />,
+      {
+        wrapNavigation: false,
+        trip: { travellers: ["Alice"] },
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+      },
+    );
+
+    fireEvent.press(screen.getByTestId("expenses-summary-pressable"));
+
+    expect(screen.getByText(i18n.t("overview"))).toBeTruthy();
+    expect(
+      screen.queryByText(new RegExp(i18n.t("budgetPerTraveller"))),
+    ).toBeNull();
+  });
+
+  it("shows an error toast instead of the modal when the period budget is unlimited", () => {
+    const expenses = [makeExpense({ calcAmount: 50, amount: 50 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="total" />,
+      {
+        wrapNavigation: false,
+        trip: { totalBudget: "", travellers: ["Alice"] },
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+      },
+    );
+
+    fireEvent.press(screen.getByTestId("expenses-summary-pressable"));
+
+    expect(screen.queryByText(i18n.t("overview"))).toBeNull();
+    expect(mockToastShow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        text1: i18n.t("noTotalBudget"),
+        text2: i18n.t("infinityLeftToSpend"),
+      }),
+    );
+  });
+
+  it("dismisses the budget overview modal on Android back", () => {
+    const expenses = [makeExpense({ calcAmount: 75, amount: 75 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="month" />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+      },
+    );
+
+    fireEvent.press(screen.getByTestId("expenses-summary-pressable"));
+    fireEvent(screen.UNSAFE_getByType(Modal), "requestClose");
 
     expect(screen.queryByText(i18n.t("overview"))).toBeNull();
   });

--- a/TravelCostApp/components/ExpensesOutput/BudgetOverviewContent.tsx
+++ b/TravelCostApp/components/ExpensesOutput/BudgetOverviewContent.tsx
@@ -86,6 +86,8 @@ const BudgetOverviewContent = ({
       {hasMultipleTravellers && (
         <FlatList
           data={travellerList}
+          nestedScrollEnabled
+          style={styles.travellerList}
           ListHeaderComponent={() => (
             <Text style={styles.overviewTextInfo}>
               {i18n.t("budgetPerTraveller")}:{" "}
@@ -182,6 +184,9 @@ const BudgetOverviewContent = ({
 export default BudgetOverviewContent;
 
 const styles = StyleSheet.create({
+  travellerList: {
+    maxHeight: dynamicScale(320, false, 0.5),
+  },
   budgetOverviewHeader: {
     flexDirection: "row",
     justifyContent: "space-between",

--- a/TravelCostApp/components/ExpensesOutput/BudgetOverviewContent.tsx
+++ b/TravelCostApp/components/ExpensesOutput/BudgetOverviewContent.tsx
@@ -1,0 +1,235 @@
+import React from "react";
+import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import * as Progress from "react-native-progress";
+
+import { GlobalStyles } from "../../constants/styles";
+import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
+import { i18n } from "../../i18n/i18n";
+import { formatExpenseWithCurrency } from "../../util/string";
+import { constantScale, dynamicScale, scale } from "../../util/scalingUtil";
+
+export interface BudgetOverviewContentProps {
+  travellerList: string[];
+  travellerBudgets: number;
+  travellerSplitExpenseSums: number[];
+  currency: string;
+  noTotalBudget: boolean;
+  periodName: string;
+  trafficLightActive: boolean;
+  currentBudgetColor: string;
+  averageDailySpending: number;
+  dailyBudget: number;
+  expenseSumNum: number;
+  budgetNumber: number;
+  onClose: () => void;
+}
+
+type TrafficLightStatus = "green" | "yellow" | "red" | null;
+
+const BudgetOverviewContent = ({
+  travellerList,
+  travellerBudgets,
+  travellerSplitExpenseSums,
+  currency,
+  noTotalBudget,
+  periodName,
+  trafficLightActive,
+  currentBudgetColor,
+  averageDailySpending,
+  dailyBudget,
+  expenseSumNum,
+  budgetNumber,
+  onClose,
+}: BudgetOverviewContentProps) => {
+  const hasMultipleTravellers = travellerList && travellerList.length > 1;
+  const travellerCount = travellerList?.length || 1;
+  const isYellowStatus =
+    trafficLightActive &&
+    currentBudgetColor === GlobalStyles.colors.accent500;
+
+  const getTrafficLightStatus = (): TrafficLightStatus => {
+    if (
+      !trafficLightActive ||
+      noTotalBudget ||
+      averageDailySpending <= 0 ||
+      dailyBudget <= 0
+    ) {
+      return null;
+    }
+
+    if (expenseSumNum <= budgetNumber) {
+      return "green";
+    }
+
+    if (averageDailySpending <= dailyBudget) {
+      return "yellow";
+    }
+
+    return "red";
+  };
+
+  const trafficLightStatus = getTrafficLightStatus();
+
+  return (
+    <>
+      <View style={styles.budgetOverviewHeader}>
+        <Text style={styles.overviewTextTitle}>{i18n.t("overview")}</Text>
+        <Pressable
+          onPress={onClose}
+          testID="budget-overview-close"
+          accessibilityRole="button"
+        >
+          <Text style={styles.overviewTextTitle}>X</Text>
+        </Pressable>
+      </View>
+
+      {hasMultipleTravellers && (
+        <FlatList
+          data={travellerList}
+          ListHeaderComponent={() => (
+            <Text style={styles.overviewTextInfo}>
+              {i18n.t("budgetPerTraveller")}:{" "}
+              {formatExpenseWithCurrency(travellerBudgets, currency)} /{" "}
+              {i18n.t(periodName)}
+            </Text>
+          )}
+          renderItem={({ item, index }) => {
+            const sum = formatExpenseWithCurrency(
+              +travellerSplitExpenseSums[index].toFixed(2),
+              currency,
+            );
+            const budgetProgress =
+              travellerSplitExpenseSums[index] / travellerBudgets;
+            const budgetColor = noTotalBudget
+              ? GlobalStyles.colors.primary500
+              : budgetProgress <= 1
+                ? GlobalStyles.colors.primary500
+                : isYellowStatus
+                  ? GlobalStyles.colors.accent500
+                  : GlobalStyles.colors.error300;
+            const unfilledColor: string = noTotalBudget
+              ? GlobalStyles.colors.primary500
+              : GlobalStyles.colors.gray600;
+            const travellerName = item;
+            return (
+              <View style={styles.travellerItemContainer}>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    paddingHorizontal: dynamicScale(4),
+                  }}
+                >
+                  <Text style={styles.overviewTextSmall}>{travellerName}</Text>
+                  <Text
+                    style={[
+                      styles.overViewTextTravellerSum,
+                      styles.sumTextMoveRight,
+                    ]}
+                  >
+                    {sum}
+                  </Text>
+                </View>
+                <View
+                  style={[
+                    styles.travellerItemProgressBarContainer,
+                    shadowRegressionStyles.toastProgressBarTrack,
+                  ]}
+                >
+                  <Progress.Bar
+                    color={budgetColor}
+                    unfilledColor={unfilledColor}
+                    borderWidth={0}
+                    progress={budgetProgress}
+                    width={scale(180)}
+                    height={constantScale(20, 0.5)}
+                    borderRadius={dynamicScale(8, false, 0.5)}
+                  />
+                </View>
+              </View>
+            );
+          }}
+        />
+      )}
+      {trafficLightStatus && (
+        <Text style={styles.overviewTextInfo}>
+          {trafficLightStatus === "green" &&
+            `🟢 - ${i18n.t("averageDailySpending")}: ${formatExpenseWithCurrency(
+              averageDailySpending / travellerCount,
+              currency,
+            )}`}
+          {trafficLightStatus === "yellow" &&
+            `🟡 - ${i18n.t("overBudgetButAverage")}: ${formatExpenseWithCurrency(
+              averageDailySpending / travellerCount,
+              currency,
+            )}\n${i18n.t("underDailyBudget")}: ${formatExpenseWithCurrency(
+              dailyBudget / travellerCount,
+              currency,
+            )}`}
+          {trafficLightStatus === "red" &&
+            `🔴 - ${i18n.t("trafficLightOverBudgetAndAverage")}\n${i18n.t("averageDailySpending")}: ${formatExpenseWithCurrency(
+              averageDailySpending / travellerCount,
+              currency,
+            )}\n${i18n.t("dailyBudget")}: ${formatExpenseWithCurrency(
+              dailyBudget / travellerCount,
+              currency,
+            )}`}
+        </Text>
+      )}
+    </>
+  );
+};
+
+export default BudgetOverviewContent;
+
+const styles = StyleSheet.create({
+  budgetOverviewHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  travellerItemContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    minHeight: dynamicScale(40, true),
+    overflow: "visible",
+  },
+  travellerItemProgressBarContainer: {
+    padding: dynamicScale(2),
+    overflow: "visible",
+    zIndex: -1,
+  },
+  sumTextMoveRight: {
+    left: dynamicScale(110),
+    position: "absolute",
+    zIndex: 999,
+  },
+  overviewTextInfo: {
+    fontSize: dynamicScale(12, false, 0.5),
+    fontWeight: "300",
+    color: GlobalStyles.colors.textColor,
+    textAlign: "left",
+    paddingVertical: dynamicScale(8, true),
+  },
+  overviewTextSmall: {
+    fontSize: dynamicScale(16, false, 0.5),
+    fontWeight: "200",
+    color: GlobalStyles.colors.textColor,
+    textAlign: "left",
+    paddingVertical: dynamicScale(4, true),
+  },
+  overViewTextTravellerSum: {
+    fontSize: dynamicScale(16, false, 0.5),
+    fontWeight: "500",
+    color: GlobalStyles.colors.gray300,
+    textAlign: "left",
+    paddingTop: dynamicScale(5, true),
+  },
+  overviewTextTitle: {
+    fontSize: dynamicScale(20, false, 0.5),
+    fontWeight: "500",
+    color: GlobalStyles.colors.textColor,
+    textAlign: "left",
+    paddingVertical: dynamicScale(8, true),
+  },
+});

--- a/TravelCostApp/components/ExpensesOutput/BudgetOverviewModal.tsx
+++ b/TravelCostApp/components/ExpensesOutput/BudgetOverviewModal.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Modal, Pressable, StyleSheet, View } from "react-native";
+import PropTypes from "prop-types";
+
+import { GlobalStyles } from "../../constants/styles";
+import { dynamicScale } from "../../util/scalingUtil";
+import BudgetOverviewContent, {
+  type BudgetOverviewContentProps,
+} from "./BudgetOverviewContent";
+
+export type BudgetOverviewModalProps = {
+  isVisible: boolean;
+  onClose: () => void;
+} & Omit<BudgetOverviewContentProps, "onClose">;
+
+const BudgetOverviewModal = ({
+  isVisible,
+  onClose,
+  ...contentProps
+}: BudgetOverviewModalProps) => {
+  return (
+    <Modal
+      visible={isVisible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <Pressable
+        style={styles.modalOverlay}
+        onPress={onClose}
+        testID="budget-overview-backdrop"
+        accessibilityRole="button"
+      >
+        <Pressable onPress={(event) => event.stopPropagation()}>
+          <View style={styles.modalContainer}>
+            <BudgetOverviewContent {...contentProps} onClose={onClose} />
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+};
+
+BudgetOverviewModal.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default BudgetOverviewModal;
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  modalContainer: {
+    backgroundColor: GlobalStyles.colors.backgroundColor,
+    borderRadius: dynamicScale(20, false, 0.5),
+    padding: dynamicScale(24, false, 0.5),
+    marginHorizontal: dynamicScale(20, false, 0.5),
+    maxWidth: dynamicScale(400, false, 0.5),
+    width: "90%",
+    ...GlobalStyles.strongShadow,
+  },
+});

--- a/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
@@ -1,5 +1,5 @@
 import { Platform, StyleSheet, View, Text } from "react-native";
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 import { GlobalStyles } from "../../constants/styles";
 import { shadowRegressionStyles, periodHeaderLabelFontSize } from "../../styles/shadow-regression-styles";
 import * as Progress from "react-native-progress";
@@ -7,14 +7,12 @@ import { TripContext } from "../../store/trip-context";
 
 import { i18n } from "../../i18n/i18n";
 
-import { formatExpenseWithCurrency, truncateNumber } from "../../util/string";
 import PropTypes from "prop-types";
 import { Pressable } from "react-native";
 import Toast from "react-native-toast-message";
 import { MAX_JS_NUMBER } from "../../confAppConstants";
 import * as Haptics from "expo-haptics";
 import { UserContext } from "../../store/user-context";
-import { getRate } from "../../util/currencyExchange";
 import { SettingsContext } from "../../store/settings-context";
 import {
   ExpenseData,
@@ -28,6 +26,7 @@ import {
   calculateDailyAverage,
   getBudgetColor,
 } from "../../util/budget";
+import BudgetOverviewModal from "./BudgetOverviewModal";
 
 const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
   const tripCtx = useContext(TripContext);
@@ -35,23 +34,7 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
   const expCtx = useContext(ExpensesContext);
   const { settings } = useContext(SettingsContext);
   const hideSpecial = settings.hideSpecialExpenses;
-  const [isToastShowing, setIsToastShowing] = useState(false);
-
-  const [lastRate, setLastRate] = useState(1);
-  const lastRateUnequal1 = lastRate !== 1;
-  const getRateCallback = useCallback(async () => {
-    if (!userCtx.lastCurrency || !tripCtx.tripCurrency) {
-      setLastRate(1);
-      return;
-    }
-    setLastRate(await getRate(tripCtx.tripCurrency, userCtx.lastCurrency));
-  }, [tripCtx.tripCurrency, userCtx.lastCurrency]);
-  useEffect(() => {
-    async function call() {
-      await getRateCallback();
-    }
-    call();
-  }, [userCtx.lastCurrency, tripCtx.tripCurrency, getRateCallback]);
+  const [isOverviewVisible, setIsOverviewVisible] = useState(false);
 
   const safeExpenses = Array.isArray(expenses) ? expenses : [];
   const travellers = Array.isArray(tripCtx.travellers)
@@ -82,23 +65,9 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
     return <></>;
   }
 
-  const expensesSumString = formatExpenseWithCurrency(
-    truncateNumber(expensesSum, 1000, true),
-    tripCurrency,
-  );
-
-  const calcExpensesSumString =
-    lastRate == 1
-      ? ""
-      : formatExpenseWithCurrency(
-          truncateNumber(expensesSum * lastRate, 1000, true),
-          userCtx.lastCurrency,
-        );
-
   let budgetNumber = Number(tripCtx.dailyBudget ?? 0);
   let infinityString = "";
   let periodExpenses: ExpenseData[] = [];
-  let periodLabel = "";
   const expenseSumNum = Number(expensesSum);
   let totalBudget = Number(tripCtx.totalBudget ?? 0);
   if (Number.isNaN(totalBudget)) totalBudget = 0;
@@ -108,30 +77,25 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
   switch (periodName) {
     case "day":
       periodExpenses = expCtx.getRecentExpenses(RangeString.day) || [];
-      periodLabel = i18n.t("todayLabel");
       break;
     case "week":
       budgetMult = 7;
       budgetNumber = budgetNumber * budgetMult;
       periodExpenses = expCtx.getRecentExpenses(RangeString.week) || [];
-      periodLabel = i18n.t("weekLabel");
       break;
     case "month":
       budgetMult = 30;
       budgetNumber = budgetNumber * budgetMult;
       periodExpenses = expCtx.getRecentExpenses(RangeString.month) || [];
-      periodLabel = i18n.t("monthLabel");
       break;
     case "year":
       budgetMult = 365;
       budgetNumber = budgetNumber * budgetMult;
       periodExpenses = expCtx.getRecentExpenses(RangeString.year) || [];
-      periodLabel = i18n.t("yearLabel");
       break;
     case "total":
       budgetNumber = totalBudget ?? MAX_JS_NUMBER;
       periodExpenses = expCtx.expenses || [];
-      periodLabel = i18n.t("totalLabel");
       break;
     default:
       break;
@@ -199,113 +163,49 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
   if (Number.isNaN(budgetProgress)) {
     return <></>;
   }
-  const calcLeftToSpend = lastRateUnequal1
-    ? formatExpenseWithCurrency(
-        truncateNumber((budgetNumber - expenseSumNum) * lastRate, 1000, true),
-        userCtx.lastCurrency,
-      )
-    : "";
-  const leftToSpendString = `${i18n.t(
-    "youHaveXLeftToSpend1",
-  )}:\n${formatExpenseWithCurrency(
-    truncateNumber(budgetNumber - expenseSumNum, 1000, true),
-    tripCurrency,
-  )}${lastRateUnequal1 ? " = " : ""}${calcLeftToSpend}${i18n.t(
-    "youHaveXLeftToSpend2",
-  )}`;
-
-  const calcOverBudget = lastRateUnequal1
-    ? formatExpenseWithCurrency(
-        truncateNumber((expenseSumNum - budgetNumber) * lastRate, 1000, true),
-        userCtx.lastCurrency,
-      )
-    : "";
-
-  const overBudgetString = `${i18n.t(
-    "exceededBudgetByX1",
-  )}:\n${formatExpenseWithCurrency(
-    truncateNumber(expenseSumNum - budgetNumber, 1000, true),
-    tripCurrency,
-  )}${lastRateUnequal1 ? " = " : ""}${calcOverBudget} !`;
-
-  const periodBudgetString = `${periodLabel} ${i18n.t(
-    "budget",
-  )} :\n${formatExpenseWithCurrency(
-    budgetNumber,
-    tripCtx.tripCurrency,
-  )} = ${formatExpenseWithCurrency(
-    budgetNumber * lastRate,
-    userCtx.lastCurrency,
-  )}`;
-
   const valid = tripCtx.tripid && travellerNames.length > 0;
+  const closeOverview = () => setIsOverviewVisible(false);
+
   const pressBudgetHandler = () => {
-    if (isToastShowing) {
-      setIsToastShowing(false);
-      Toast.hide();
+    if (isOverviewVisible) {
+      closeOverview();
       return;
     }
-    setIsToastShowing(true);
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     if (infinityString) {
       Toast.show({
         type: "error",
         text1: i18n.t("noTotalBudget"),
         text2: i18n.t("infinityLeftToSpend"),
-        onHide() {
-          setIsToastShowing(false);
-        },
       });
       return;
     }
-    const tripCurrency = tripCtx.tripCurrency;
-    const lastCurrency = userCtx.lastCurrency;
     if (!valid) {
-      Toast.hide();
-      setIsToastShowing(false);
       return;
     }
-    Toast.show({
-      type: "budgetOverview",
-      position: "bottom",
-      text1: `${periodLabel} ${i18n.t("expenses")} :\n${expensesSumString} ${
-        lastRateUnequal1 ? "=" : ""
-      } ${calcExpensesSumString}`,
-      text2:
-        budgetNumber > expenseSumNum
-          ? `${leftToSpendString}`
-          : `${overBudgetString}`,
-      bottomOffset: 40,
-      visibilityTime: 20000,
-      onHide: () => {
-        setIsToastShowing(false);
-      },
-      props: {
-        text3: `${formatExpenseWithCurrency(
-          1,
-          tripCurrency,
-        )} = ${formatExpenseWithCurrency(lastRate, lastCurrency)}`,
-        travellerList: travellerNames,
-        travellerBudgets:
-          travellerNames.length > 0 ? budgetNumber / travellerNames.length : 0,
-        budgetNumber: budgetNumber,
-        travellerSplitExpenseSums: travellerSplitExpenseSums,
-        currency: tripCurrency,
-        noTotalBudget: noTotalBudget,
-        periodName: periodName,
-        periodLabel: periodLabel,
-        periodBudgetString: periodBudgetString,
-        lastRateUnequal1: lastRateUnequal1,
-        trafficLightActive: settings.trafficLightBudgetColors,
-        currentBudgetColor: budgetColor,
-        averageDailySpending: averageDailySpending,
-        dailyBudget: dailyBudget,
-        expenseSumNum: expenseSumNum,
-      },
-    });
+    setIsOverviewVisible(true);
   };
 
   return (
+    <>
+    <BudgetOverviewModal
+      isVisible={isOverviewVisible}
+      onClose={closeOverview}
+      travellerList={travellerNames}
+      travellerBudgets={
+        travellerNames.length > 0 ? budgetNumber / travellerNames.length : 0
+      }
+      travellerSplitExpenseSums={travellerSplitExpenseSums}
+      currency={tripCurrency}
+      noTotalBudget={noTotalBudget}
+      periodName={periodName}
+      trafficLightActive={settings.trafficLightBudgetColors}
+      currentBudgetColor={budgetColor}
+      averageDailySpending={averageDailySpending}
+      dailyBudget={dailyBudget}
+      expenseSumNum={expenseSumNum}
+      budgetNumber={budgetNumber}
+    />
     <Pressable
       testID="expenses-summary-pressable"
       onPress={() => pressBudgetHandler()}
@@ -335,6 +235,7 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
         height={constantScale(6, 0.5)}
       />
     </Pressable>
+    </>
   );
 };
 

--- a/TravelCostApp/components/UI/ToastComponent.tsx
+++ b/TravelCostApp/components/UI/ToastComponent.tsx
@@ -4,7 +4,7 @@ import Toast, {
   ToastConfig,
 } from "react-native-toast-message";
 import React from "react";
-import { StyleSheet, View, FlatList } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { GlobalStyles } from "../../constants/styles";
 import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
 import LoadingBarOverlay from "./LoadingBarOverlay";
@@ -18,33 +18,11 @@ import { TouchableOpacity } from "react-native-gesture-handler";
 import { getMMKVString, MMKV_KEYS, setMMKVString } from "../../store/mmkv";
 import { DEVELOPER_MODE } from "../../confAppConstants";
 import { isPremiumMember } from "../Premium/PremiumConstants";
-import { formatExpenseWithCurrency } from "../../util/string";
 import { shouldShowOnboarding } from "../Rating/firstStartUtil";
 import { Pressable } from "react-native";
-import { constantScale, dynamicScale, scale } from "../../util/scalingUtil";
+import { constantScale, dynamicScale } from "../../util/scalingUtil";
 import { DeviceType, deviceType } from "expo-device";
 import { OnboardingFlags } from "../../types/onboarding";
-
-interface BudgetOverviewToastProps {
-  travellerList: string[];
-  travellerBudgets: number;
-  travellerSplitExpenseSums: number[];
-  currency: string;
-  noTotalBudget: boolean;
-  periodName: string;
-  periodLabel: string;
-  periodBudgetString: string;
-  lastRateUnequal1: boolean;
-  trafficLightActive: boolean;
-  currentBudgetColor: string;
-  averageDailySpending: number;
-  dailyBudget: number;
-  expenseSumNum: number;
-  budgetNumber: number;
-  text3?: string;
-}
-
-type TrafficLightStatus = "green" | "yellow" | "red" | null;
 
 const MINHEIGHT = dynamicScale(60, true);
 const MINHEIGHT_LOADINGBAR = dynamicScale(88, true);
@@ -312,164 +290,6 @@ const toastConfig: ToastConfig = {
       </View>
     );
   },
-  budgetOverview: (props) => {
-    const toastProps = props.props as BudgetOverviewToastProps;
-    const {
-      travellerList,
-      travellerBudgets,
-      travellerSplitExpenseSums,
-      currency,
-      noTotalBudget,
-      periodName,
-      trafficLightActive,
-      currentBudgetColor,
-      averageDailySpending,
-      dailyBudget,
-      expenseSumNum,
-      budgetNumber,
-    } = toastProps;
-
-    const hasMultipleTravellers = travellerList && travellerList.length > 1;
-    const travellerCount = travellerList?.length || 1;
-    const isYellowStatus =
-      trafficLightActive &&
-      currentBudgetColor === GlobalStyles.colors.accent500;
-
-    const getTrafficLightStatus = (): TrafficLightStatus => {
-      if (
-        !trafficLightActive ||
-        noTotalBudget ||
-        averageDailySpending <= 0 ||
-        dailyBudget <= 0
-      ) {
-        return null;
-      }
-
-      if (expenseSumNum <= budgetNumber) {
-        return "green";
-      }
-
-      if (averageDailySpending <= dailyBudget) {
-        return "yellow";
-      }
-
-      return "red";
-    };
-
-    const trafficLightStatus = getTrafficLightStatus();
-
-    return (
-      <View
-        style={[styles.budgetOverviewContainer, shadowRegressionStyles.toastSurface]}
-      >
-        <View style={styles.budgetOverviewHeader}>
-          <Text style={styles.overviewTextTitle}>{i18n.t("overview")}</Text>
-          <Pressable onPress={() => Toast.hide()}>
-            <Text style={styles.overviewTextTitle}>X</Text>
-          </Pressable>
-        </View>
-
-        {hasMultipleTravellers && (
-          <FlatList
-            data={travellerList}
-            ListHeaderComponent={() => {
-              return (
-                <Text style={styles.overviewTextInfo}>
-                  {i18n.t("budgetPerTraveller")}:{" "}
-                  {formatExpenseWithCurrency(travellerBudgets, currency)} /{" "}
-                  {i18n.t(periodName)}
-                </Text>
-              );
-            }}
-            renderItem={({ item, index }) => {
-              const sum = formatExpenseWithCurrency(
-                +travellerSplitExpenseSums[index].toFixed(2),
-                currency
-              );
-              const budgetProgress =
-                travellerSplitExpenseSums[index] / travellerBudgets;
-              const budgetColor = noTotalBudget
-                ? GlobalStyles.colors.primary500
-                : budgetProgress <= 1
-                  ? GlobalStyles.colors.primary500
-                  : isYellowStatus
-                    ? GlobalStyles.colors.accent500
-                    : GlobalStyles.colors.error300;
-              const unfilledColor: string = noTotalBudget
-                ? GlobalStyles.colors.primary500
-                : budgetProgress <= 1
-                  ? GlobalStyles.colors.gray600
-                  : GlobalStyles.colors.gray600;
-              const travellerName = item;
-              return (
-                <View style={styles.travellerItemContainer}>
-                  <View
-                    style={{
-                      flexDirection: "row",
-                      paddingHorizontal: dynamicScale(4),
-                    }}
-                  >
-                    <Text style={styles.overviewTextSmall}>
-                      {travellerName}
-                    </Text>
-                    <Text
-                      style={[
-                        styles.overViewTextTravellerSum,
-                        styles.sumTextMoveRight,
-                      ]}
-                    >
-                      {sum}
-                    </Text>
-                  </View>
-                  <View
-                    style={[
-                      styles.travellerItemProgressBarContainer,
-                      shadowRegressionStyles.toastProgressBarTrack,
-                    ]}
-                  >
-                    <Progress.Bar
-                      color={budgetColor}
-                      unfilledColor={unfilledColor}
-                      borderWidth={0}
-                      progress={budgetProgress}
-                      width={scale(180)}
-                      height={constantScale(20, 0.5)}
-                      borderRadius={dynamicScale(8, false, 0.5)}
-                    ></Progress.Bar>
-                  </View>
-                </View>
-              );
-            }}
-          ></FlatList>
-        )}
-        {trafficLightStatus && (
-          <Text style={styles.overviewTextInfo}>
-            {trafficLightStatus === "green" &&
-              `🟢 - ${i18n.t("averageDailySpending")}: ${formatExpenseWithCurrency(
-                averageDailySpending / travellerCount,
-                currency
-              )}`}
-            {trafficLightStatus === "yellow" &&
-              `🟡 - ${i18n.t("overBudgetButAverage")}: ${formatExpenseWithCurrency(
-                averageDailySpending / travellerCount,
-                currency
-              )}\n${i18n.t("underDailyBudget")}: ${formatExpenseWithCurrency(
-                dailyBudget / travellerCount,
-                currency
-              )}`}
-            {trafficLightStatus === "red" &&
-              `🔴 - ${i18n.t("trafficLightOverBudgetAndAverage")}\n${i18n.t("averageDailySpending")}: ${formatExpenseWithCurrency(
-                averageDailySpending / travellerCount,
-                currency
-              )}\n${i18n.t("dailyBudget")}: ${formatExpenseWithCurrency(
-                dailyBudget / travellerCount,
-                currency
-              )}`}
-          </Text>
-        )}
-      </View>
-    );
-  },
 };
 
 function isCalledToday() {
@@ -537,65 +357,6 @@ const ToastComponent = () => {
 export default ToastComponent;
 
 const styles = StyleSheet.create({
-  budgetOverviewContainer: {
-    flex: 1,
-    borderColor: GlobalStyles.colors.primaryGrayed,
-    borderWidth: 1,
-    borderRadius: 36,
-    paddingHorizontal: dynamicScale(30),
-    paddingVertical: dynamicScale(12),
-    backgroundColor: GlobalStyles.colors.backgroundColorLight,
-  },
-  budgetOverviewHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  travellerItemContainer: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    minHeight: dynamicScale(40, true),
-    overflow: "visible",
-  },
-  travellerItemProgressBarContainer: {
-    padding: dynamicScale(2),
-    overflow: "visible",
-    zIndex: -1,
-  },
-  sumTextMoveRight: {
-    left: dynamicScale(110),
-    position: "absolute",
-    zIndex: 999,
-  },
-  overviewTextInfo: {
-    fontSize: dynamicScale(12, false, 0.5),
-    fontWeight: "300",
-    color: GlobalStyles.colors.textColor,
-    textAlign: "left",
-    paddingVertical: dynamicScale(8, true),
-  },
-  overviewTextSmall: {
-    fontSize: dynamicScale(16, false, 0.5),
-    fontWeight: "200",
-    color: GlobalStyles.colors.textColor,
-    textAlign: "left",
-    paddingVertical: dynamicScale(4, true),
-  },
-  overViewTextTravellerSum: {
-    fontSize: dynamicScale(16, false, 0.5),
-    fontWeight: "500",
-    color: GlobalStyles.colors.gray300,
-    textAlign: "left",
-    paddingTop: dynamicScale(5, true),
-  },
-  overviewTextTitle: {
-    fontSize: dynamicScale(20, false, 0.5),
-    fontWeight: "500",
-    color: GlobalStyles.colors.textColor,
-    textAlign: "left",
-    paddingVertical: dynamicScale(8, true),
-  },
   bannerContainerContainer: {
     borderColor: "black",
     borderRadius: 999,


### PR DESCRIPTION
## Summary
- Wire the period expense total in `ExpensesSummary` to a React Native `Modal` instead of the `budgetOverview` toast.
- Extract overview UI into `BudgetOverviewContent` / `BudgetOverviewModal` (transparent overlay, slide animation, close, backdrop, Android back).
- Remove the unused `budgetOverview` toast type from `ToastComponent`; infinity/no-budget still uses the error toast.

## Test plan
- [ ] Tap period expense total on Recent Expenses / Overview → modal opens with traveller budget bars
- [ ] Dismiss via X, backdrop tap, and Android back
- [ ] Multi-traveller bars and traffic-light footer match previous overview
- [ ] `pnpm test -- __tests__/components/expenses-summary.test.tsx`

Closes #305