### PR TITLE
Large-trip template pool (250 cap) and template picker help

### DIFF
--- a/TravelCostApp/__tests__/components/add-expense-button.test.tsx
+++ b/TravelCostApp/__tests__/components/add-expense-button.test.tsx
@@ -108,6 +108,56 @@ describe("AddExpenseButton", () => {
     useWindowDimensionsSpy.mockRestore();
   });
 
+  it("opens template help from the info button", () => {
+    const { screen } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    fireEvent.press(screen.getByTestId("expense-template-picker-info"));
+
+    expect(screen.getByTestId("expense-template-help-modal")).toBeTruthy();
+    expect(screen.getByText(i18n.t("templateExpensesHelpTitle"))).toBeTruthy();
+    expect(
+      screen.getByText(i18n.t("templateExpensesHelpText"), { exact: false })
+    ).toBeTruthy();
+    expect(screen.getByTestId("expense-template-picker-modal")).toBeTruthy();
+  });
+
+  it("dismisses template help via confirm and keeps the picker open", () => {
+    const { screen, templateExpense } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    fireEvent.press(screen.getByTestId("expense-template-picker-info"));
+    fireEvent.press(screen.getByText(i18n.t("confirm")));
+
+    expect(screen.queryByTestId("expense-template-help-modal")).toBeNull();
+    expect(screen.getByTestId("expense-template-picker-modal")).toBeTruthy();
+    expect(screen.getByText(templateExpense.description)).toBeTruthy();
+  });
+
+  it("dismisses template help via backdrop and keeps the picker open", () => {
+    const { screen, templateExpense } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    fireEvent.press(screen.getByTestId("expense-template-picker-info"));
+    fireEvent.press(screen.getByTestId("expense-template-help-backdrop"));
+
+    expect(screen.queryByTestId("expense-template-help-modal")).toBeNull();
+    expect(screen.getByTestId("expense-template-picker-modal")).toBeTruthy();
+    expect(screen.getByText(templateExpense.description)).toBeTruthy();
+  });
+
+  it("dismisses the template picker after viewing help", () => {
+    const { screen } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    fireEvent.press(screen.getByTestId("expense-template-picker-info"));
+    fireEvent.press(screen.getByText(i18n.t("confirm")));
+    fireEvent.press(screen.getByText(i18n.t("cancel")));
+
+    expect(screen.queryByTestId("expense-template-picker-modal")).toBeNull();
+    expect(screen.getByTestId("add-expense-fab")).toBeTruthy();
+  });
+
   it("dismisses the template picker via backdrop and keeps the fab visible", () => {
     const navigation = { navigate: jest.fn() };
     const templateExpense = makeExpense({

--- a/TravelCostApp/__tests__/components/add-expense-button.test.tsx
+++ b/TravelCostApp/__tests__/components/add-expense-button.test.tsx
@@ -108,6 +108,48 @@ describe("AddExpenseButton", () => {
     useWindowDimensionsSpy.mockRestore();
   });
 
+  it("shows only recent template expenses when the trip has more than 250 expenses", () => {
+    const expenses = Array.from({ length: 251 }, (_, i) =>
+      makeExpense({
+        id: `e-${i}`,
+        description: i === 0 ? "Ancient coffee" : `Expense ${i}`,
+        editedTimestamp: i,
+      })
+    );
+
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <AddExpenseButton navigation={navigation} />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+      }
+    );
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    expect(screen.getByText("Expense 250")).toBeTruthy();
+    expect(screen.queryByText("Ancient coffee")).toBeNull();
+  });
+
+  it("does not reopen template help after closing the picker with help left open", () => {
+    const { screen } = renderAddExpenseButtonWithTemplate();
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+    fireEvent.press(screen.getByTestId("expense-template-picker-info"));
+    expect(screen.getByTestId("expense-template-help-modal")).toBeTruthy();
+
+    fireEvent(screen.UNSAFE_getByType(Modal), "requestClose");
+
+    fireEvent(screen.getByTestId("add-expense-fab"), "longPress");
+
+    expect(screen.queryByTestId("expense-template-help-modal")).toBeNull();
+    expect(screen.getByTestId("expense-template-picker-modal")).toBeTruthy();
+  });
+
   it("opens template help from the info button", () => {
     const { screen } = renderAddExpenseButtonWithTemplate();
 

--- a/TravelCostApp/__tests__/util/template-expense-pool.test.ts
+++ b/TravelCostApp/__tests__/util/template-expense-pool.test.ts
@@ -1,0 +1,45 @@
+import type { ExpenseData } from "../../util/expense";
+import { expensesForTemplateSelection } from "../../util/template-expense-pool";
+import { makeExpense } from "../fixtures/expense";
+
+function expenseWithTimestamp(
+  id: string,
+  editedTimestamp: number
+): ExpenseData {
+  return makeExpense({ id, editedTimestamp });
+}
+
+describe("expensesForTemplateSelection", () => {
+  it("returns all expenses when count is at most 250", () => {
+    const expenses = Array.from({ length: 250 }, (_, i) =>
+      expenseWithTimestamp(`e-${i}`, i)
+    );
+
+    expect(expensesForTemplateSelection(expenses)).toBe(expenses);
+  });
+
+  it("returns the 250 newest expenses by editedTimestamp when count exceeds 250", () => {
+    const expenses = Array.from({ length: 300 }, (_, i) =>
+      expenseWithTimestamp(`e-${i}`, i)
+    );
+
+    const pool = expensesForTemplateSelection(expenses);
+
+    expect(pool).toHaveLength(250);
+    expect(pool.map((e) => e.editedTimestamp)).toEqual(
+      Array.from({ length: 250 }, (_, i) => 299 - i)
+    );
+  });
+
+  it("at 251 expenses excludes only the oldest by editedTimestamp", () => {
+    const expenses = Array.from({ length: 251 }, (_, i) =>
+      expenseWithTimestamp(`e-${i}`, i)
+    );
+
+    const pool = expensesForTemplateSelection(expenses);
+
+    expect(pool).toHaveLength(250);
+    expect(pool.some((e) => e.id === "e-0")).toBe(false);
+    expect(pool.some((e) => e.id === "e-250")).toBe(true);
+  });
+});

--- a/TravelCostApp/components/ManageExpense/AddExpenseButton.tsx
+++ b/TravelCostApp/components/ManageExpense/AddExpenseButton.tsx
@@ -3,7 +3,7 @@ import { GlobalStyles } from "../../constants/styles";
 import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
 import * as Haptics from "expo-haptics";
 import Animated, { SlideInDown, SlideOutDown } from "react-native-reanimated";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { Ionicons } from "@expo/vector-icons";
 import { TourGuideZone } from "rn-tourguide";
 
@@ -35,7 +35,10 @@ const AddExpenseButton = ({ navigation }) => {
   const authCtx = useContext(AuthContext);
   const expCtx = useContext(ExpensesContext);
 
-  const templateSourceExpenses = expensesForTemplateSelection(expCtx.expenses);
+  const templateSourceExpenses = useMemo(
+    () => expensesForTemplateSelection(expCtx.expenses),
+    [expCtx.expenses]
+  );
 
   const lastExpenses: ExpenseData[] = uniqBy(
     [...templateSourceExpenses].sort((a, b) => {

--- a/TravelCostApp/components/ManageExpense/AddExpenseButton.tsx
+++ b/TravelCostApp/components/ManageExpense/AddExpenseButton.tsx
@@ -19,6 +19,7 @@ import {
   ExpenseData,
   findMostDuplicatedDescriptionExpenses,
 } from "../../util/expense";
+import { expensesForTemplateSelection } from "../../util/template-expense-pool";
 import uniqBy from "lodash.uniqby";
 import { constantScale, dynamicScale } from "../../util/scalingUtil";
 import { safelyParseJSON } from "../../util/jsonParse";
@@ -34,14 +35,18 @@ const AddExpenseButton = ({ navigation }) => {
   const authCtx = useContext(AuthContext);
   const expCtx = useContext(ExpensesContext);
 
+  const templateSourceExpenses = expensesForTemplateSelection(expCtx.expenses);
+
   const lastExpenses: ExpenseData[] = uniqBy(
-    [...expCtx.expenses].sort((a, b) => {
+    [...templateSourceExpenses].sort((a, b) => {
       return (b.editedTimestamp ?? 0) - (a.editedTimestamp ?? 0);
     }),
     "description"
   );
 
-  const topDuplicates = findMostDuplicatedDescriptionExpenses(expCtx.expenses);
+  const topDuplicates = findMostDuplicatedDescriptionExpenses(
+    templateSourceExpenses
+  );
 
   const [lastExpensesNumber, setLastExpensesNumber] = useState(PageLength);
   const [templatePickerVisible, setTemplatePickerVisible] = useState(false);

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplateHelpModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplateHelpModal.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text } from "react-native";
+import PropTypes from "prop-types";
+
+import AppModal from "../UI/AppModal";
+import FlatButton from "../UI/FlatButton";
+import { GlobalStyles } from "../../constants/styles";
+import { i18n } from "../../i18n/i18n";
+import { dynamicScale } from "../../util/scalingUtil";
+
+export type ExpenseTemplateHelpModalProps = {
+  isVisible: boolean;
+  onClose: () => void;
+};
+
+const ExpenseTemplateHelpModal = ({
+  isVisible,
+  onClose,
+}: ExpenseTemplateHelpModalProps) => {
+  return (
+    <AppModal
+      isVisible={isVisible}
+      onClose={onClose}
+      testID="expense-template-help-modal"
+      backdropTestID="expense-template-help-backdrop"
+      contentTestID="expense-template-help-content"
+      contentStyle={styles.modalContent}
+    >
+      <Text style={styles.title}>{i18n.t("templateExpensesHelpTitle")}</Text>
+      <ScrollView style={styles.bodyScroll}>
+        <Text style={styles.body}>{i18n.t("templateExpensesHelpText")}</Text>
+      </ScrollView>
+      <FlatButton onPress={onClose} textStyle={styles.dismissButtonText}>
+        {i18n.t("confirm")}
+      </FlatButton>
+    </AppModal>
+  );
+};
+
+ExpenseTemplateHelpModal.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default ExpenseTemplateHelpModal;
+
+const styles = StyleSheet.create({
+  modalContent: {
+    maxHeight: "70%",
+    padding: dynamicScale(20, false, 0.5),
+  },
+  title: {
+    fontSize: dynamicScale(20, false, 0.5),
+    fontWeight: "600",
+    color: GlobalStyles.colors.textColor,
+    marginBottom: dynamicScale(12, true),
+    textAlign: "center",
+  },
+  bodyScroll: {
+    maxHeight: dynamicScale(320, true),
+    marginBottom: dynamicScale(16, true),
+  },
+  body: {
+    fontSize: dynamicScale(14, false, 0.5),
+    color: GlobalStyles.colors.textColor,
+    lineHeight: dynamicScale(20, false, 0.5),
+  },
+  dismissButtonText: {
+    fontSize: dynamicScale(16, false, 0.5),
+  },
+});

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { FlatList, StyleSheet, Text, useWindowDimensions, View } from "react-native";
 import PropTypes from "prop-types";
 import * as Haptics from "expo-haptics";
@@ -44,6 +44,12 @@ const ExpenseTemplatePickerModal = ({
   const closeHelp = useCallback(() => {
     setHelpVisible(false);
   }, []);
+
+  useEffect(() => {
+    if (!isVisible) {
+      setHelpVisible(false);
+    }
+  }, [isVisible]);
 
   const renderItem = ({
     item,

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
@@ -1,15 +1,18 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import { FlatList, StyleSheet, Text, useWindowDimensions, View } from "react-native";
 import PropTypes from "prop-types";
+import * as Haptics from "expo-haptics";
 
 import AppModal from "../UI/AppModal";
 import ExpenseListRow from "../ExpensesOutput/ExpenseListRow";
+import ExpenseTemplateHelpModal from "./ExpenseTemplateHelpModal";
 import { GlobalStyles } from "../../constants/styles";
 import { i18n } from "../../i18n/i18n";
 import type { ExpenseData } from "../../util/expense";
 import { templatePickerModalContentWidth } from "../../util/modal-layout";
 import { dynamicScale } from "../../util/scalingUtil";
 import FlatButton from "../UI/FlatButton";
+import InfoButton from "../UI/InfoButton";
 
 export type ExpenseTemplatePickerModalProps = {
   isVisible: boolean;
@@ -28,9 +31,19 @@ const ExpenseTemplatePickerModal = ({
   onSelectTemplate,
   onLoadMore,
 }: ExpenseTemplatePickerModalProps) => {
+  const [helpVisible, setHelpVisible] = useState(false);
   const { width: screenWidth } = useWindowDimensions();
   const contentWidth = templatePickerModalContentWidth(screenWidth);
   const hasTopSection = topDuplicateCount > 0;
+
+  const openHelp = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setHelpVisible(true);
+  }, []);
+
+  const closeHelp = useCallback(() => {
+    setHelpVisible(false);
+  }, []);
 
   const renderItem = ({
     item,
@@ -80,12 +93,19 @@ const ExpenseTemplatePickerModal = ({
     >
       <View style={styles.modalHeader}>
         <Text style={styles.modalTitle}>{i18n.t("templateExpenses")}</Text>
+        <InfoButton
+          testID="expense-template-picker-info"
+          accessibilityLabel={i18n.t("templateExpensesHelpTitle")}
+          containerStyle={styles.infoButton}
+          onPress={openHelp}
+        />
         <View testID="expense-template-picker-close">
           <FlatButton onPress={onClose} textStyle={styles.closeButtonText}>
             {i18n.t("cancel")}
           </FlatButton>
         </View>
       </View>
+      <ExpenseTemplateHelpModal isVisible={helpVisible} onClose={closeHelp} />
       <FlatList
         testID="expense-template-picker-list"
         data={templates}
@@ -130,6 +150,9 @@ const styles = StyleSheet.create({
     fontWeight: "300",
     fontSize: dynamicScale(22, false, 0.5),
     color: GlobalStyles.colors.textColor,
+  },
+  infoButton: {
+    marginHorizontal: dynamicScale(6, false, 0.5),
   },
   closeButtonText: {
     fontSize: dynamicScale(16, false, 0.5),

--- a/TravelCostApp/components/UI/InfoButton.tsx
+++ b/TravelCostApp/components/UI/InfoButton.tsx
@@ -5,11 +5,19 @@ import { GlobalStyles } from "../../constants/styles";
 import PropTypes from "prop-types";
 import { dynamicScale } from "../../util/scalingUtil";
 
-const InfoButton = ({ containerStyle, onPress }) => {
+const InfoButton = ({
+  containerStyle,
+  onPress,
+  testID,
+  accessibilityLabel,
+}) => {
   return (
     <Pressable
       style={[styles.container, containerStyle]}
       onPress={onPress}
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
     >
       <Text style={styles.text}>i</Text>
     </Pressable>
@@ -21,6 +29,8 @@ export default InfoButton;
 InfoButton.propTypes = {
   containerStyle: PropTypes.object,
   onPress: PropTypes.func.isRequired,
+  testID: PropTypes.string,
+  accessibilityLabel: PropTypes.string,
 };
 
 const styles = StyleSheet.create({

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -478,6 +478,9 @@ const en = {
   bannerText2:
     "Save even more money with the latest functions of the premium version.\nStart your free trial today!",
   templateExpenses: "Expense Templates",
+  templateExpensesHelpTitle: "How expense templates work",
+  templateExpensesHelpText:
+    "Long-press the + button to start from a past expense instead of a blank form.\n\nCopied: description, amount, category, currency and country, who paid, and how the cost is split. The date is always set to today—you can change it if you need another day.\n\nThis creates a new expense, not an edit of the old one. Review and adjust anything before you save.",
   mostUsedExpenses: "Most used expenses",
   lastUsedExpenses: "Last used expenses",
   budgetPerTraveller: "Budget per traveller",
@@ -1091,6 +1094,9 @@ const de = {
   bannerText2:
     "Spare noch mehr Geld mit den neuesten Funktionen der Premium-Version.\nStarte noch heute deine kostenlose Testversion!",
   templateExpenses: "Ausgaben-Vorlagen",
+  templateExpensesHelpTitle: "So funktionieren Ausgaben-Vorlagen",
+  templateExpensesHelpText:
+    "Halte die +-Taste gedrückt, um von einer früheren Ausgabe statt einem leeren Formular zu starten.\n\nÜbernommen werden: Beschreibung, Betrag, Kategorie, Währung und Land, Wer hat bezahlt und die Aufteilung. Das Datum ist immer heute—ändere es, wenn du einen anderen Tag brauchst.\n\nEs entsteht eine neue Ausgabe, keine Bearbeitung der alten. Prüfe alles und passe es an, bevor du speicherst.",
   mostUsedExpenses: "Am häufigsten verwendete Ausgaben",
   lastUsedExpenses: "Zuletzt verwendete Ausgaben",
   budgetPerTraveller: "Budget pro Reisendem",
@@ -1704,6 +1710,9 @@ const fr = {
   bannerText2:
     "Économisez encore plus d'argent avec les dernières fonctionnalités de la version premium.\nCommencez votre essai gratuit dès aujourd'hui !",
   templateExpenses: "Modèles de dépenses",
+  templateExpensesHelpTitle: "Comment fonctionnent les modèles de dépenses",
+  templateExpensesHelpText:
+    "Appuyez longuement sur le bouton + pour partir d'une dépense passée au lieu d'un formulaire vide.\n\nReprise : description, montant, catégorie, devise et pays, qui a payé et le partage. La date est toujours aujourd'hui—modifiez-la si vous avez besoin d'un autre jour.\n\nCela crée une nouvelle dépense, pas une modification de l'ancienne. Vérifiez et ajustez tout avant d'enregistrer.",
   mostUsedExpenses: "Dépenses les plus utilisées",
   lastUsedExpenses: "Dernières dépenses utilisées",
   budgetPerTraveller: "Budget par voyageur",
@@ -2318,6 +2327,9 @@ const ru = {
   bannerText2:
     "Экономьте еще больше с последними функциями премиум-версии.\nНачните бесплатную пробную версию сегодня!",
   templateExpenses: "Шаблоны расходов",
+  templateExpensesHelpTitle: "Как работают шаблоны расходов",
+  templateExpensesHelpText:
+    "Долгое нажатие на кнопку + позволяет начать с прошлого расхода вместо пустой формы.\n\nКопируются: описание, сумма, категория, валюта и страна, кто оплатил и как делится сумма. Дата всегда сегодня—измените её, если нужен другой день.\n\nСоздаётся новый расход, а не правка старого. Проверьте и при необходимости измените данные перед сохранением.",
   mostUsedExpenses: "Самые используемые расходы",
   lastUsedExpenses: "Последние использованные расходы",
   budgetPerTraveller: "Бюджет на одного путешественника",

--- a/TravelCostApp/util/template-expense-pool.ts
+++ b/TravelCostApp/util/template-expense-pool.ts
@@ -1,0 +1,20 @@
+import type { ExpenseData } from "./expense";
+
+/** When a trip has more than this many expenses, template selection uses a capped pool. */
+export const LARGE_TRIP_TEMPLATE_EXPENSE_THRESHOLD = 250;
+
+/** Newest expenses (by `editedTimestamp`) used as the template source on large trips. */
+export const LARGE_TRIP_TEMPLATE_POOL_SIZE = 250;
+
+export function expensesForTemplateSelection(
+  expenses: ExpenseData[]
+): ExpenseData[] {
+  if (expenses.length <= LARGE_TRIP_TEMPLATE_EXPENSE_THRESHOLD) {
+    return expenses;
+  }
+  return [...expenses]
+    .sort(
+      (a, b) => (b.editedTimestamp ?? 0) - (a.editedTimestamp ?? 0)
+    )
+    .slice(0, LARGE_TRIP_TEMPLATE_POOL_SIZE);
+}


### PR DESCRIPTION
## Summary
- Add `expensesForTemplateSelection` to limit template picker input to the 250 newest expenses by `editedTimestamp` when a trip has more than 250 expenses.
- Wire the helper into `AddExpenseButton` for duplicate/recent template selection only; the main expense ledger is unchanged.
- Add localized help modal (i) on the template picker explaining which fields copy vs reset when using a **Template expense**.

## Test plan
- [x] `pnpm test -- __tests__/util/template-expense-pool.test.ts`
- [x] `pnpm test -- __tests__/components/add-expense-button.test.tsx`
- [ ] Long-press add expense on a trip with >250 expenses and confirm templates reflect recent activity

Closes #307