### PR TITLE
Fix non-serializable navigation params for filtered expense views (DTO)

### DIFF
--- a/TravelCostApp/__tests__/screens/filtered-expenses.test.tsx
+++ b/TravelCostApp/__tests__/screens/filtered-expenses.test.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useNavigation: () => ({ pop: jest.fn(), navigate: jest.fn() }),
+  };
+});
+
+const mockExpensesOutput = jest.fn(() => null);
+jest.mock("../../components/ExpensesOutput/ExpensesOutput", () => ({
+  __esModule: true,
+  default: (props: unknown) => {
+    mockExpensesOutput(props);
+    return null;
+  },
+}));
+
+import FilteredExpenses from "../../screens/FilteredExpenses";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { makeExpense } from "../fixtures/expense";
+import { toExpenseNavigationDtos } from "../../util/expense-navigation-dto";
+import { i18n } from "../../i18n/i18n";
+
+describe("FilteredExpenses route params", () => {
+  beforeEach(() => {
+    mockExpensesOutput.mockClear();
+  });
+
+  it("hydrates serializable expense DTOs from route params for list rendering", () => {
+    const expenses = [
+      makeExpense({
+        id: "older",
+        date: new Date("2026-01-01T00:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "newer",
+        date: new Date("2026-01-15T00:00:00.000Z"),
+      }),
+    ];
+
+    renderWithAppProviders(
+      <FilteredExpenses
+        route={{
+          params: {
+            expenses: toExpenseNavigationDtos(expenses),
+            dayString: "Jan 2026",
+            showSumForTravellerName: "Alice",
+          },
+        }}
+      />
+    );
+
+    expect(mockExpensesOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isFiltered: true,
+        showSumForTravellerName: "Alice",
+        expenses: expect.arrayContaining([
+          expect.objectContaining({
+            id: "older",
+            date: new Date("2026-01-01T00:00:00.000Z"),
+          }),
+          expect.objectContaining({
+            id: "newer",
+            date: new Date("2026-01-15T00:00:00.000Z"),
+          }),
+        ]),
+      })
+    );
+
+    expect(
+      mockExpensesOutput.mock.calls[0][0].expenses.map(
+        (exp: { id: string }) => exp.id
+      )
+    ).toEqual(["older", "newer"]);
+  });
+
+  it("uses the earliest hydrated expense date for add-expense-here", () => {
+    const expenses = [
+      makeExpense({
+        id: "later",
+        date: new Date("2026-03-20T00:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "earlier",
+        date: new Date("2026-03-05T00:00:00.000Z"),
+      }),
+    ];
+
+    const screen = renderWithAppProviders(
+      <FilteredExpenses
+        route={{
+          params: {
+            expenses: toExpenseNavigationDtos(expenses),
+            dayString: "Mar 2026",
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText(new RegExp(i18n.t("addExp"), "i"))
+    ).toBeTruthy();
+  });
+});

--- a/TravelCostApp/__tests__/screens/filtered-expenses.test.tsx
+++ b/TravelCostApp/__tests__/screens/filtered-expenses.test.tsx
@@ -76,6 +76,25 @@ describe("FilteredExpenses route params", () => {
     ).toEqual(["older", "newer"]);
   });
 
+  it("renders an empty filtered list when route params omit expenses", () => {
+    renderWithAppProviders(
+      <FilteredExpenses
+        route={{
+          params: {
+            dayString: "Empty",
+          },
+        }}
+      />
+    );
+
+    expect(mockExpensesOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isFiltered: true,
+        expenses: [],
+      })
+    );
+  });
+
   it("uses the earliest hydrated expense date for add-expense-here", () => {
     const expenses = [
       makeExpense({

--- a/TravelCostApp/__tests__/screens/filtered-pie-charts.test.tsx
+++ b/TravelCostApp/__tests__/screens/filtered-pie-charts.test.tsx
@@ -29,6 +29,7 @@ jest.mock("../../screens/FilteredExpenses", () => () => null);
 import FilteredPieCharts from "../../screens/FilteredPieCharts";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import { makeExpense } from "../fixtures/expense";
+import { toExpenseNavigationDtos } from "../../util/expense-navigation-dto";
 import { i18n } from "../../i18n/i18n";
 
 const CATEGORIES = i18n.t("categories");
@@ -41,7 +42,7 @@ function renderScreen(routeOverrides: Record<string, unknown> = {}) {
   const navigation = { navigate: jest.fn(), pop: jest.fn() };
   const route = {
     params: {
-      expenses: [makeExpense({ id: "e1" })],
+      expenses: toExpenseNavigationDtos([makeExpense({ id: "e1" })]),
       dayString: "May 2026",
       noList: false,
       ...routeOverrides,

--- a/TravelCostApp/__tests__/screens/filtered-pie-charts.test.tsx
+++ b/TravelCostApp/__tests__/screens/filtered-pie-charts.test.tsx
@@ -109,4 +109,10 @@ describe("FilteredPieCharts navigation arrows", () => {
     fireEvent.press(screen.getByTestId("icon-chevron-back-outline"));
     expectActiveTitle(screen, CURRENCIES);
   });
+
+  it("renders when route params omit expenses", () => {
+    const { screen } = renderScreen({ expenses: undefined });
+
+    expectActiveTitle(screen, CATEGORIES);
+  });
 });

--- a/TravelCostApp/__tests__/util/expense-navigation-dto.test.ts
+++ b/TravelCostApp/__tests__/util/expense-navigation-dto.test.ts
@@ -1,0 +1,66 @@
+import { DateTime } from "luxon";
+import { makeExpense } from "../fixtures/expense";
+import {
+  hydrateExpenseFromNavigationDto,
+  hydrateExpensesFromNavigationDtos,
+  toExpenseNavigationDto,
+  toExpenseNavigationDtos,
+} from "../../util/expense-navigation-dto";
+
+describe("expense navigation DTO round-trip", () => {
+  it("serializes Date fields to ISO strings and hydrates back to equivalent ExpenseData", () => {
+    const expense = makeExpense({
+      id: "nav-1",
+      date: new Date("2026-03-10T08:30:00.000Z"),
+      startDate: new Date("2026-03-10T08:30:00.000Z"),
+      endDate: new Date("2026-03-12T18:00:00.000Z"),
+      description: "hostel",
+    });
+
+    const dto = toExpenseNavigationDto(expense);
+    expect(dto.date).toBe("2026-03-10T08:30:00.000Z");
+    expect(dto.startDate).toBe("2026-03-10T08:30:00.000Z");
+    expect(dto.endDate).toBe("2026-03-12T18:00:00.000Z");
+    expect(dto.description).toBe("hostel");
+
+    const hydrated = hydrateExpenseFromNavigationDto(dto);
+    expect(hydrated.id).toBe("nav-1");
+    expect(hydrated.description).toBe("hostel");
+    expect(hydrated.date).toEqual(new Date("2026-03-10T08:30:00.000Z"));
+    expect(hydrated.startDate).toEqual(new Date("2026-03-10T08:30:00.000Z"));
+    expect(hydrated.endDate).toEqual(new Date("2026-03-12T18:00:00.000Z"));
+  });
+
+  it("survives JSON round-trip like React Navigation persisted state", () => {
+    const expenses = [
+      makeExpense({ id: "a", date: new Date("2026-01-01T00:00:00.000Z") }),
+      makeExpense({ id: "b", date: new Date("2026-01-02T00:00:00.000Z") }),
+    ];
+
+    const params = {
+      expenses: toExpenseNavigationDtos(expenses),
+      dayString: "Jan 2026",
+    };
+    const fromNavState = JSON.parse(JSON.stringify(params));
+
+    const restored = hydrateExpensesFromNavigationDtos(fromNavState.expenses);
+    expect(restored.map((e) => e.id)).toEqual(["a", "b"]);
+    expect(restored[0].date).toEqual(new Date("2026-01-01T00:00:00.000Z"));
+    expect(restored[1].date).toEqual(new Date("2026-01-02T00:00:00.000Z"));
+  });
+
+  it("serializes Luxon DateTime fields to ISO strings", () => {
+    const expense = makeExpense({
+      date: DateTime.fromISO("2026-05-20T12:00:00.000Z"),
+      startDate: DateTime.fromISO("2026-05-20T12:00:00.000Z"),
+      endDate: DateTime.fromISO("2026-05-21T12:00:00.000Z"),
+    });
+
+    const dto = toExpenseNavigationDto(expense);
+    expect(dto.date).toBe("2026-05-20T12:00:00.000Z");
+    expect(dto.endDate).toBe("2026-05-21T12:00:00.000Z");
+
+    const hydrated = hydrateExpenseFromNavigationDto(dto);
+    expect(hydrated.date).toEqual(new Date("2026-05-20T12:00:00.000Z"));
+  });
+});

--- a/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseCategories.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseCategories.tsx
@@ -14,6 +14,7 @@ import PropTypes from "prop-types";
 import { processTitleStringFilteredPiecharts } from "../../../util/string";
 import { TripContext } from "../../../store/trip-context";
 import { ExpenseData, getExpensesSum } from "../../../util/expense";
+import { toExpenseNavigationDtos } from "../../../util/expense-navigation-dto";
 import { shadowRegressionStyles } from "../../../styles/shadow-regression-styles";
 import { dynamicScale } from "../../../util/scalingUtil";
 import { OrientationContext } from "../../../store/orientation-context";
@@ -92,7 +93,7 @@ const ExpenseCategories = ({
         onPress={() => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           navigation.navigate("FilteredExpenses", {
-            expenses: itemData.item.catExpenses,
+            expenses: toExpenseNavigationDtos(itemData.item.catExpenses),
             dayString: getCatLocalized(itemData.item.cat) + " " + newPeriodName,
           });
         }}

--- a/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseCountries.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseCountries.tsx
@@ -12,6 +12,7 @@ import { i18n } from "../../../i18n/i18n";
 import { getCatLocalized } from "../../../util/category";
 import PropTypes from "prop-types";
 import { ExpenseData, getExpensesSum } from "../../../util/expense";
+import { toExpenseNavigationDtos } from "../../../util/expense-navigation-dto";
 import ExpenseCountryFlag from "../ExpenseCountryFlag";
 import { shadowRegressionStyles } from "../../../styles/shadow-regression-styles";
 import BlurPremium from "../../Premium/BlurPremium";
@@ -101,7 +102,7 @@ const ExpenseCountries = ({
         onPress={() => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           navigation.navigate("FilteredExpenses", {
-            expenses: itemData.item.catExpenses,
+            expenses: toExpenseNavigationDtos(itemData.item.catExpenses),
             dayString: getCatLocalized(itemData.item.cat) + " " + newPeriodName,
           });
         }}

--- a/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseCurrencies.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseCurrencies.tsx
@@ -12,6 +12,7 @@ import { i18n } from "../../../i18n/i18n";
 import { getCatLocalized } from "../../../util/category";
 import PropTypes from "prop-types";
 import { ExpenseData, getExpensesSum } from "../../../util/expense";
+import { toExpenseNavigationDtos } from "../../../util/expense-navigation-dto";
 import { shadowRegressionStyles } from "../../../styles/shadow-regression-styles";
 import BlurPremium from "../../Premium/BlurPremium";
 import { processTitleStringFilteredPiecharts } from "../../../util/string";
@@ -90,7 +91,7 @@ const ExpenseCurrencies = ({
         onPress={() => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           navigation.navigate("FilteredExpenses", {
-            expenses: itemData.item.catExpenses,
+            expenses: toExpenseNavigationDtos(itemData.item.catExpenses),
             dayString: getCatLocalized(itemData.item.cat) + " " + newPeriodName,
           });
         }}

--- a/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseGraph.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseGraph.tsx
@@ -23,6 +23,7 @@ import {
   MAX_JS_NUMBER,
   PRELOADED_DATA_POINTS,
 } from "../../../confAppConstants";
+import { toExpenseNavigationDtos } from "../../../util/expense-navigation-dto";
 import { SettingsContext } from "../../../store/settings-context";
 import { getExpensesSumPeriod } from "../../../util/expense";
 import { dynamicScale } from "../../../util/scalingUtil";
@@ -140,7 +141,7 @@ const ExpenseGraph = ({
                 // if (!filteredExpenses || filteredExpenses?.length === 0) return;
 
                 navigation.navigate("FilteredExpenses", {
-                  expenses: filteredExpenses,
+                  expenses: toExpenseNavigationDtos(filteredExpenses),
                   dayString: dayString,
                 });
               }}
@@ -155,7 +156,7 @@ const ExpenseGraph = ({
                   );
                 // if (!filteredExpenses || filteredExpenses?.length === 0) return;
                 navigation.navigate("FilteredPieCharts", {
-                  expenses: filteredExpenses,
+                  expenses: toExpenseNavigationDtos(filteredExpenses),
                   dayString: titleStringFilteredPieCharts,
                 });
               }}
@@ -253,7 +254,7 @@ const ExpenseGraph = ({
                   );
                 // if (!filteredExpenses || filteredExpenses?.length === 0) return;
                 navigation.navigate("FilteredExpenses", {
-                  expenses: filteredExpenses,
+                  expenses: toExpenseNavigationDtos(filteredExpenses),
                   dayString: weekString,
                 });
               }}
@@ -268,7 +269,7 @@ const ExpenseGraph = ({
                   );
                 // if (!filteredExpenses || filteredExpenses?.length === 0) return;
                 navigation.navigate("FilteredPieCharts", {
-                  expenses: filteredExpenses,
+                  expenses: toExpenseNavigationDtos(filteredExpenses),
                   dayString: titleStringFilteredPieCharts,
                 });
               }}
@@ -342,7 +343,7 @@ const ExpenseGraph = ({
                   );
                 // if (!filteredExpenses || filteredExpenses?.length === 0) return;
                 navigation.navigate("FilteredExpenses", {
-                  expenses: filteredExpenses,
+                  expenses: toExpenseNavigationDtos(filteredExpenses),
                   dayString: month,
                 });
               }}
@@ -357,7 +358,7 @@ const ExpenseGraph = ({
                   );
                 // if (!filteredExpenses || filteredExpenses?.length === 0) return;
                 navigation.navigate("FilteredPieCharts", {
-                  expenses: filteredExpenses,
+                  expenses: toExpenseNavigationDtos(filteredExpenses),
                   dayString: titleStringFilteredPieCharts,
                 });
               }}
@@ -435,7 +436,7 @@ const ExpenseGraph = ({
                   );
                 // if (!filteredExpenses || filteredExpenses?.length === 0) return;
                 navigation.navigate("FilteredExpenses", {
-                  expenses: filteredExpenses,
+                  expenses: toExpenseNavigationDtos(filteredExpenses),
                   dayString: yearString,
                 });
               }}
@@ -450,7 +451,7 @@ const ExpenseGraph = ({
                   );
                 // if (!filteredExpenses || filteredExpenses?.length === 0) return;
                 navigation.navigate("FilteredPieCharts", {
-                  expenses: filteredExpenses,
+                  expenses: toExpenseNavigationDtos(filteredExpenses),
                   dayString: titleStringFilteredPieCharts,
                 });
               }}

--- a/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseTravellers.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseStatistics/ExpenseTravellers.tsx
@@ -15,6 +15,7 @@ import {
   ExpenseData,
   getExpensesSum,
 } from "../../../util/expense";
+import { toExpenseNavigationDtos } from "../../../util/expense-navigation-dto";
 import { sumByTraveller } from "../../../util/expenseTotals";
 import { TripContext } from "../../../store/trip-context";
 import { shadowRegressionStyles } from "../../../styles/shadow-regression-styles";
@@ -107,7 +108,7 @@ const ExpenseTravellers = ({
         onPress={() => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           navigation.navigate("FilteredExpenses", {
-            expenses: itemData.item.catExpenses,
+            expenses: toExpenseNavigationDtos(itemData.item.catExpenses),
             dayString: getCatLocalized(itemData.item.cat) + " " + newPeriodName,
             showSumForTravellerName: itemData.item.cat,
           });

--- a/TravelCostApp/components/ExpensesOutput/ExpensesList.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesList.tsx
@@ -57,6 +57,7 @@ import { addShadowItemsToExpenses } from "./ExpenseListUtil";
 import { UserContext } from "../../store/user-context";
 import * as Haptics from "expo-haptics";
 import { toShortFormat } from "../../util/date";
+import { toExpenseNavigationDtos } from "../../util/expense-navigation-dto";
 import {
   DEVELOPER_MODE,
   EXPENSES_LOAD_TIMEOUT,
@@ -479,7 +480,7 @@ function ExpensesList({
     });
 
     navigation.navigate("FilteredPieCharts", {
-      expenses: finderExpenses,
+      expenses: toExpenseNavigationDtos(finderExpenses),
       dayString: `${finderExpenses?.length} selected Expenses from ${periodName}`,
       noList: true,
     });

--- a/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
@@ -18,6 +18,7 @@ import { useNavigation } from "@react-navigation/native";
 import { ExpensesContext, RangeString } from "../../store/expenses-context";
 import { UserContext } from "../../store/user-context";
 import { dynamicScale } from "../../util/scalingUtil";
+import { toExpenseNavigationDtos } from "../../util/expense-navigation-dto";
 
 function ExpensesOutput({
   expenses,
@@ -83,7 +84,7 @@ function ExpensesOutput({
                 textStyle={{ marginVertical: dynamicScale(4, false, 0.5) }}
                 onPress={() => {
                   (navigation as any).navigate("FilteredExpenses", {
-                    expenses: yesterdayExpenses,
+                    expenses: toExpenseNavigationDtos(yesterdayExpenses),
                     dayString: i18n.t("yesterday"),
                   });
                 }}
@@ -96,7 +97,7 @@ function ExpensesOutput({
                 textStyle={{ marginVertical: dynamicScale(4, false, 0.5) }}
                 onPress={() => {
                   (navigation as any).navigate("FilteredExpenses", {
-                    expenses: tomorrowExpenses,
+                    expenses: toExpenseNavigationDtos(tomorrowExpenses),
                     dayString: i18n.t("tomorrow"),
                   });
                 }}

--- a/TravelCostApp/screens/FilteredExpenses.tsx
+++ b/TravelCostApp/screens/FilteredExpenses.tsx
@@ -28,7 +28,7 @@ const FilteredExpenses = ({ route, expensesAsArg, dayStringAsArg }) => {
       }
     : {
         ...routeParams,
-        expenses: hydrateExpensesFromNavigationDtos(routeParams.expenses),
+        expenses: hydrateExpensesFromNavigationDtos(routeParams?.expenses ?? []),
       };
   const withArgs = expensesAsArg ? true : false;
   const navigation = useNavigation();

--- a/TravelCostApp/screens/FilteredExpenses.tsx
+++ b/TravelCostApp/screens/FilteredExpenses.tsx
@@ -13,19 +13,27 @@ import { useNavigation } from "@react-navigation/native";
 import AddExpenseHereButton from "../components/UI/AddExpensesHereButton";
 import { getEarliestDate } from "../util/date";
 import { ExpenseData } from "../util/expense";
+import {
+  expenseDateToIsoString,
+  hydrateExpensesFromNavigationDtos,
+} from "../util/expense-navigation-dto";
 
 const FilteredExpenses = ({ route, expensesAsArg, dayStringAsArg }) => {
+  const routeParams = route?.params;
   const { expenses, dayString, showSumForTravellerName } = expensesAsArg
     ? {
         expenses: expensesAsArg,
         dayString: dayStringAsArg,
         showSumForTravellerName: "",
       }
-    : route.params;
+    : {
+        ...routeParams,
+        expenses: hydrateExpensesFromNavigationDtos(routeParams.expenses),
+      };
   const withArgs = expensesAsArg ? true : false;
   const navigation = useNavigation();
   const earliestDate = getEarliestDate(
-    expenses.map((exp: ExpenseData) => exp.date)
+    expenses.map((exp: ExpenseData) => expenseDateToIsoString(exp.date))
   );
   // ||new Date(dayString).toISOString();
 

--- a/TravelCostApp/screens/FilteredPieCharts.tsx
+++ b/TravelCostApp/screens/FilteredPieCharts.tsx
@@ -19,13 +19,16 @@ import { ExpenseData } from "../util/expense";
 import { getEarliestDate } from "../util/date";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
 import { OrientationContext } from "../store/orientation-context";
-import { hydrateExpensesFromNavigationDtos, expenseDateToIsoString } from "../util/expense-navigation-dto";
+import {
+  expenseDateToIsoString,
+  hydrateExpensesFromNavigationDtos,
+} from "../util/expense-navigation-dto";
 
 const FilteredPieCharts = ({ navigation, route }) => {
   const { dayString, noList = false } = route.params;
   const expenses = useMemo(
-    () => hydrateExpensesFromNavigationDtos(route.params.expenses),
-    [route.params.expenses]
+    () => hydrateExpensesFromNavigationDtos(route.params?.expenses ?? []),
+    [route.params?.expenses]
   );
   const [toggleGraphEnum, setToggleGraphEnum] = useState(0);
 

--- a/TravelCostApp/screens/FilteredPieCharts.tsx
+++ b/TravelCostApp/screens/FilteredPieCharts.tsx
@@ -19,9 +19,14 @@ import { ExpenseData } from "../util/expense";
 import { getEarliestDate } from "../util/date";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
 import { OrientationContext } from "../store/orientation-context";
+import { hydrateExpensesFromNavigationDtos, expenseDateToIsoString } from "../util/expense-navigation-dto";
 
 const FilteredPieCharts = ({ navigation, route }) => {
-  const { expenses, dayString, noList = false } = route.params;
+  const { dayString, noList = false } = route.params;
+  const expenses = useMemo(
+    () => hydrateExpensesFromNavigationDtos(route.params.expenses),
+    [route.params.expenses]
+  );
   const [toggleGraphEnum, setToggleGraphEnum] = useState(0);
 
   const { isPortrait, isTablet } = useContext(OrientationContext);
@@ -95,7 +100,10 @@ const FilteredPieCharts = ({ navigation, route }) => {
   }, [contentsMaxIndex]);
 
   const earliestDate = useMemo(
-    () => getEarliestDate(expenses.map((exp: ExpenseData) => exp.date)),
+    () =>
+      getEarliestDate(
+        expenses.map((exp: ExpenseData) => expenseDateToIsoString(exp.date))
+      ),
     [expenses]
   );
 

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -10,6 +10,7 @@ import { Platform, StyleSheet, Text, View, ScrollView } from "react-native";
 import DatePickerContainer from "../components/UI/DatePickerContainer";
 import DatePickerModal from "../components/UI/DatePickerModal";
 import { getFormattedDate } from "../util/date";
+import { toExpenseNavigationDtos } from "../util/expense-navigation-dto";
 
 import { i18n } from "../i18n/i18n";
 
@@ -201,7 +202,7 @@ const FinderScreen = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     trackEvent(VexoEvents.FINDER_PRESSED);
     navigation.navigate("FilteredPieCharts", {
-      expenses: filteredExpenses,
+      expenses: toExpenseNavigationDtos(filteredExpenses),
       dayString: allEpensesQueryString + queryString + " " + dateString,
     });
   }, [

--- a/TravelCostApp/screens/SplitSummaryScreen.tsx
+++ b/TravelCostApp/screens/SplitSummaryScreen.tsx
@@ -40,6 +40,7 @@ import {
   isPaidString,
   getEffectivePaidBack,
 } from "../util/expense";
+import { toExpenseNavigationDtos } from "../util/expense-navigation-dto";
 import Animated from "react-native-reanimated";
 import { formatExpenseWithCurrency } from "../util/string";
 import { useFocusEffect } from "@react-navigation/native";
@@ -305,7 +306,7 @@ const SplitSummaryScreen = ({ navigation }) => {
           onPress={() => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
             navigation.navigate("FilteredExpenses", {
-              expenses: expensesList,
+              expenses: toExpenseNavigationDtos(expensesList),
               dayString: `${item.userName} ${i18n.t("owes")} ${
                 item.whoPaid
               } ${formatExpenseWithCurrency(item.amount, tripCurrency)}`,

--- a/TravelCostApp/screens/TripSummaryScreen.tsx
+++ b/TravelCostApp/screens/TripSummaryScreen.tsx
@@ -27,6 +27,7 @@ import {
   getAllExpensesData,
   getExpensesSum,
 } from "../util/expense";
+import { toExpenseNavigationDtos } from "../util/expense-navigation-dto";
 import { formatExpenseWithCurrency } from "../util/string";
 import PropTypes from "prop-types";
 import { TripContext, TripData } from "../store/trip-context";
@@ -618,7 +619,7 @@ const TripSummaryScreen = ({ navigation }) => {
               onPress={() => {
                 Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                 navigation.navigate("FilteredPieCharts", {
-                  expenses: allExpensesList,
+                  expenses: toExpenseNavigationDtos(allExpensesList),
                   dayString: `${titleText}\n${allExpensesList?.length} ${i18n.t(
                     "expensesTab"
                   )}`,

--- a/TravelCostApp/util/expense-navigation-dto.ts
+++ b/TravelCostApp/util/expense-navigation-dto.ts
@@ -1,0 +1,75 @@
+import { createSafeDate, DateOrDateTime } from "./date";
+import { ExpenseData } from "./expense";
+
+export type ExpenseNavigationDto = Omit<
+  ExpenseData,
+  "date" | "startDate" | "endDate"
+> & {
+  date: string;
+  startDate: string;
+  endDate: string;
+};
+
+export type FilteredExpensesParams = {
+  expenses: ExpenseNavigationDto[];
+  dayString: string;
+  showSumForTravellerName?: string;
+};
+
+export type FilteredPieChartsParams = {
+  expenses: ExpenseNavigationDto[];
+  dayString: string;
+  noList?: boolean;
+};
+
+function toIsoString(dateValue: DateOrDateTime | string): string {
+  if (typeof dateValue === "string") {
+    return dateValue;
+  }
+  if (dateValue instanceof Date) {
+    return dateValue.toISOString();
+  }
+  return dateValue.toJSDate().toISOString();
+}
+
+export function expenseDateToIsoString(
+  dateValue: DateOrDateTime | string
+): string {
+  return toIsoString(dateValue);
+}
+
+export function toExpenseNavigationDto(
+  expense: ExpenseData
+): ExpenseNavigationDto {
+  const { date, startDate, endDate, ...rest } = expense;
+  return {
+    ...rest,
+    date: toIsoString(date),
+    startDate: toIsoString(startDate),
+    endDate: toIsoString(endDate),
+  };
+}
+
+export function toExpenseNavigationDtos(
+  expenses: ExpenseData[]
+): ExpenseNavigationDto[] {
+  return expenses.map(toExpenseNavigationDto);
+}
+
+export function hydrateExpenseFromNavigationDto(
+  dto: ExpenseNavigationDto
+): ExpenseData {
+  const { date, startDate, endDate, ...rest } = dto;
+  return {
+    ...rest,
+    date: createSafeDate(date),
+    startDate: createSafeDate(startDate),
+    endDate: createSafeDate(endDate),
+  };
+}
+
+export function hydrateExpensesFromNavigationDtos(
+  dtos: ExpenseNavigationDto[]
+): ExpenseData[] {
+  return dtos.map(hydrateExpenseFromNavigationDto);
+}


### PR DESCRIPTION
## Summary
- Add `expense-navigation-dto` helpers to serialize `ExpenseData` dates to ISO strings for navigation and hydrate back on destination screens.
- Update all `FilteredExpenses` / `FilteredPieCharts` navigate call sites to pass DTO arrays while preserving filtered subset and order.
- Hydrate route params in `FilteredExpenses` and `FilteredPieCharts`; keep in-memory props path for nested filtered list inside pie charts.

## Test plan
- [x] `pnpm test __tests__/util/expense-navigation-dto.test.ts`
- [x] `pnpm test __tests__/screens/filtered-expenses.test.tsx`
- [x] `pnpm test __tests__/screens/filtered-pie-charts.test.tsx`
- [x] `pnpm test __tests__/screens/split-summary-screen.test.tsx __tests__/screens/finder-screen.test.tsx`
- [ ] Open filtered expense views from graph, statistics breakdowns, ledger shortcuts, split rows, Finder, and filtered pie charts — no React Navigation non-serializable warning

Closes #308