### PR TITLE
Active-trip refactor — slice 1: hydrateTrip pure mapper

### DIFF
--- a/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
+++ b/TravelCostApp/__tests__/store/trip-context-storage.test.tsx
@@ -129,5 +129,60 @@ describe("TripContext storage contracts", () => {
     expect(results[0].inputTripHasTotalSum).toBe(true);
     expect("totalSum" in (results[0].storedTrip as any)).toBe(false);
   });
+
+  it("loadTripDataFromStorage sets tripid and isDynamicDailyBudget from stored trip", async () => {
+    const { getMMKVObject } = require("../../store/mmkv");
+    getMMKVObject.mockReturnValueOnce({
+      tripid: "stored-trip",
+      tripName: "Stored",
+      totalBudget: "200",
+      dailyBudget: "20",
+      tripCurrency: "USD",
+      travellers: [],
+      startDate: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+      endDate: new Date("2026-01-11T00:00:00.000Z").toISOString(),
+      isDynamicDailyBudget: true,
+    });
+
+    const ctxRef: {
+      current: {
+        getcurrentTrip: () => {
+          tripid?: string;
+          isDynamicDailyBudget?: boolean;
+        };
+      } | null;
+    } = { current: null };
+    let loadedTripid: string | undefined;
+
+    function LoadFromStorageProbe() {
+      const { TripContext } = require("../../store/trip-context");
+      const ctx = useContext(TripContext);
+      ctxRef.current = ctx;
+      const didInit = useRef(false);
+      useEffect(() => {
+        if (didInit.current) return;
+        didInit.current = true;
+        ctx.loadTripDataFromStorage().then((loaded) => {
+          loadedTripid = loaded?.tripid;
+        });
+      }, [ctx]);
+      return null;
+    }
+
+    const TripContextProvider = require("../../store/trip-context").default;
+    render(
+      <ExpensesContext.Provider value={{ expenses: [] } as any}>
+        <TripContextProvider>
+          <LoadFromStorageProbe />
+        </TripContextProvider>
+      </ExpensesContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(loadedTripid).toBe("stored-trip");
+      expect(ctxRef.current?.getcurrentTrip().tripid).toBe("stored-trip");
+      expect(ctxRef.current?.getcurrentTrip().isDynamicDailyBudget).toBe(true);
+    });
+  });
 });
 

--- a/TravelCostApp/__tests__/util/hydrate-trip.test.ts
+++ b/TravelCostApp/__tests__/util/hydrate-trip.test.ts
@@ -1,0 +1,64 @@
+import { MAX_JS_NUMBER } from "../../confAppConstants";
+import type { TripData } from "../../types/trip";
+import { isPaidString } from "../../util/expense";
+import { hydrateTrip } from "../../util/hydrate-trip";
+
+function minimalTrip(overrides: Partial<TripData> = {}): TripData {
+  return {
+    tripid: "trip-1",
+    tripName: "Trip",
+    totalBudget: "100",
+    dailyBudget: "10",
+    tripCurrency: "EUR",
+    travellers: [],
+    ...overrides,
+  };
+}
+
+describe("hydrateTrip", () => {
+  it("migrates isPaidDate to isPaidTimestamp and sets isPaid to notPaid", () => {
+    const paidDate = "2024-06-15T12:00:00.000Z";
+    const raw = minimalTrip({
+      isPaid: isPaidString.paid,
+      isPaidDate: paidDate,
+      isPaidTimestamp: undefined,
+    });
+
+    const hydrated = hydrateTrip(raw);
+
+    expect(hydrated.isPaidTimestamp).toBe(new Date(paidDate).getTime());
+    expect(hydrated.isPaid).toBe(isPaidString.notPaid);
+  });
+
+  it("drops deprecated totalSum without mutating the input", () => {
+    const raw = {
+      ...minimalTrip(),
+      totalSum: 999,
+    } as TripData & { totalSum: number };
+
+    const hydrated = hydrateTrip(raw);
+
+    expect("totalSum" in hydrated).toBe(false);
+    expect("totalSum" in raw).toBe(true);
+  });
+
+  it("uses max-budget fallback when totalBudget is missing", () => {
+    const hydrated = hydrateTrip(minimalTrip({ totalBudget: undefined }));
+
+    expect(hydrated.totalBudget).toBe(MAX_JS_NUMBER.toString());
+  });
+
+  it("clamps negative dailyBudget to 0.0001", () => {
+    const hydrated = hydrateTrip(minimalTrip({ dailyBudget: "-5" }));
+
+    expect(hydrated.dailyBudget).toBe("0.0001");
+  });
+
+  it("preserves isDynamicDailyBudget when set on raw trip", () => {
+    const hydrated = hydrateTrip(
+      minimalTrip({ isDynamicDailyBudget: true })
+    );
+
+    expect(hydrated.isDynamicDailyBudget).toBe(true);
+  });
+});

