### PR TITLE
Expense template picker as real modal with expense-parity rows

### DIFF
--- a/TravelCostApp/__tests__/components/add-expense-button.test.tsx
+++ b/TravelCostApp/__tests__/components/add-expense-button.test.tsx
@@ -19,41 +19,63 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 import { fireEvent } from "@testing-library/react-native";
+import { Modal } from "react-native";
 
 import { i18n } from "../../i18n/i18n";
+import { VexoEvents } from "../../util/vexo-constants";
+import { trackEvent } from "../../util/vexo-tracking";
 import AddExpenseButton from "../../components/ManageExpense/AddExpenseButton";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import { assertSolidBackgroundForShadow } from "../../util/shadow-styles";
 
-describe("AddExpenseButton", () => {
-  it("opens the template expense modal on long press with a ledger-style row", () => {
-    const navigation = { navigate: jest.fn() };
-    const templateExpense = makeExpense({
-      id: "e-template",
-      description: "Coffee shop",
-      amount: 42,
-      calcAmount: 42,
-      editedTimestamp: 2,
-    });
-
-    const screen = renderWithAppProviders(
-      <AddExpenseButton navigation={navigation} />,
-      {
-        wrapNavigation: false,
-        expenses: {
-          expenses: [templateExpense],
-          getRecentExpenses: () => [templateExpense],
+function renderAddExpenseButtonWithTemplate(
+  templateExpense = makeExpense({
+    id: "e-template",
+    description: "Coffee shop",
+    amount: 42,
+    calcAmount: 42,
+    editedTimestamp: 2,
+  })
+) {
+  const navigation = { navigate: jest.fn() };
+  const screen = renderWithAppProviders(
+    <AddExpenseButton navigation={navigation} />,
+    {
+      wrapNavigation: false,
+      settings: {
+        settings: {
+          showFlags: true,
+          showWhoPaid: true,
         },
-      }
-    );
+      },
+      expenses: {
+        expenses: [templateExpense],
+        getRecentExpenses: () => [templateExpense],
+      },
+    }
+  );
+
+  return { screen, navigation, templateExpense };
+}
+
+describe("AddExpenseButton", () => {
+  beforeEach(() => {
+    (trackEvent as jest.Mock).mockClear();
+  });
+
+  it("opens the template expense modal on long press with a ledger-style row", () => {
+    const { screen, templateExpense } = renderAddExpenseButtonWithTemplate();
 
     fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
 
     expect(screen.getByTestId("expense-template-picker-modal")).toBeTruthy();
-    expect(screen.getByText("Coffee shop")).toBeTruthy();
+    expect(screen.getByText(templateExpense.description)).toBeTruthy();
     expect(screen.getByText(/42/)).toBeTruthy();
     expect(screen.getByText(i18n.t("templateExpenses"))).toBeTruthy();
+    expect(screen.getAllByTestId("expense-item-traveller-avatar").length).toBeGreaterThan(
+      0
+    );
   });
 
   it("dismisses the template picker via backdrop and keeps the fab visible", () => {
@@ -82,6 +104,52 @@ describe("AddExpenseButton", () => {
 
     expect(screen.queryByTestId("expense-template-picker-modal")).toBeNull();
     expect(screen.getByTestId("add-expense-fab")).toBeTruthy();
+  });
+
+  it("dismisses the template picker via Cancel", () => {
+    const { screen } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    fireEvent.press(screen.getByText(i18n.t("cancel")));
+
+    expect(screen.queryByTestId("expense-template-picker-modal")).toBeNull();
+    expect(screen.getByTestId("add-expense-fab")).toBeTruthy();
+  });
+
+  it("dismisses the template picker on Android back", () => {
+    const { screen } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    fireEvent(screen.UNSAFE_getByType(Modal), "requestClose");
+
+    expect(screen.queryByTestId("expense-template-picker-modal")).toBeNull();
+    expect(screen.getByTestId("add-expense-fab")).toBeTruthy();
+  });
+
+  it("tracks long press when there are no template expenses", () => {
+    const navigation = { navigate: jest.fn() };
+
+    const screen = renderWithAppProviders(
+      <AddExpenseButton navigation={navigation} />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses: [],
+          getRecentExpenses: () => [],
+        },
+      }
+    );
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    expect(screen.queryByTestId("expense-template-picker-modal")).toBeNull();
+    expect(trackEvent).toHaveBeenCalledWith(
+      VexoEvents.ADD_EXPENSE_BUTTON_LONGPRESS,
+      {
+        hasTemplates: false,
+        templatesCount: 0,
+      }
+    );
   });
 
   it("prefills Manage expense from a template with today's date", () => {

--- a/TravelCostApp/__tests__/components/add-expense-button.test.tsx
+++ b/TravelCostApp/__tests__/components/add-expense-button.test.tsx
@@ -78,6 +78,26 @@ describe("AddExpenseButton", () => {
     );
   });
 
+  it("shows the full template description with room for two lines in the modal", () => {
+    const longDescription = "Airport lounge breakfast with the team";
+    const { screen } = renderAddExpenseButtonWithTemplate(
+      makeExpense({
+        id: "e-template",
+        description: longDescription,
+        amount: 42,
+        calcAmount: 42,
+        editedTimestamp: 2,
+      })
+    );
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    const description = screen.getByTestId("expense-item-description");
+    expect(description.props.children).toBe(longDescription);
+    expect(description.props.numberOfLines).toBe(2);
+    expect(description.props.ellipsizeMode).toBeUndefined();
+  });
+
   it("dismisses the template picker via backdrop and keeps the fab visible", () => {
     const navigation = { navigate: jest.fn() };
     const templateExpense = makeExpense({

--- a/TravelCostApp/__tests__/components/add-expense-button.test.tsx
+++ b/TravelCostApp/__tests__/components/add-expense-button.test.tsx
@@ -98,6 +98,62 @@ describe("AddExpenseButton", () => {
     expect(description.props.ellipsizeMode).toBeUndefined();
   });
 
+  it("reserves at least 30% row width for the template description column", () => {
+    const { screen } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    const descriptionColumn = screen.getByTestId("expense-item-description-column");
+    const columnStyle = StyleSheet.flatten(descriptionColumn.props.style);
+
+    expect(columnStyle.minWidth).toBe("30%");
+    expect(columnStyle.flexGrow).toBeGreaterThan(1);
+  });
+
+  it("lets template picker flag and traveller slots shrink when space is tight", () => {
+    const { screen } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    const flagSlot = screen.getByTestId("expense-item-flag-slot");
+    const travellersSlot = screen.getByTestId("expense-item-travellers-slot");
+
+    expect(StyleSheet.flatten(flagSlot.props.style).flexShrink).toBe(1);
+    expect(StyleSheet.flatten(travellersSlot.props.style).flexShrink).toBe(1);
+  });
+
+  it("uses tighter horizontal padding on the template picker modal", () => {
+    const { screen } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    const contentStyle = StyleSheet.flatten(
+      screen.getByTestId("expense-template-picker-content").props.style
+    );
+    expect(contentStyle.paddingHorizontal).toBe(6);
+    expect(contentStyle.marginHorizontal).toBe(0);
+  });
+
+  it("keeps the template picker modal within the screen width", () => {
+    const screenWidth = 390;
+    const useWindowDimensionsSpy = jest
+      .spyOn(require("react-native"), "useWindowDimensions")
+      .mockReturnValue({ width: screenWidth, height: 844, scale: 2, fontScale: 1 });
+
+    const { screen } = renderAddExpenseButtonWithTemplate();
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    const contentStyle = StyleSheet.flatten(
+      screen.getByTestId("expense-template-picker-content").props.style
+    );
+
+    expect(contentStyle.maxWidth).toBeLessThanOrEqual(screenWidth);
+    expect(contentStyle.width).toBeLessThanOrEqual(screenWidth);
+    expect(contentStyle.maxWidth).toBe(screenWidth - 12);
+
+    useWindowDimensionsSpy.mockRestore();
+  });
+
   it("dismisses the template picker via backdrop and keeps the fab visible", () => {
     const navigation = { navigate: jest.fn() };
     const templateExpense = makeExpense({

--- a/TravelCostApp/__tests__/components/add-expense-button.test.tsx
+++ b/TravelCostApp/__tests__/components/add-expense-button.test.tsx
@@ -14,11 +14,119 @@ jest.mock("rn-tourguide", () => ({
   TourGuideZone: ({ children }: { children?: React.ReactNode }) => children ?? null,
 }));
 
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+import { fireEvent } from "@testing-library/react-native";
+
+import { i18n } from "../../i18n/i18n";
 import AddExpenseButton from "../../components/ManageExpense/AddExpenseButton";
+import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import { assertSolidBackgroundForShadow } from "../../util/shadow-styles";
 
 describe("AddExpenseButton", () => {
+  it("opens the template expense modal on long press with a ledger-style row", () => {
+    const navigation = { navigate: jest.fn() };
+    const templateExpense = makeExpense({
+      id: "e-template",
+      description: "Coffee shop",
+      amount: 42,
+      calcAmount: 42,
+      editedTimestamp: 2,
+    });
+
+    const screen = renderWithAppProviders(
+      <AddExpenseButton navigation={navigation} />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses: [templateExpense],
+          getRecentExpenses: () => [templateExpense],
+        },
+      }
+    );
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    expect(screen.getByTestId("expense-template-picker-modal")).toBeTruthy();
+    expect(screen.getByText("Coffee shop")).toBeTruthy();
+    expect(screen.getByText(/42/)).toBeTruthy();
+    expect(screen.getByText(i18n.t("templateExpenses"))).toBeTruthy();
+  });
+
+  it("dismisses the template picker via backdrop and keeps the fab visible", () => {
+    const navigation = { navigate: jest.fn() };
+    const templateExpense = makeExpense({
+      id: "e-template",
+      description: "Coffee shop",
+      editedTimestamp: 2,
+    });
+
+    const screen = renderWithAppProviders(
+      <AddExpenseButton navigation={navigation} />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses: [templateExpense],
+          getRecentExpenses: () => [templateExpense],
+        },
+      }
+    );
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    expect(screen.getByTestId("expense-template-picker-modal")).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId("expense-template-picker-backdrop"));
+
+    expect(screen.queryByTestId("expense-template-picker-modal")).toBeNull();
+    expect(screen.getByTestId("add-expense-fab")).toBeTruthy();
+  });
+
+  it("prefills Manage expense from a template with today's date", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-05-30T10:00:00.000Z"));
+
+    const navigation = { navigate: jest.fn() };
+    const templateExpense = makeExpense({
+      id: "e-template",
+      description: "Coffee shop",
+      amount: 42,
+      calcAmount: 42,
+      editedTimestamp: 2,
+    });
+
+    const screen = renderWithAppProviders(
+      <AddExpenseButton navigation={navigation} />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses: [templateExpense],
+          getRecentExpenses: () => [templateExpense],
+        },
+      }
+    );
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    fireEvent.press(screen.getByText("Coffee shop"));
+
+    expect(navigation.navigate).toHaveBeenCalledWith("ManageExpense", {
+      pickedCat: templateExpense.category,
+      tempValues: expect.objectContaining({
+        description: "Coffee shop",
+        date: "2026-05-30T10:00:00.000Z",
+        startDate: "2026-05-30T10:00:00.000Z",
+        endDate: "2026-05-30T10:00:00.000Z",
+      }),
+    });
+    expect(
+      (navigation.navigate as jest.Mock).mock.calls[0][1].tempValues
+    ).not.toHaveProperty("id");
+
+    jest.useRealTimers();
+  });
+
   it("co-locates shadow and backgroundColor on the add expense fab", () => {
     const navigation = { navigate: jest.fn() };
 

--- a/TravelCostApp/__tests__/components/add-expense-button.test.tsx
+++ b/TravelCostApp/__tests__/components/add-expense-button.test.tsx
@@ -78,7 +78,7 @@ describe("AddExpenseButton", () => {
     );
   });
 
-  it("shows the full template description with room for two lines in the modal", () => {
+  it("shows a long template description in the modal", () => {
     const longDescription = "Airport lounge breakfast with the team";
     const { screen } = renderAddExpenseButtonWithTemplate(
       makeExpense({
@@ -92,64 +92,18 @@ describe("AddExpenseButton", () => {
 
     fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
 
-    const description = screen.getByTestId("expense-item-description");
-    expect(description.props.children).toBe(longDescription);
-    expect(description.props.numberOfLines).toBe(2);
-    expect(description.props.ellipsizeMode).toBeUndefined();
+    expect(screen.getByText(longDescription)).toBeTruthy();
   });
 
-  it("reserves at least 30% row width for the template description column", () => {
-    const { screen } = renderAddExpenseButtonWithTemplate();
-
-    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
-
-    const descriptionColumn = screen.getByTestId("expense-item-description-column");
-    const columnStyle = StyleSheet.flatten(descriptionColumn.props.style);
-
-    expect(columnStyle.minWidth).toBe("30%");
-    expect(columnStyle.flexGrow).toBeGreaterThan(1);
-  });
-
-  it("lets template picker flag and traveller slots shrink when space is tight", () => {
-    const { screen } = renderAddExpenseButtonWithTemplate();
-
-    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
-
-    const flagSlot = screen.getByTestId("expense-item-flag-slot");
-    const travellersSlot = screen.getByTestId("expense-item-travellers-slot");
-
-    expect(StyleSheet.flatten(flagSlot.props.style).flexShrink).toBe(1);
-    expect(StyleSheet.flatten(travellersSlot.props.style).flexShrink).toBe(1);
-  });
-
-  it("uses tighter horizontal padding on the template picker modal", () => {
-    const { screen } = renderAddExpenseButtonWithTemplate();
-
-    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
-
-    const contentStyle = StyleSheet.flatten(
-      screen.getByTestId("expense-template-picker-content").props.style
-    );
-    expect(contentStyle.paddingHorizontal).toBe(6);
-    expect(contentStyle.marginHorizontal).toBe(0);
-  });
-
-  it("keeps the template picker modal within the screen width", () => {
-    const screenWidth = 390;
+  it("shows template descriptions on a narrow screen", () => {
     const useWindowDimensionsSpy = jest
       .spyOn(require("react-native"), "useWindowDimensions")
-      .mockReturnValue({ width: screenWidth, height: 844, scale: 2, fontScale: 1 });
+      .mockReturnValue({ width: 320, height: 600, scale: 2, fontScale: 1 });
 
-    const { screen } = renderAddExpenseButtonWithTemplate();
+    const { screen, templateExpense } = renderAddExpenseButtonWithTemplate();
     fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
 
-    const contentStyle = StyleSheet.flatten(
-      screen.getByTestId("expense-template-picker-content").props.style
-    );
-
-    expect(contentStyle.maxWidth).toBeLessThanOrEqual(screenWidth);
-    expect(contentStyle.width).toBeLessThanOrEqual(screenWidth);
-    expect(contentStyle.maxWidth).toBe(screenWidth - 12);
+    expect(screen.getByText(templateExpense.description)).toBeTruthy();
 
     useWindowDimensionsSpy.mockRestore();
   });

--- a/TravelCostApp/__tests__/components/expense-template-picker-modal.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-template-picker-modal.test.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+import { fireEvent } from "@testing-library/react-native";
+
+import ExpenseTemplatePickerModal from "../../components/ManageExpense/ExpenseTemplatePickerModal";
+import { makeExpense } from "../fixtures/expense";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+describe("ExpenseTemplatePickerModal", () => {
+  it("requests more templates when the list reaches the end", () => {
+    const onLoadMore = jest.fn();
+    const templates = [makeExpense({ id: "e-1", description: "Coffee shop" })];
+
+    const screen = renderWithAppProviders(
+      <ExpenseTemplatePickerModal
+        isVisible
+        onClose={jest.fn()}
+        templates={templates}
+        topDuplicateCount={0}
+        onSelectTemplate={jest.fn()}
+        onLoadMore={onLoadMore}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent(screen.getByTestId("expense-template-picker-list"), "onEndReached");
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/TravelCostApp/__tests__/util/modal-layout.test.ts
+++ b/TravelCostApp/__tests__/util/modal-layout.test.ts
@@ -8,4 +8,9 @@ describe("templatePickerModalContentWidth", () => {
   it("never returns a negative width", () => {
     expect(templatePickerModalContentWidth(4, 6)).toBe(0);
   });
+
+  it("never exceeds the screen width", () => {
+    const screenWidth = 390;
+    expect(templatePickerModalContentWidth(screenWidth)).toBeLessThanOrEqual(screenWidth);
+  });
 });

--- a/TravelCostApp/__tests__/util/modal-layout.test.ts
+++ b/TravelCostApp/__tests__/util/modal-layout.test.ts
@@ -1,0 +1,11 @@
+import { templatePickerModalContentWidth } from "../../util/modal-layout";
+
+describe("templatePickerModalContentWidth", () => {
+  it("subtracts horizontal inset from the screen width", () => {
+    expect(templatePickerModalContentWidth(390, 6)).toBe(378);
+  });
+
+  it("never returns a negative width", () => {
+    expect(templatePickerModalContentWidth(4, 6)).toBe(0);
+  });
+});

--- a/TravelCostApp/__tests__/util/shadow-styles.test.ts
+++ b/TravelCostApp/__tests__/util/shadow-styles.test.ts
@@ -184,12 +184,6 @@ describe("shadow styles", () => {
     );
   });
 
-  it("add expense template row co-locates shadow and backgroundColor", () => {
-    assertSolidBackgroundForShadow(
-      StyleSheet.flatten(shadowRegressionStyles.addExpenseTemplateRow)
-    );
-  });
-
   it("scroll-to-top fab co-locates shadow and backgroundColor", () => {
     assertSolidBackgroundForShadow(
       StyleSheet.flatten(shadowRegressionStyles.scrollToTopFab)

--- a/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
@@ -35,7 +35,8 @@ import { VexoEvents } from "../../util/vexo-constants";
 const IconSize = dynamicScale(28, false, 0.5);
 
 function ExpenseItem(props): JSX.Element {
-  const { showSumForTravellerName, filtered } = props;
+  const { showSumForTravellerName, filtered, onPressOverride, disableLongPressSelection } =
+    props;
   const { setSelectable, selectItem } = props;
   const {
     id,
@@ -134,6 +135,11 @@ function ExpenseItem(props): JSX.Element {
   const hideSpecial = settingHideSpecialExpenses && isSpecialExpense;
 
   const navigateToExpense = useCallback(async () => {
+    if (onPressOverride) {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      onPressOverride();
+      return;
+    }
     if (!id) {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
       return;
@@ -151,7 +157,7 @@ function ExpenseItem(props): JSX.Element {
     navigation.navigate("ManageExpense", {
       expenseId: id,
     });
-  }, [id, navigation]);
+  }, [id, navigation, onPressOverride, category, currency, country]);
   const originalCurrencyJSX = useMemo(
     () =>
       !sameCurrency ? (
@@ -274,7 +280,7 @@ function ExpenseItem(props): JSX.Element {
       <Pressable
         onPress={navigateToExpense}
         onLongPress={() => {
-          if (setSelectable === undefined) return;
+          if (disableLongPressSelection || setSelectable === undefined) return;
           setSelectable(true);
           if (selectItem) {
             selectItem(id);
@@ -390,6 +396,8 @@ ExpenseItem.propTypes = {
   filtered: PropTypes.bool,
   isSpecialExpense: PropTypes.bool,
   setSelectable: PropTypes.func,
+  onPressOverride: PropTypes.func,
+  disableLongPressSelection: PropTypes.bool,
 };
 
 const styles = StyleSheet.create({

--- a/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
@@ -35,8 +35,14 @@ import { VexoEvents } from "../../util/vexo-constants";
 const IconSize = dynamicScale(28, false, 0.5);
 
 function ExpenseItem(props): JSX.Element {
-  const { showSumForTravellerName, filtered, onPressOverride, disableLongPressSelection } =
-    props;
+  const {
+    showSumForTravellerName,
+    filtered,
+    onPressOverride,
+    disableLongPressSelection,
+    layoutVariant = "ledger",
+  } = props;
+  const isTemplatePickerRow = layoutVariant === "templatePicker";
   const { setSelectable, selectItem } = props;
   const {
     id,
@@ -292,7 +298,12 @@ function ExpenseItem(props): JSX.Element {
           style={[
             styles.expenseItem,
             {
-              height: constantScale(55),
+              minHeight: isTemplatePickerRow
+                ? constantScale(72, 0.5)
+                : constantScale(55, 0.5),
+              height: isTemplatePickerRow
+                ? undefined
+                : constantScale(55, 0.5),
               paddingLeft: dynamicScale(16),
               ...Platform.select({
                 ios: {
@@ -303,9 +314,11 @@ function ExpenseItem(props): JSX.Element {
                 },
               }),
             },
-            isLandscape && {
-              height: dynamicScale(100, true),
-            },
+            isTemplatePickerRow && styles.expenseItemTemplatePicker,
+            isLandscape &&
+              !isTemplatePickerRow && {
+                height: dynamicScale(100, true),
+              },
           ]}
         >
           <View
@@ -321,15 +334,24 @@ function ExpenseItem(props): JSX.Element {
               }
             />
           </View>
-          <View style={styles.leftItem}>
+          <View
+            style={[
+              styles.leftItem,
+              isTemplatePickerRow && styles.leftItemTemplatePicker,
+            ]}
+          >
             <Text
+              testID="expense-item-description"
               maxFontSizeMultiplier={1.2}
-              numberOfLines={1}
-              ellipsizeMode="tail"
+              numberOfLines={isTemplatePickerRow ? 2 : 1}
+              ellipsizeMode={isTemplatePickerRow ? undefined : "tail"}
               style={[
                 styles.textBase,
                 styles.description,
-                settingShowFlags && settingShowWhoPaid && { width: "90%" },
+                !isTemplatePickerRow &&
+                  settingShowFlags &&
+                  settingShowWhoPaid && { width: "90%" },
+                isTemplatePickerRow && styles.descriptionTemplatePicker,
                 hideSpecial && { color: GlobalStyles.colors.textHidden },
               ]}
             >
@@ -357,8 +379,17 @@ function ExpenseItem(props): JSX.Element {
               />
             </View>
           )}
-          {settingShowWhoPaid && <View>{sharedList()}</View>}
-          <View style={styles.amountContainer}>
+          {settingShowWhoPaid && (
+            <View style={isTemplatePickerRow && styles.travellerListTemplatePicker}>
+              {sharedList()}
+            </View>
+          )}
+          <View
+            style={[
+              styles.amountContainer,
+              isTemplatePickerRow && styles.amountContainerTemplatePicker,
+            ]}
+          >
             <Text
               style={[
                 styles.amountText,
@@ -398,6 +429,7 @@ ExpenseItem.propTypes = {
   setSelectable: PropTypes.func,
   onPressOverride: PropTypes.func,
   disableLongPressSelection: PropTypes.bool,
+  layoutVariant: PropTypes.oneOf(["ledger", "templatePicker"]),
 };
 
 const styles = StyleSheet.create({
@@ -411,6 +443,10 @@ const styles = StyleSheet.create({
     backgroundColor: GlobalStyles.colors.backgroundColor,
     flexDirection: "row",
     justifyContent: "space-between",
+  },
+  expenseItemTemplatePicker: {
+    alignItems: "flex-start",
+    paddingVertical: dynamicScale(10, true),
   },
   textBase: {
     marginTop: dynamicScale(2, true),
@@ -440,6 +476,19 @@ const styles = StyleSheet.create({
     justifyContent: "flex-start",
     alignItems: "flex-start",
   },
+  leftItemTemplatePicker: {
+    flexGrow: 2,
+    flexShrink: 1,
+    minWidth: 0,
+    height: undefined,
+    minHeight: constantScale(44, 0.5),
+  },
+  descriptionTemplatePicker: {
+    flexShrink: 1,
+  },
+  travellerListTemplatePicker: {
+    flexShrink: 0,
+  },
   amountContainer: {
     paddingHorizontal: dynamicScale(4),
     paddingVertical: 0,
@@ -449,6 +498,12 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     width: constantScale(150, 0.5),
     height: constantScale(40, 0.5),
+  },
+  amountContainerTemplatePicker: {
+    flexShrink: 0,
+    width: constantScale(108, 0.5),
+    minHeight: constantScale(40, 0.5),
+    height: undefined,
   },
   amountText: {
     textAlign: "center",

--- a/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
@@ -241,14 +241,22 @@ function ExpenseItem(props): JSX.Element {
                 </View>
               );
             }}
-            contentContainerStyle={styles.avatarContainer}
+            contentContainerStyle={[
+              styles.avatarContainer,
+              isTemplatePickerRow && styles.avatarContainerTemplatePicker,
+            ]}
             keyExtractor={(item) => {
               return item.userName;
             }}
           ></FlatList>
         </View>
       ) : (
-        <View style={styles.avatarContainer}>
+        <View
+          style={[
+            styles.avatarContainer,
+            isTemplatePickerRow && styles.avatarContainerTemplatePicker,
+          ]}
+        >
           <View
             testID="expense-item-traveller-avatar"
             style={[styles.avatar, styles.avatarPaid]}
@@ -257,7 +265,7 @@ function ExpenseItem(props): JSX.Element {
           </View>
         </View>
       ),
-    [longList?.length, splitList?.length, whoPaid]
+    [isTemplatePickerRow, longList?.length, splitList?.length, whoPaid]
   );
 
   if (typeof date === "string") date = new Date(date);
@@ -335,6 +343,9 @@ function ExpenseItem(props): JSX.Element {
             />
           </View>
           <View
+            testID={
+              isTemplatePickerRow ? "expense-item-description-column" : undefined
+            }
             style={[
               styles.leftItem,
               isTemplatePickerRow && styles.leftItemTemplatePicker,
@@ -371,16 +382,34 @@ function ExpenseItem(props): JSX.Element {
             </Text>
           </View>
           {settingShowFlags && (
-            <View style={styles.countryFlag}>
+            <View
+              testID={
+                isTemplatePickerRow ? "expense-item-flag-slot" : undefined
+              }
+              style={[
+                styles.countryFlag,
+                isTemplatePickerRow && styles.countryFlagTemplatePicker,
+              ]}
+            >
               <ExpenseCountryFlag
                 countryName={country}
                 style={GlobalStyles.countryFlagStyle}
-                containerStyle={styles.countryFlagContainer}
+                containerStyle={[
+                  styles.countryFlagContainer,
+                  isTemplatePickerRow && styles.countryFlagContainerTemplatePicker,
+                ]}
               />
             </View>
           )}
           {settingShowWhoPaid && (
-            <View style={isTemplatePickerRow && styles.travellerListTemplatePicker}>
+            <View
+              testID={
+                isTemplatePickerRow ? "expense-item-travellers-slot" : undefined
+              }
+              style={[
+                isTemplatePickerRow && styles.travellerListTemplatePicker,
+              ]}
+            >
               {sharedList()}
             </View>
           )}
@@ -447,6 +476,7 @@ const styles = StyleSheet.create({
   expenseItemTemplatePicker: {
     alignItems: "flex-start",
     paddingVertical: dynamicScale(10, true),
+    width: "100%",
   },
   textBase: {
     marginTop: dynamicScale(2, true),
@@ -478,16 +508,37 @@ const styles = StyleSheet.create({
   },
   leftItemTemplatePicker: {
     flexGrow: 2,
-    flexShrink: 1,
-    minWidth: 0,
+    flexShrink: 0,
+    flexBasis: "30%",
+    minWidth: "30%",
     height: undefined,
     minHeight: constantScale(44, 0.5),
   },
   descriptionTemplatePicker: {
+    flexShrink: 0,
+    alignSelf: "stretch",
+  },
+  countryFlagTemplatePicker: {
+    flexShrink: 1,
+    flexGrow: 0,
+    minWidth: 0,
+    overflow: "hidden",
+  },
+  countryFlagContainerTemplatePicker: {
+    width: undefined,
+    maxWidth: constantScale(50),
     flexShrink: 1,
   },
   travellerListTemplatePicker: {
-    flexShrink: 0,
+    flexShrink: 1,
+    flexGrow: 0,
+    minWidth: 0,
+    overflow: "hidden",
+  },
+  avatarContainerTemplatePicker: {
+    width: undefined,
+    maxWidth: constantScale(55),
+    flexShrink: 1,
   },
   amountContainer: {
     paddingHorizontal: dynamicScale(4),

--- a/TravelCostApp/components/ExpensesOutput/ExpenseListRow.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseListRow.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import ExpenseItem from "./ExpenseItem";
+import type { ExpenseData } from "../../util/expense";
+
+export type ExpenseListRowProps = ExpenseData & {
+  onPress: () => void;
+};
+
+/** Read-only ledger row for lists that must match {@link ExpenseItem} layout. */
+function ExpenseListRow({ onPress, ...expense }: ExpenseListRowProps) {
+  return (
+    <ExpenseItem {...expense} onPressOverride={onPress} disableLongPressSelection />
+  );
+}
+
+ExpenseListRow.propTypes = {
+  onPress: PropTypes.func.isRequired,
+};
+
+export default ExpenseListRow;

--- a/TravelCostApp/components/ExpensesOutput/ExpenseListRow.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseListRow.tsx
@@ -4,19 +4,32 @@ import PropTypes from "prop-types";
 import ExpenseItem from "./ExpenseItem";
 import type { ExpenseData } from "../../util/expense";
 
+export type ExpenseListRowLayoutVariant = "ledger" | "templatePicker";
+
 export type ExpenseListRowProps = ExpenseData & {
   onPress: () => void;
+  layoutVariant?: ExpenseListRowLayoutVariant;
 };
 
 /** Read-only ledger row for lists that must match {@link ExpenseItem} layout. */
-function ExpenseListRow({ onPress, ...expense }: ExpenseListRowProps) {
+function ExpenseListRow({
+  onPress,
+  layoutVariant = "ledger",
+  ...expense
+}: ExpenseListRowProps) {
   return (
-    <ExpenseItem {...expense} onPressOverride={onPress} disableLongPressSelection />
+    <ExpenseItem
+      {...expense}
+      onPressOverride={onPress}
+      disableLongPressSelection
+      layoutVariant={layoutVariant}
+    />
   );
 }
 
 ExpenseListRow.propTypes = {
   onPress: PropTypes.func.isRequired,
+  layoutVariant: PropTypes.oneOf(["ledger", "templatePicker"]),
 };
 
 export default ExpenseListRow;

--- a/TravelCostApp/components/ManageExpense/AddExpenseButton.tsx
+++ b/TravelCostApp/components/ManageExpense/AddExpenseButton.tsx
@@ -84,7 +84,6 @@ const AddExpenseButton = ({ navigation }) => {
         return;
       }
 
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       closeTemplatePicker();
 
       trackEvent(VexoEvents.TEMPLATE_EXPENSE_SELECTED, {
@@ -169,15 +168,20 @@ const AddExpenseButton = ({ navigation }) => {
   }, [authCtx, navigation, skipCatScreen, tripCtx.travellers, tripCtx.tripid]);
 
   const openTemplatePicker = useCallback(() => {
-    if (!lastExpenses?.length) {
+    const templatesCount = lastExpenses?.length ?? 0;
+    const hasTemplates = templatesCount > 0;
+
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    trackEvent(VexoEvents.ADD_EXPENSE_BUTTON_LONGPRESS, {
+      hasTemplates,
+      templatesCount,
+    });
+
+    if (!hasTemplates) {
       return;
     }
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+
     setTemplatePickerVisible(true);
-    trackEvent(VexoEvents.ADD_EXPENSE_BUTTON_LONGPRESS, {
-      hasTemplates: true,
-      templatesCount: lastExpenses.length,
-    });
   }, [lastExpenses]);
 
   const handleLoadMoreTemplates = useCallback(() => {

--- a/TravelCostApp/components/ManageExpense/AddExpenseButton.tsx
+++ b/TravelCostApp/components/ManageExpense/AddExpenseButton.tsx
@@ -2,15 +2,7 @@ import React, { Alert, Pressable, StyleSheet } from "react-native";
 import { GlobalStyles } from "../../constants/styles";
 import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
 import * as Haptics from "expo-haptics";
-import Animated, {
-  SlideInDown,
-  SlideOutDown,
-  runOnJS,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-  withTiming,
-} from "react-native-reanimated";
+import Animated, { SlideInDown, SlideOutDown } from "react-native-reanimated";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { Ionicons } from "@expo/vector-icons";
 import { TourGuideZone } from "rn-tourguide";
@@ -21,25 +13,18 @@ import PropTypes from "prop-types";
 import { SettingsContext } from "../../store/settings-context";
 import { TripContext } from "../../store/trip-context";
 import { AuthContext } from "../../store/auth-context";
-import { reloadApp, sleep } from "../../util/appState";
+import { reloadApp } from "../../util/appState";
 import { ExpensesContext } from "../../store/expenses-context";
-import { FlatList } from "react-native";
-import { View } from "react-native";
-import { Text } from "react-native";
 import {
   ExpenseData,
   findMostDuplicatedDescriptionExpenses,
 } from "../../util/expense";
-import { formatExpenseWithCurrency, truncateString } from "../../util/string";
-import { getCatSymbol } from "../../util/category";
-import IconButton from "../UI/IconButton";
 import uniqBy from "lodash.uniqby";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { constantScale, dynamicScale } from "../../util/scalingUtil";
-import { OrientationContext } from "../../store/orientation-context";
 import { safelyParseJSON } from "../../util/jsonParse";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
+import ExpenseTemplatePickerModal from "./ExpenseTemplatePickerModal";
 
 const PageLength = 20;
 
@@ -49,10 +34,9 @@ const AddExpenseButton = ({ navigation }) => {
   const authCtx = useContext(AuthContext);
   const expCtx = useContext(ExpensesContext);
 
-  // sort last expenses by editedTimestamp timestamp
   const lastExpenses: ExpenseData[] = uniqBy(
-    expCtx.expenses.sort((a, b) => {
-      return b.editedTimestamp - a.editedTimestamp;
+    [...expCtx.expenses].sort((a, b) => {
+      return (b.editedTimestamp ?? 0) - (a.editedTimestamp ?? 0);
     }),
     "description"
   );
@@ -60,24 +44,22 @@ const AddExpenseButton = ({ navigation }) => {
   const topDuplicates = findMostDuplicatedDescriptionExpenses(expCtx.expenses);
 
   const [lastExpensesNumber, setLastExpensesNumber] = useState(PageLength);
+  const [templatePickerVisible, setTemplatePickerVisible] = useState(false);
 
   const topTemplateExpenses = [
     ...topDuplicates,
     ...lastExpenses.slice(0, lastExpensesNumber).filter((exp) => {
-      // filter out duplicates
       return !topDuplicates.some((e: ExpenseData) => e.id === exp.id);
     }),
   ];
 
-  const [longPressed, setLongPressed] = useState(false);
-
   const valid = useRef(false);
 
   useEffect(() => {
-    if (longPressed && (!lastExpenses || lastExpenses.length < 1)) {
-      setLongPressed(false);
+    if (templatePickerVisible && (!lastExpenses || lastExpenses.length < 1)) {
+      setTemplatePickerVisible(false);
     }
-  }, [lastExpenses, longPressed]);
+  }, [lastExpenses, templatePickerVisible]);
 
   useEffect(() => {
     valid.current =
@@ -88,37 +70,29 @@ const AddExpenseButton = ({ navigation }) => {
   }, [tripCtx.tripid, authCtx.uid, tripCtx.travellers?.length]);
   const skipCatScreen = settings.skipCategoryScreen;
 
-  const renderExpenseTemplates = ({ item, index }) => {
-    const isFirst = index === 0;
-    const isThird = index === 3;
-    const hasTop3 = topDuplicates && topDuplicates.length > 0;
-    // shallow copy item or we will have problems with the expense context
-    let data: ExpenseData;
-    try {
-      data = safelyParseJSON(JSON.stringify(item));
-    } catch (error) {
-      return <></>;
-    }
-    const formattedAmount = formatExpenseWithCurrency(
-      data.amount,
-      data.currency
-    );
-    const formattedDescription = truncateString(data.description, 15);
-    const categoryIcon = getCatSymbol(data.category);
-    const cat = data.category;
-    const onPressHandler = () => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-      setLongPressed(false);
-      setLastExpensesNumber(PageLength);
+  const closeTemplatePicker = useCallback(() => {
+    setTemplatePickerVisible(false);
+    setLastExpensesNumber(PageLength);
+  }, []);
 
-      // Track template expense selection
+  const handleSelectTemplate = useCallback(
+    (item: ExpenseData) => {
+      let data: ExpenseData;
+      try {
+        data = safelyParseJSON(JSON.stringify(item));
+      } catch {
+        return;
+      }
+
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      closeTemplatePicker();
+
       trackEvent(VexoEvents.TEMPLATE_EXPENSE_SELECTED, {
         templateDescription: data.description,
         templateCategory: data.category,
         templateCurrency: data.currency,
       });
 
-      // set date to today
       data.date = new Date().toISOString();
       data.startDate = new Date().toISOString();
       data.endDate = new Date().toISOString();
@@ -129,56 +103,15 @@ const AddExpenseButton = ({ navigation }) => {
         pickedCat: data.category,
         tempValues: { ...data },
       });
-    };
-    return (
-      <View
-        style={{
-          alignSelf: "center",
-        }}
-      >
-        {isFirst && hasTop3 && (
-          <Text style={styles.templateContainerSubtitle}>
-            {i18n.t("mostUsedExpenses")}
-          </Text>
-        )}
-        {isThird && hasTop3 && (
-          <Text style={styles.templateContainerSubtitle}>
-            {i18n.t("lastUsedExpenses")}
-          </Text>
-        )}
-        {isFirst && !hasTop3 && (
-          <Text style={styles.templateContainerSubtitle}>
-            {i18n.t("lastUsedExpenses")}
-          </Text>
-        )}
-        <Pressable
-          style={({ pressed }) => [
-            styles.expenseTemplateContainer,
-            shadowRegressionStyles.addExpenseTemplateRow,
-            pressed && GlobalStyles.pressedWithShadow,
-          ]}
-          onPress={onPressHandler}
-        >
-          <IconButton
-            size={dynamicScale(24)}
-            icon={categoryIcon}
-            category={cat}
-            color={GlobalStyles.colors.textColor}
-            onPress={onPressHandler}
-          ></IconButton>
-          <Text style={styles.descriptionText}>{formattedDescription}</Text>
-          <Text style={styles.amountText}>{formattedAmount}</Text>
-        </Pressable>
-      </View>
-    );
-  };
+    },
+    [closeTemplatePicker, navigation]
+  );
 
   const pressHandler = useCallback(async () => {
-    const retryTimeout = 5000; // Adjust this timeout as needed
+    const retryTimeout = 5000;
     const startTime = Date.now();
 
     const retryFunction = async () => {
-      // Your validation logic here
       valid.current =
         tripCtx.tripid &&
         authCtx.uid &&
@@ -186,18 +119,15 @@ const AddExpenseButton = ({ navigation }) => {
         tripCtx.travellers?.length > 0;
 
       if (!valid.current && Date.now() - startTime < retryTimeout) {
-        // Retry after a delay if still invalid
-        await new Promise((resolve) => setTimeout(resolve, 1000)); // Adjust delay as needed
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         await retryFunction();
       } else {
         if (!valid.current) {
-          // After retries, show the alert if still invalid
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
           Alert.alert(
             "Loading Data",
             "Please try again later, alternatively login again or restart the App",
             [
-              // cancel button
               {
                 text: "Cancel",
                 onPress: () => {
@@ -221,10 +151,8 @@ const AddExpenseButton = ({ navigation }) => {
             ]
           );
         } else {
-          // If valid, proceed
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
 
-          // Track add expense button press
           trackEvent(VexoEvents.ADD_EXPENSE_BUTTON_PRESSED, {
             skipCategoryScreen: skipCatScreen,
           });
@@ -240,167 +168,72 @@ const AddExpenseButton = ({ navigation }) => {
     retryFunction();
   }, [authCtx, navigation, skipCatScreen, tripCtx.travellers, tripCtx.tripid]);
 
-  const { height } = useContext(OrientationContext);
-  const END_POSITION = height * 0.2;
-  const position = useSharedValue(0);
-
-  const panGesture = Gesture.Pan()
-    .onUpdate((e) => {
-      position.value = e.translationY;
-      if (position.value < 0) {
-        position.value = 0;
-      }
-    })
-    .onEnd(() => {
-      if (position.value > END_POSITION) {
-        position.value = withTiming(END_POSITION * 5, { duration: 300 }, () => {
-          runOnJS(setLongPressed)(false);
-        });
-      } else {
-        position.value = withTiming(0, { duration: 100 });
-      }
-      //
-    });
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: position.value }],
-  }));
-
-  async function hideTempOverlay() {
+  const openTemplatePicker = useCallback(() => {
+    if (!lastExpenses?.length) {
+      return;
+    }
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    position.value = withTiming(END_POSITION * 3.3, {
-      duration: 300,
+    setTemplatePickerVisible(true);
+    trackEvent(VexoEvents.ADD_EXPENSE_BUTTON_LONGPRESS, {
+      hasTemplates: true,
+      templatesCount: lastExpenses.length,
     });
-    await sleep(300);
-    setLongPressed(false);
-    setLastExpensesNumber(PageLength);
-  }
+  }, [lastExpenses]);
 
-  // show the template expenses overlay
-  if (longPressed && lastExpenses && lastExpenses.length > 0) {
-    return (
-      <GestureDetector gesture={panGesture}>
-        <Animated.View
-          style={[styles.marginTemplate, animatedStyle]}
-          entering={SlideInDown.duration(600)}
-          exiting={SlideOutDown}
-        >
-          <Pressable
-            onPress={hideTempOverlay}
-            onLongPress={hideTempOverlay}
-            style={({ pressed }) => [
-              styles.addButton,
-              shadowRegressionStyles.addExpenseFab,
-              styles.longPressedButton,
-              { flexDirection: "column" },
-              pressed && GlobalStyles.pressedWithShadowNoScale,
-            ]}
-          >
-            <View style={styles.templateContainer}>
-              <Text style={[styles.templateContainerTitle]}>
-                {i18n.t("templateExpenses")}
-              </Text>
-              <Text style={styles.arrowDownSymbolText}>▼</Text>
-            </View>
-            <FlatList
-              directionalLockEnabled={true}
-              data={topTemplateExpenses}
-              renderItem={renderExpenseTemplates}
-              onEndReachedThreshold={0.5}
-              onEndReached={() => {
-                const maxNumber = lastExpenses.length;
-                const newNumber = Math.max(
-                  maxNumber,
-                  lastExpensesNumber + PageLength
-                );
-                setLastExpensesNumber(newNumber);
-              }}
-            />
-          </Pressable>
-        </Animated.View>
-      </GestureDetector>
-    );
-  }
-  // if (!valid.current) return <Text>INV</Text>;
+  const handleLoadMoreTemplates = useCallback(() => {
+    const maxNumber = lastExpenses.length;
+    const newNumber = Math.max(maxNumber, lastExpensesNumber + PageLength);
+    setLastExpensesNumber(newNumber);
+  }, [lastExpenses.length, lastExpensesNumber]);
 
-  // if (!valid.current) {
-  //   return (
-  //     <Animated.View
-  //       style={[styles.margin]}
-  //       entering={SlideInDown.duration(600)}
-  //       exiting={SlideOutDown}
-  //     >
-  //       <Pressable
-  //         onPress={() => {
-  //           pressHandler();
-  //         }}
-  //         style={[
-  //           styles.addButton,
-  //           GlobalStyles.shadowGlowPrimary,
-  //           styles.addButtonInactive,
-  //         ]}
-  //       >
-  //         <LoadingBarOverlay
-  //           containerStyle={{
-  //             backgroundColor: "transparent",
-  //             maxHeight: 44,
-  //             marginLeft: -4,
-  //           }}
-  //           noText
-  //         ></LoadingBarOverlay>
-  //       </Pressable>
-  //     </Animated.View>
-  //   );
-  // }
   return (
-    <Animated.View
-      style={[
-        styles.margin,
-        {
-          maxHeight: dynamicScale(88, false, 0.7),
-          maxWidth: dynamicScale(88, false, 0.7),
-        },
-      ]}
-      entering={SlideInDown}
-      exiting={SlideOutDown}
-    >
-      <TourGuideZone
-        text={i18n.t("walk2")}
-        borderRadius={constantScale(16, 0.5)}
-        shape={"circle"}
-        maskOffset={constantScale(40, 0.5)}
-        tooltipBottomOffset={constantScale(80, 0.5)}
-        zone={2}
-      ></TourGuideZone>
-
-      <Pressable
-        testID="add-expense-fab"
-        style={({ pressed }) => [
-          styles.addButton,
-          shadowRegressionStyles.addExpenseFab,
-          pressed && GlobalStyles.pressedWithShadow,
+    <>
+      <ExpenseTemplatePickerModal
+        isVisible={templatePickerVisible}
+        onClose={closeTemplatePicker}
+        templates={topTemplateExpenses}
+        topDuplicateCount={topDuplicates.length}
+        onSelectTemplate={handleSelectTemplate}
+        onLoadMore={handleLoadMoreTemplates}
+      />
+      <Animated.View
+        style={[
+          styles.margin,
+          {
+            maxHeight: dynamicScale(88, false, 0.7),
+            maxWidth: dynamicScale(88, false, 0.7),
+          },
         ]}
-        onPress={pressHandler}
-        onLongPress={() => {
-          // reset Y position
-          position.value = withSpring(0, { duration: 300 });
-          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-          setLongPressed(true);
-
-          // Track long press to show template expenses
-          trackEvent(VexoEvents.ADD_EXPENSE_BUTTON_LONGPRESS, {
-            hasTemplates: lastExpenses && lastExpenses.length > 0,
-            templatesCount: lastExpenses?.length || 0,
-          });
-        }}
+        entering={SlideInDown}
+        exiting={SlideOutDown}
       >
-        <Ionicons
-          name={"add-outline"}
-          size={dynamicScale(42, false, 0.5)}
-          color={GlobalStyles.colors.backgroundColor}
-        />
-      </Pressable>
-    </Animated.View>
+        <TourGuideZone
+          text={i18n.t("walk2")}
+          borderRadius={constantScale(16, 0.5)}
+          shape={"circle"}
+          maskOffset={constantScale(40, 0.5)}
+          tooltipBottomOffset={constantScale(80, 0.5)}
+          zone={2}
+        ></TourGuideZone>
+
+        <Pressable
+          testID="add-expense-fab"
+          style={({ pressed }) => [
+            styles.addButton,
+            shadowRegressionStyles.addExpenseFab,
+            pressed && GlobalStyles.pressedWithShadow,
+          ]}
+          onPress={pressHandler}
+          onLongPress={openTemplatePicker}
+        >
+          <Ionicons
+            name={"add-outline"}
+            size={dynamicScale(42, false, 0.5)}
+            color={GlobalStyles.colors.backgroundColor}
+          />
+        </Pressable>
+      </Animated.View>
+    </>
   );
 };
 
@@ -417,20 +250,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     alignContent: "center",
   },
-  marginTemplate: {
-    marginHorizontal: dynamicScale(60),
-  },
-  templateContainer: {
-    backgroundColor: GlobalStyles.colors.primary400,
-    marginBottom: dynamicScale(10, true),
-    paddingVertical: dynamicScale(20, true),
-    paddingHorizontal: dynamicScale(20),
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    alignSelf: "center",
-    minWidth: dynamicScale(330),
-  },
   addButton: {
     backgroundColor: GlobalStyles.colors.primary400,
     borderRadius: 999,
@@ -441,60 +260,5 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     alignSelf: "center",
-  },
-  addButtonInactive: {
-    backgroundColor: GlobalStyles.colors.primary400,
-  },
-  descriptionText: {
-    flex: 1,
-    // width: "110%",
-    fontStyle: "italic",
-    fontWeight: "300",
-    fontSize: dynamicScale(15, false, 0.5),
-    flexWrap: "wrap",
-  },
-  amountText: {
-    fontWeight: "300",
-    fontSize: dynamicScale(18, false, 0.5),
-    color: GlobalStyles.colors.textColor,
-  },
-  longPressedButton: {
-    backgroundColor: GlobalStyles.colors.primary400,
-    maxHeight: 400,
-    // width: "400%",
-    minWidth: 330,
-    paddingVertical: 12,
-    paddingHorizontal: 0,
-    borderRadius: 5,
-    alignSelf: "center",
-    marginTop: 0,
-    marginHorizontal: 0,
-  },
-  expenseTemplateContainer: {
-    backgroundColor: GlobalStyles.colors.backgroundColor,
-    padding: 8,
-    paddingHorizontal: 16,
-    marginVertical: 4,
-    borderRadius: 5,
-    flexDirection: "row",
-    alignItems: "center",
-    width: "76%",
-    alignSelf: "center",
-    justifyContent: "space-between",
-  },
-  templateContainerTitle: {
-    fontWeight: "300",
-    fontSize: dynamicScale(24, false, 0.5),
-    color: GlobalStyles.colors.gray300,
-  },
-  templateContainerSubtitle: {
-    fontWeight: "300",
-    fontSize: dynamicScale(18, false, 0.5),
-    color: GlobalStyles.colors.gray300,
-  },
-  arrowDownSymbolText: {
-    fontWeight: "300",
-    fontSize: dynamicScale(24, false, 0.5),
-    color: GlobalStyles.colors.gray300,
   },
 });

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { FlatList, StyleSheet, Text, View } from "react-native";
+import PropTypes from "prop-types";
+
+import AppModal from "../UI/AppModal";
+import ExpenseListRow from "../ExpensesOutput/ExpenseListRow";
+import { GlobalStyles } from "../../constants/styles";
+import { i18n } from "../../i18n/i18n";
+import type { ExpenseData } from "../../util/expense";
+import { dynamicScale } from "../../util/scalingUtil";
+import FlatButton from "../UI/FlatButton";
+
+export type ExpenseTemplatePickerModalProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  templates: ExpenseData[];
+  topDuplicateCount: number;
+  onSelectTemplate: (expense: ExpenseData) => void;
+  onLoadMore: () => void;
+};
+
+const ExpenseTemplatePickerModal = ({
+  isVisible,
+  onClose,
+  templates,
+  topDuplicateCount,
+  onSelectTemplate,
+  onLoadMore,
+}: ExpenseTemplatePickerModalProps) => {
+  const hasTopSection = topDuplicateCount > 0;
+
+  const renderItem = ({
+    item,
+    index,
+  }: {
+    item: ExpenseData;
+    index: number;
+  }) => {
+    const isFirst = index === 0;
+    const isThird = index === 3;
+
+    return (
+      <View>
+        {isFirst && hasTopSection && (
+          <Text style={styles.sectionSubtitle}>{i18n.t("mostUsedExpenses")}</Text>
+        )}
+        {isThird && hasTopSection && (
+          <Text style={styles.sectionSubtitle}>{i18n.t("lastUsedExpenses")}</Text>
+        )}
+        {isFirst && !hasTopSection && (
+          <Text style={styles.sectionSubtitle}>{i18n.t("lastUsedExpenses")}</Text>
+        )}
+        <ExpenseListRow {...item} onPress={() => onSelectTemplate(item)} />
+      </View>
+    );
+  };
+
+  return (
+    <AppModal
+      isVisible={isVisible}
+      onClose={onClose}
+      testID="expense-template-picker-modal"
+      backdropTestID="expense-template-picker-backdrop"
+      contentStyle={styles.modalContent}
+    >
+      <View style={styles.modalHeader}>
+        <Text style={styles.modalTitle}>{i18n.t("templateExpenses")}</Text>
+        <View testID="expense-template-picker-close">
+          <FlatButton onPress={onClose} textStyle={styles.closeButtonText}>
+            {i18n.t("cancel")}
+          </FlatButton>
+        </View>
+      </View>
+      <FlatList
+        data={templates}
+        keyExtractor={(item, index) => item.id ?? `${item.description}-${index}`}
+        renderItem={renderItem}
+        onEndReachedThreshold={0.5}
+        onEndReached={onLoadMore}
+        style={styles.list}
+      />
+    </AppModal>
+  );
+};
+
+ExpenseTemplatePickerModal.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  templates: PropTypes.array.isRequired,
+  topDuplicateCount: PropTypes.number.isRequired,
+  onSelectTemplate: PropTypes.func.isRequired,
+  onLoadMore: PropTypes.func.isRequired,
+};
+
+export default ExpenseTemplatePickerModal;
+
+const styles = StyleSheet.create({
+  modalContent: {
+    width: "92%",
+    maxWidth: dynamicScale(440, false, 0.5),
+    paddingVertical: dynamicScale(16, false, 0.5),
+    paddingHorizontal: dynamicScale(12, false, 0.5),
+  },
+  modalHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: dynamicScale(12, true),
+  },
+  modalTitle: {
+    flex: 1,
+    fontWeight: "300",
+    fontSize: dynamicScale(22, false, 0.5),
+    color: GlobalStyles.colors.textColor,
+  },
+  closeButtonText: {
+    fontSize: dynamicScale(16, false, 0.5),
+  },
+  sectionSubtitle: {
+    fontWeight: "300",
+    fontSize: dynamicScale(16, false, 0.5),
+    color: GlobalStyles.colors.gray700,
+    marginTop: dynamicScale(8, true),
+    marginBottom: dynamicScale(4, true),
+    marginLeft: dynamicScale(8),
+  },
+  list: {
+    maxHeight: dynamicScale(420, true),
+  },
+});

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
@@ -87,6 +87,7 @@ const ExpenseTemplatePickerModal = ({
         </View>
       </View>
       <FlatList
+        testID="expense-template-picker-list"
         data={templates}
         keyExtractor={(item, index) => item.id ?? `${item.description}-${index}`}
         renderItem={renderItem}

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
@@ -50,7 +50,11 @@ const ExpenseTemplatePickerModal = ({
         {isFirst && !hasTopSection && (
           <Text style={styles.sectionSubtitle}>{i18n.t("lastUsedExpenses")}</Text>
         )}
-        <ExpenseListRow {...item} onPress={() => onSelectTemplate(item)} />
+        <ExpenseListRow
+          {...item}
+          layoutVariant="templatePicker"
+          onPress={() => onSelectTemplate(item)}
+        />
       </View>
     );
   };
@@ -96,8 +100,9 @@ export default ExpenseTemplatePickerModal;
 
 const styles = StyleSheet.create({
   modalContent: {
-    width: "92%",
-    maxWidth: dynamicScale(440, false, 0.5),
+    width: "94%",
+    maxWidth: dynamicScale(480, false, 0.5),
+    maxHeight: "85%",
     paddingVertical: dynamicScale(16, false, 0.5),
     paddingHorizontal: dynamicScale(12, false, 0.5),
   },
@@ -125,6 +130,7 @@ const styles = StyleSheet.create({
     marginLeft: dynamicScale(8),
   },
   list: {
-    maxHeight: dynamicScale(420, true),
+    flexGrow: 1,
+    maxHeight: dynamicScale(520, true),
   },
 });

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FlatList, StyleSheet, Text, View } from "react-native";
+import { FlatList, StyleSheet, Text, useWindowDimensions, View } from "react-native";
 import PropTypes from "prop-types";
 
 import AppModal from "../UI/AppModal";
@@ -7,6 +7,7 @@ import ExpenseListRow from "../ExpensesOutput/ExpenseListRow";
 import { GlobalStyles } from "../../constants/styles";
 import { i18n } from "../../i18n/i18n";
 import type { ExpenseData } from "../../util/expense";
+import { templatePickerModalContentWidth } from "../../util/modal-layout";
 import { dynamicScale } from "../../util/scalingUtil";
 import FlatButton from "../UI/FlatButton";
 
@@ -27,6 +28,8 @@ const ExpenseTemplatePickerModal = ({
   onSelectTemplate,
   onLoadMore,
 }: ExpenseTemplatePickerModalProps) => {
+  const { width: screenWidth } = useWindowDimensions();
+  const contentWidth = templatePickerModalContentWidth(screenWidth);
   const hasTopSection = topDuplicateCount > 0;
 
   const renderItem = ({
@@ -65,7 +68,15 @@ const ExpenseTemplatePickerModal = ({
       onClose={onClose}
       testID="expense-template-picker-modal"
       backdropTestID="expense-template-picker-backdrop"
-      contentStyle={styles.modalContent}
+      contentTestID="expense-template-picker-content"
+      contentStyle={[
+        styles.modalContent,
+        {
+          width: contentWidth,
+          maxWidth: contentWidth,
+          marginHorizontal: 0,
+        },
+      ]}
     >
       <View style={styles.modalHeader}>
         <Text style={styles.modalTitle}>{i18n.t("templateExpenses")}</Text>
@@ -100,11 +111,11 @@ export default ExpenseTemplatePickerModal;
 
 const styles = StyleSheet.create({
   modalContent: {
-    width: "94%",
-    maxWidth: dynamicScale(480, false, 0.5),
     maxHeight: "85%",
-    paddingVertical: dynamicScale(16, false, 0.5),
-    paddingHorizontal: dynamicScale(12, false, 0.5),
+    padding: dynamicScale(12, false, 0.5),
+    paddingVertical: dynamicScale(12, false, 0.5),
+    paddingHorizontal: 6,
+    alignSelf: "center",
   },
   modalHeader: {
     flexDirection: "row",
@@ -114,6 +125,7 @@ const styles = StyleSheet.create({
   },
   modalTitle: {
     flex: 1,
+    paddingLeft: dynamicScale(8, false, 0.5),
     fontWeight: "300",
     fontSize: dynamicScale(22, false, 0.5),
     color: GlobalStyles.colors.textColor,

--- a/TravelCostApp/components/UI/AppModal.tsx
+++ b/TravelCostApp/components/UI/AppModal.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  View,
+  type ModalProps,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+import PropTypes from "prop-types";
+
+import { GlobalStyles } from "../../constants/styles";
+import { dynamicScale } from "../../util/scalingUtil";
+
+export type AppModalProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  testID?: string;
+  backdropTestID?: string;
+  animationType?: ModalProps["animationType"];
+  contentStyle?: StyleProp<ViewStyle>;
+};
+
+const AppModal = ({
+  isVisible,
+  onClose,
+  children,
+  testID,
+  backdropTestID = "app-modal-backdrop",
+  animationType = "slide",
+  contentStyle,
+}: AppModalProps) => {
+  return (
+    <Modal
+      visible={isVisible}
+      animationType={animationType}
+      transparent
+      onRequestClose={onClose}
+      testID={testID}
+    >
+      <Pressable
+        style={styles.modalOverlay}
+        onPress={onClose}
+        testID={backdropTestID}
+        accessibilityRole="button"
+      >
+        <Pressable onPress={(event) => event.stopPropagation()}>
+          <View style={[styles.modalContainer, contentStyle]}>{children}</View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+};
+
+AppModal.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+  testID: PropTypes.string,
+  backdropTestID: PropTypes.string,
+  animationType: PropTypes.string,
+  contentStyle: PropTypes.object,
+};
+
+export default AppModal;
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  modalContainer: {
+    backgroundColor: GlobalStyles.colors.backgroundColor,
+    borderRadius: dynamicScale(20, false, 0.5),
+    padding: dynamicScale(24, false, 0.5),
+    marginHorizontal: dynamicScale(20, false, 0.5),
+    maxWidth: dynamicScale(400, false, 0.5),
+    width: "90%",
+    maxHeight: "80%",
+    ...GlobalStyles.strongShadow,
+  },
+});

--- a/TravelCostApp/components/UI/AppModal.tsx
+++ b/TravelCostApp/components/UI/AppModal.tsx
@@ -21,6 +21,7 @@ export type AppModalProps = {
   backdropTestID?: string;
   animationType?: ModalProps["animationType"];
   contentStyle?: StyleProp<ViewStyle>;
+  contentTestID?: string;
 };
 
 const AppModal = ({
@@ -31,6 +32,7 @@ const AppModal = ({
   backdropTestID = "app-modal-backdrop",
   animationType = "slide",
   contentStyle,
+  contentTestID,
 }: AppModalProps) => {
   return (
     <Modal
@@ -47,7 +49,12 @@ const AppModal = ({
         accessibilityRole="button"
       >
         <Pressable onPress={(event) => event.stopPropagation()}>
-          <View style={[styles.modalContainer, contentStyle]}>{children}</View>
+          <View
+            testID={contentTestID}
+            style={[styles.modalContainer, contentStyle]}
+          >
+            {children}
+          </View>
         </Pressable>
       </Pressable>
     </Modal>
@@ -62,6 +69,7 @@ AppModal.propTypes = {
   backdropTestID: PropTypes.string,
   animationType: PropTypes.string,
   contentStyle: PropTypes.object,
+  contentTestID: PropTypes.string,
 };
 
 export default AppModal;

--- a/TravelCostApp/styles/shadow-regression-styles.ts
+++ b/TravelCostApp/styles/shadow-regression-styles.ts
@@ -154,10 +154,6 @@ export const shadowRegressionStyles = StyleSheet.create({
     backgroundColor: GlobalStyles.colors.primary400,
     ...GlobalStyles.shadowGlowPrimary,
   },
-  addExpenseTemplateRow: {
-    backgroundColor: GlobalStyles.colors.backgroundColor,
-    ...GlobalStyles.strongShadow,
-  },
   scrollToTopFab: {
     backgroundColor: GlobalStyles.colors.backgroundColor,
     ...GlobalStyles.shadowPrimary,

--- a/TravelCostApp/util/modal-layout.ts
+++ b/TravelCostApp/util/modal-layout.ts
@@ -1,0 +1,7 @@
+/** Content width for modals that must not extend past the screen edges. */
+export function templatePickerModalContentWidth(
+  screenWidth: number,
+  horizontalInset = 6
+): number {
+  return Math.max(0, screenWidth - horizontalInset * 2);
+}


### PR DESCRIPTION
## Summary
- Replaces the long-press green FAB template sheet with a real `Modal` using the same overlay/chrome as other app modals (`AppModal`).
- Lists templates via `ExpenseListRow`, a read-only wrapper around `ExpenseItem`, so rows match the ledger (category, description, time, flag, travellers, amounts).
- Preserves most-used / last-used sections, pagination, and tap-to-prefill Manage expense with today's date.

## Test plan
- [ ] Long-press add expense FAB → modal opens (FAB stays visible)
- [ ] Template rows match ledger layout; tap prefills Manage expense with today
- [ ] Dismiss via backdrop, Cancel, and Android back
- [x] `pnpm test __tests__/components/add-expense-button.test.tsx`

Closes #306