--- a/TravelCostApp/__tests__/util/hydrate-trip.test.ts
+++ b/TravelCostApp/__tests__/util/hydrate-trip.test.ts
@@ -54,6 +54,22 @@ describe("hydrateTrip", () => {
     expect(hydrated.dailyBudget).toBe("0.0001");
   });
 
+  it.each([
+    ["empty isPaidDate", ""],
+    ["invalid isPaidDate", "not-a-date"],
+  ])("does not set isPaidTimestamp for %s", (_label, isPaidDate) => {
+    const raw = minimalTrip({
+      isPaid: isPaidString.paid,
+      isPaidDate,
+      isPaidTimestamp: undefined,
+    });
+
+    const hydrated = hydrateTrip(raw);
+
+    expect(hydrated.isPaidTimestamp).toBeUndefined();
+    expect(hydrated.isPaid).toBe(isPaidString.paid);
+  });
+
   it("preserves isDynamicDailyBudget when set on raw trip", () => {
     const hydrated = hydrateTrip(
       minimalTrip({ isDynamicDailyBudget: true })

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -38,7 +38,7 @@ export type TripContextType = {
   addTrip: ({ tripName, tripTotalBudget }) => void;
   deleteTrip: (tripid: string) => void;
   getcurrentTrip: () => TripData;
-  setCurrentTrip: (tripid: string, trip: TripData) => Promise<void>;
+  setCurrentTrip: (tripid: string, trip: TripData) => Promise<TripData | void>;
   fetchAndSetCurrentTrip: (tripid: string) => Promise<TripData>;
   saveTripDataInStorage: (tripData: TripData) => Promise<void>;
   loadTripDataFromStorage: () => Promise<TripData>;
@@ -77,7 +77,7 @@ export const TripContext = createContext<TripContextType>({
     const tripData = {} as TripData;
     return tripData;
   },
-  setCurrentTrip: async (tripid: string, trip: TripData) => {},
+  setCurrentTrip: async (tripid: string, trip: TripData) => undefined,
   fetchAndSetCurrentTrip: async (tripid: string): Promise<TripData> => {
     return {};
   },
@@ -216,7 +216,10 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     }
   }
 
-  async function setCurrentTrip(tripid: string, trip: TripData) {
+  async function setCurrentTrip(
+    tripid: string,
+    trip: TripData
+  ): Promise<TripData | void> {
     if (!trip) return;
     if (tripid === "reset") {
       _setTripid("");
@@ -234,7 +237,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       return;
     }
 
-    const hydratedTrip = hydrateTrip({ ...trip, tripid });
+    const hydratedTrip = hydrateTrip({ ...trip, tripid: trip.tripid ?? tripid });
 
     _setTripid(tripid);
     setTripName(hydratedTrip.tripName);
@@ -260,6 +263,8 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       });
       setTravellers(extractedTravellers);
     }
+
+    return hydratedTrip;
   }
 
   async function fetchAndSetCurrentTrip(tripid: string) {
@@ -271,8 +276,8 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       if (!trip) throw new Error("no trip found");
       trip.tripid = tripid;
 
-      const migratedTrip = hydrateTrip(trip);
-      await setCurrentTrip(tripid, trip);
+      const migratedTrip = await setCurrentTrip(tripid, trip);
+      if (!migratedTrip) return;
 
       // If migration occurred, save migrated trip back to database and storage
       if (
@@ -355,9 +360,11 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     if (tripData) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const hadDeprecatedTotalSum = "totalSum" in (tripData as any);
-      const migratedTrip = hydrateTrip(tripData);
-
-      await setCurrentTrip(tripData.tripid ?? "", tripData);
+      const migratedTrip = await setCurrentTrip(tripData.tripid ?? "", tripData);
+      if (!migratedTrip) {
+        setIsLoading(false);
+        return;
+      }
 
       try {
         await loadTravellersFromStorage();

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -3,7 +3,6 @@
 import React, { createContext, useEffect, useState } from "react";
 import { fetchTrip, fetchUser, getTravellers, updateTrip } from "../util/http";
 import { asyncStoreGetObject, asyncStoreSetObject } from "./async-storage";
-import { MAX_JS_NUMBER } from "../confAppConstants";
 import { secureStoreGetItem } from "./secure-storage";
 import { ExpenseData, isPaidString } from "../util/expense";
 import { Traveller } from "../util/traveler";
@@ -16,6 +15,7 @@ import { computeDynamicDailyBudget } from "../util/budget";
 import type { TripData } from "../types/trip";
 import { settleTrip } from "../util/settlement";
 import { useTripTotalSpent } from "../hooks/useTripTotalSpent";
+import { hydrateTrip } from "../util/hydrate-trip";
 
 export type { TripData };
 
@@ -200,43 +200,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     setRefreshState(!refreshState);
   }
 
-  /**
-   * Migrates trip data from old settlement system (isPaidDate) to new system (isPaidTimestamp).
-   * Old system: "settled until today" - isPaidDate exists but means partial settlement
-   * New system: "settled everything" - isPaidTimestamp means all expenses before that timestamp are paid
-   * Migration: Convert isPaidDate to isPaidTimestamp, set isPaid to false (since old system was different)
-   */
-  function migrateTripSettlementData(trip: TripData): TripData {
-    // If trip has isPaidDate but no isPaidTimestamp, migrate it
-    if (trip.isPaidDate && !trip.isPaidTimestamp) {
-      try {
-        // Convert ISO string date to timestamp
-        const date = new Date(trip.isPaidDate);
-        if (!isNaN(date.getTime())) {
-          trip.isPaidTimestamp = date.getTime();
-          // Set isPaid to false because old system was "settled until today", not "settled everything"
-          trip.isPaid = isPaidString.notPaid;
-        }
-      } catch (error) {
-        safeLogError(error);
-      }
-    }
-    return trip;
-  }
-
-  function dropDeprecatedTripFields(trip: TripData): TripData {
-    // `totalSum` was a persisted trip-level total-spent number. We now derive totals
-    // from expenses (see #247) and drop this field on load to avoid stale state.
-    //
-    // Important: don't mutate the input object; callers may retain the reference.
-    if (!trip) return trip;
-    if (!("totalSum" in trip)) return trip;
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { totalSum: _deprecatedTotalSum, ...rest } = trip as any;
-    return rest as TripData;
-  }
-
   async function fetchAndSetTravellers(tripid: string): Promise<boolean> {
     await loadTravellersFromStorage();
     const { isFastEnough } = await isConnectionFastEnough();
@@ -271,30 +234,20 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       return;
     }
 
-    // Migrate trip data from old settlement system
-    const migratedTrip = dropDeprecatedTripFields(migrateTripSettlementData(trip));
+    const hydratedTrip = hydrateTrip({ ...trip, tripid });
 
     _setTripid(tripid);
-    setTripName(migratedTrip.tripName);
-    setTotalBudget(
-      migratedTrip.totalBudget
-        ? migratedTrip.totalBudget.toString()
-        : MAX_JS_NUMBER.toString()
-    );
-    setTripCurrency(migratedTrip.tripCurrency);
-    // negative Numbers are not allowed
-    if (Number(migratedTrip.dailyBudget) < 0) {
-      setdailyBudget("0.0001");
-    } else {
-      setdailyBudget(migratedTrip.dailyBudget.toString());
-    }
-    setStartDate(migratedTrip.startDate);
-    setEndDate(migratedTrip.endDate);
-    setIsPaid(migratedTrip.isPaid ?? isPaidString.notPaid);
-    setIsPaidDate(migratedTrip.isPaidDate);
-    setIsPaidTimestamp(migratedTrip.isPaidTimestamp);
+    setTripName(hydratedTrip.tripName);
+    setTotalBudget(hydratedTrip.totalBudget!);
+    setTripCurrency(hydratedTrip.tripCurrency);
+    setdailyBudget(hydratedTrip.dailyBudget!);
+    setStartDate(hydratedTrip.startDate);
+    setEndDate(hydratedTrip.endDate);
+    setIsPaid(hydratedTrip.isPaid!);
+    setIsPaidDate(hydratedTrip.isPaidDate!);
+    setIsPaidTimestamp(hydratedTrip.isPaidTimestamp);
     setIsLoading(false);
-    setIsDynamicDailyBudget(migratedTrip.isDynamicDailyBudget);
+    setIsDynamicDailyBudget(hydratedTrip.isDynamicDailyBudget ?? false);
     if (typeof trip.travellers[1] === "string") {
       setTravellers(trip.travellers);
     } else {
@@ -318,10 +271,8 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       if (!trip) throw new Error("no trip found");
       trip.tripid = tripid;
 
-      // Migrate trip data from old settlement system
-      const migratedTrip = dropDeprecatedTripFields(migrateTripSettlementData(trip));
-
-      await setCurrentTrip(tripid, migratedTrip);
+      const migratedTrip = hydrateTrip(trip);
+      await setCurrentTrip(tripid, trip);
 
       // If migration occurred, save migrated trip back to database and storage
       if (
@@ -402,38 +353,18 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   async function loadTripDataFromStorage() {
     const tripData: TripData = getMMKVObject(MMKV_KEYS.CURRENT_TRIP);
     if (tripData) {
-      // `totalSum` might still exist in persisted data from older app versions.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const hadDeprecatedTotalSum = "totalSum" in (tripData as any);
+      const migratedTrip = hydrateTrip(tripData);
 
-      // Migrate trip data from old settlement system
-      const migratedTrip = dropDeprecatedTripFields(
-        migrateTripSettlementData(tripData)
-      );
+      await setCurrentTrip(tripData.tripid ?? "", tripData);
 
-      setTripName(migratedTrip.tripName);
-      setTotalBudget(
-        migratedTrip.totalBudget
-          ? migratedTrip.totalBudget.toString()
-          : MAX_JS_NUMBER.toString()
-      );
-
-      setTripCurrency(migratedTrip.tripCurrency);
-      setdailyBudget(migratedTrip.dailyBudget.toString());
-      setIsPaid(migratedTrip.isPaid ?? isPaidString.notPaid);
-      setIsPaidDate(migratedTrip.isPaidDate ?? "");
-      setIsPaidTimestamp(migratedTrip.isPaidTimestamp);
-      setStartDate(migratedTrip.startDate ?? "");
-      setEndDate(migratedTrip.endDate ?? "");
       try {
         await loadTravellersFromStorage();
       } catch (error) {
         safeLogError(error);
       }
-      setIsLoading(false);
 
-      // If migration occurred, save migrated trip back to storage.
-      // Also persist the cleanup of deprecated fields (e.g. legacy `totalSum`).
       const didMigrateSettlementData =
         tripData.isPaidDate &&
         !tripData.isPaidTimestamp &&

--- a/TravelCostApp/util/hydrate-trip.ts
+++ b/TravelCostApp/util/hydrate-trip.ts
@@ -5,11 +5,14 @@ import { isPaidString } from "./expense";
 export function hydrateTrip(raw: TripData): TripData {
   if (!raw) return raw;
 
-  const trip: TripData = { ...raw };
-  if ("totalSum" in trip) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (trip as any).totalSum;
-  }
+  const trip: TripData =
+    "totalSum" in raw
+      ? (() => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+          const { totalSum, ...rest } = raw as any;
+          return rest as TripData;
+        })()
+      : { ...raw };
 
   if (trip.isPaidDate && !trip.isPaidTimestamp) {
     const date = new Date(trip.isPaidDate);

--- a/TravelCostApp/util/hydrate-trip.ts
+++ b/TravelCostApp/util/hydrate-trip.ts
@@ -1,0 +1,37 @@
+import { MAX_JS_NUMBER } from "../confAppConstants";
+import type { TripData } from "../types/trip";
+import { isPaidString } from "./expense";
+
+export function hydrateTrip(raw: TripData): TripData {
+  if (!raw) return raw;
+
+  const trip: TripData = { ...raw };
+  if ("totalSum" in trip) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (trip as any).totalSum;
+  }
+
+  if (trip.isPaidDate && !trip.isPaidTimestamp) {
+    const date = new Date(trip.isPaidDate);
+    if (!isNaN(date.getTime())) {
+      trip.isPaidTimestamp = date.getTime();
+      trip.isPaid = isPaidString.notPaid;
+    }
+  }
+
+  const totalBudget = trip.totalBudget
+    ? trip.totalBudget.toString()
+    : MAX_JS_NUMBER.toString();
+
+  const dailyBudgetRaw = trip.dailyBudget?.toString() ?? "0";
+  const dailyBudget =
+    Number(dailyBudgetRaw) < 0 ? "0.0001" : dailyBudgetRaw;
+
+  return {
+    ...trip,
+    totalBudget,
+    dailyBudget,
+    isPaid: trip.isPaid ?? isPaidString.notPaid,
+    isPaidDate: trip.isPaidDate ?? "",
+  };
+}


### PR DESCRIPTION
## Summary
- Add pure `hydrateTrip` to normalize raw trip data (settlement migration, drop `totalSum`, budget fallback/clamp).
- Route all three `TripContext` hydration paths through it so network, set-current, and storage loads produce the same active-trip fields.
- Fix storage load omitting `tripid` and `isDynamicDailyBudget`.

## Test plan
- [x] `pnpm test -- __tests__/util/hydrate-trip.test.ts`
- [x] `pnpm test -- __tests__/store/trip-context-storage.test.tsx`

Closes #323