### PR TITLE
Fix new-expense country default when lastCountry differs from trip

### DIFF
--- a/TravelCostApp/__tests__/components/expense-form.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-form.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
@@ -48,6 +48,11 @@ jest.mock("../../store/secure-storage", () => ({
 
 jest.mock("../../util/currencyExchange", () => ({
   getRate: jest.fn(async () => 1),
+}));
+
+jest.mock("../../components/Premium/PremiumConstants", () => ({
+  isPremiumMember: jest.fn(async () => true),
+  ENTITLEMENT_ID: "premium",
 }));
 
 jest.mock("../../components/UI/DatePickerContainer", () => {
@@ -125,6 +130,7 @@ import { i18n } from "../../i18n/i18n";
 import { makeExpense } from "../fixtures/expense";
 import { AppProviders, renderWithAppProviders } from "../fixtures/app-providers";
 import { Alert } from "react-native";
+import { getExpenseDraft } from "../../store/mmkv";
 
 function renderNewExpenseForm(
   overrides: Parameters<typeof renderWithAppProviders>[1] = {}
@@ -176,7 +182,9 @@ function renderNewExpenseForm(
   );
 }
 
-function renderNewExpenseWithDeferredLastCountry() {
+function renderNewExpenseWithDeferredLastCountry(
+  onSubmit: jest.Mock = jest.fn(async () => {})
+) {
   const navigation = {
     navigate: jest.fn(),
     pop: jest.fn(),
@@ -211,6 +219,8 @@ function renderNewExpenseWithDeferredLastCountry() {
             userName: "Alice",
             lastCountry,
             lastCurrency,
+            setLastCountry: jest.fn(),
+            setLastCurrency: jest.fn(),
             setPeriodString: jest.fn(),
             isSendingOfflineQueueMutex: false,
             setIsSendingOfflineQueueMutex: jest.fn(),
@@ -226,12 +236,12 @@ function renderNewExpenseWithDeferredLastCountry() {
       >
         <ExpenseForm
           onCancel={jest.fn()}
-          onSubmit={jest.fn(async () => {})}
+          onSubmit={onSubmit}
           submitButtonLabel={i18n.t("add")}
           isEditing={false}
           defaultValues={makeExpense({
-            amount: 0,
-            description: "",
+            amount: 25,
+            description: "Hotel stay",
             whoPaid: "",
             splitList: [],
             listEQUAL: [],
@@ -378,5 +388,60 @@ describe("ExpenseForm", () => {
     });
 
     alertSpy.mockRestore();
+  });
+
+  it("submits latest-used country on advanced save after secure storage loads", async () => {
+    jest.useFakeTimers();
+    const onSubmit = jest.fn(async () => {});
+    const screen = renderNewExpenseWithDeferredLastCountry(onSubmit);
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expense-form-country-flag")).toHaveTextContent(
+        "US"
+      );
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getAllByText(i18n.t("add")).pop()!);
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(onSubmit).toHaveBeenCalled();
+    expect(onSubmit.mock.calls[0][0].country).toBe("US");
+    jest.useRealTimers();
+  });
+
+  it("applies latest-used country after restoring a draft with an empty country", async () => {
+    const draftExpense = makeExpense({
+      amount: 25,
+      description: "Hotel stay",
+      country: "",
+      currency: "EUR",
+    });
+    (getExpenseDraft as jest.Mock).mockReturnValue(draftExpense);
+
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _message, buttons) => {
+        const restoreButton = buttons?.find(
+          (button) => button.text === i18n.t("restore")
+        );
+        restoreButton?.onPress?.();
+      });
+
+    const screen = renderNewExpenseWithDeferredLastCountry();
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expense-form-country-flag")).toHaveTextContent(
+        "US"
+      );
+    });
+
+    alertSpy.mockRestore();
+    (getExpenseDraft as jest.Mock).mockReturnValue(undefined);
   });
 });

--- a/TravelCostApp/__tests__/components/expense-form.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-form.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { fireEvent, waitFor } from "@testing-library/react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
@@ -50,8 +50,63 @@ jest.mock("../../util/currencyExchange", () => ({
   getRate: jest.fn(async () => 1),
 }));
 
-jest.mock("../../components/UI/DatePickerContainer", () => () => null);
-jest.mock("../../components/UI/DatePickerModal", () => () => null);
+jest.mock("../../components/UI/DatePickerContainer", () => {
+  const React = require("react");
+  const { Pressable, Text } = require("react-native");
+  return function MockDatePickerContainer({
+    openDatePickerRange,
+  }: {
+    openDatePickerRange?: () => void;
+  }) {
+    return React.createElement(
+      Pressable,
+      { testID: "open-date-range", onPress: openDatePickerRange },
+      React.createElement(Text, null, "open-range")
+    );
+  };
+});
+
+jest.mock("../../components/UI/DatePickerModal", () => {
+  const React = require("react");
+  const { Pressable, Text } = require("react-native");
+  return function MockDatePickerModal({
+    onConfirmRange,
+  }: {
+    onConfirmRange?: (expenseOut: {
+      startDate: Date;
+      endDate: Date;
+    }) => void;
+  }) {
+    return React.createElement(
+      Pressable,
+      {
+        testID: "confirm-ranged-dates",
+        onPress: () =>
+          onConfirmRange?.({
+            startDate: new Date("2026-01-15T12:00:00.000Z"),
+            endDate: new Date("2026-01-20T12:00:00.000Z"),
+          }),
+      },
+      React.createElement(Text, null, "confirm-range")
+    );
+  };
+});
+
+jest.mock("../../components/ExpensesOutput/ExpenseCountryFlag", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  return function MockExpenseCountryFlag({
+    countryName,
+  }: {
+    countryName?: string;
+  }) {
+    return React.createElement(
+      Text,
+      { testID: "expense-form-country-flag" },
+      countryName ?? ""
+    );
+  };
+});
 
 jest.mock("../../components/Currency/CurrencyPicker", () => {
   const React = require("react");
@@ -68,7 +123,8 @@ jest.mock("../../components/Currency/CurrencyPicker", () => {
 import ExpenseForm from "../../components/ManageExpense/ExpenseForm";
 import { i18n } from "../../i18n/i18n";
 import { makeExpense } from "../fixtures/expense";
-import { renderWithAppProviders } from "../fixtures/app-providers";
+import { AppProviders, renderWithAppProviders } from "../fixtures/app-providers";
+import { Alert } from "react-native";
 
 function renderNewExpenseForm(
   overrides: Parameters<typeof renderWithAppProviders>[1] = {}
@@ -118,6 +174,80 @@ function renderNewExpenseForm(
       },
     }
   );
+}
+
+function renderNewExpenseWithDeferredLastCountry() {
+  const navigation = {
+    navigate: jest.fn(),
+    pop: jest.fn(),
+    popToTop: jest.fn(),
+  };
+  const tripExpense = makeExpense({
+    id: "e1",
+    currency: "EUR",
+    country: "DE",
+    calcAmount: 75,
+  });
+
+  function Host() {
+    const [lastCountry, setLastCountry] = React.useState("");
+    const [lastCurrency, setLastCurrency] = React.useState("");
+
+    React.useEffect(() => {
+      setLastCountry("US");
+      setLastCurrency("USD");
+    }, []);
+
+    return (
+      <AppProviders
+        overrides={{
+          trip: {
+            tripid: "t1",
+            tripCurrency: "EUR",
+            travellers: ["Alice", "Bob"],
+            fetchAndSetTravellers: jest.fn(async () => {}),
+          },
+          user: {
+            userName: "Alice",
+            lastCountry,
+            lastCurrency,
+            setPeriodString: jest.fn(),
+            isSendingOfflineQueueMutex: false,
+            setIsSendingOfflineQueueMutex: jest.fn(),
+          },
+          expenses: {
+            expenses: [tripExpense],
+            isSyncing: false,
+            updateExpenseId: undefined,
+            getRecentExpenses: () => [tripExpense],
+            loadExpensesFromStorage: jest.fn(async () => {}),
+          },
+        }}
+      >
+        <ExpenseForm
+          onCancel={jest.fn()}
+          onSubmit={jest.fn(async () => {})}
+          submitButtonLabel={i18n.t("add")}
+          isEditing={false}
+          defaultValues={makeExpense({
+            amount: 0,
+            description: "",
+            whoPaid: "",
+            splitList: [],
+            listEQUAL: [],
+          })}
+          pickedCat="food"
+          navigation={navigation as any}
+          editedExpenseId="TEMP_EXPENSE_ID"
+          newCat={false}
+          iconName="food"
+          dateISO=""
+        />
+      </AppProviders>
+    );
+  }
+
+  return render(<Host />);
 }
 
 describe("ExpenseForm", () => {
@@ -211,5 +341,42 @@ describe("ExpenseForm", () => {
     await waitFor(() => {
       expect(screen.getByText("USD | $")).toBeTruthy();
     });
+  });
+
+  it("applies latest-used country after secure storage loads on a new expense", async () => {
+    const screen = renderNewExpenseWithDeferredLastCountry();
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expense-form-country-flag")).toHaveTextContent(
+        "US"
+      );
+    });
+  });
+
+  it("keeps latest-used country after confirming a ranged date span", async () => {
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _message, buttons) => {
+        const splitButton = buttons?.find(
+          (button) => button.text === i18n.t("splitUpExpenses")
+        );
+        splitButton?.onPress?.();
+      });
+
+    const screen = renderNewExpenseWithDeferredLastCountry();
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+    fireEvent.press(screen.getByTestId("open-date-range"));
+    fireEvent.press(screen.getByTestId("confirm-ranged-dates"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expense-form-country-flag")).toHaveTextContent(
+        "US"
+      );
+    });
+
+    alertSpy.mockRestore();
   });
 });

--- a/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
@@ -121,6 +121,17 @@ describe("resolveLoadedLastCountryIfStale", () => {
       })
     ).toBeNull();
   });
+
+  it("returns latest-used country when a restored draft left country empty", () => {
+    expect(
+      resolveLoadedLastCountryIfStale({
+        isEditing: false,
+        lastCountry: "US",
+        currentCountry: "",
+        mostRecentExpenseCountry: "DE",
+      })
+    ).toBe("US");
+  });
 });
 
 describe("resolveLoadedLastCurrencyIfStale", () => {
@@ -134,6 +145,18 @@ describe("resolveLoadedLastCurrencyIfStale", () => {
         mostRecentExpenseCurrency: "EUR",
       })
     ).toBe("USD");
+  });
+
+  it("returns null when the user already changed currency away from trip defaults", () => {
+    expect(
+      resolveLoadedLastCurrencyIfStale({
+        isEditing: false,
+        lastCurrency: "USD",
+        currentCurrency: "GBP",
+        tripCurrency: "EUR",
+        mostRecentExpenseCurrency: "EUR",
+      })
+    ).toBeNull();
   });
 });
 

--- a/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
@@ -1,8 +1,12 @@
 import {
   applyFieldValidityToInputs,
+  countriesRepresentSamePlace,
+  countryLabelForPicker,
   resolveAmountValue,
   resolveDefaultNewExpenseCountry,
   resolveDefaultNewExpenseCurrency,
+  resolveLoadedLastCountryIfStale,
+  resolveLoadedLastCurrencyIfStale,
 } from "../../util/expense-form-inputs";
 import type { ExpenseFormInputsState } from "../../util/expense-form-inputs";
 
@@ -76,6 +80,60 @@ describe("resolveDefaultNewExpenseCountry", () => {
         mostRecentExpenseCountry: "DE",
       })
     ).toBe("US");
+  });
+});
+
+describe("countriesRepresentSamePlace", () => {
+  it("treats ISO codes and English names as the same country", () => {
+    expect(countriesRepresentSamePlace("DE", "Germany")).toBe(true);
+    expect(countriesRepresentSamePlace("US", "United States of America")).toBe(
+      true
+    );
+  });
+});
+
+describe("countryLabelForPicker", () => {
+  it("maps stored ISO codes to English picker labels", () => {
+    expect(countryLabelForPicker("DE")).toBe("Germany");
+    expect(countryLabelForPicker("US")).toBe("United States of America");
+  });
+});
+
+describe("resolveLoadedLastCountryIfStale", () => {
+  it("returns latest-used country when the form still shows trip defaults", () => {
+    expect(
+      resolveLoadedLastCountryIfStale({
+        isEditing: false,
+        lastCountry: "US",
+        currentCountry: "DE",
+        mostRecentExpenseCountry: "DE",
+      })
+    ).toBe("US");
+  });
+
+  it("returns null when the user already changed country away from trip defaults", () => {
+    expect(
+      resolveLoadedLastCountryIfStale({
+        isEditing: false,
+        lastCountry: "US",
+        currentCountry: "France",
+        mostRecentExpenseCountry: "DE",
+      })
+    ).toBeNull();
+  });
+});
+
+describe("resolveLoadedLastCurrencyIfStale", () => {
+  it("returns latest-used currency when the form still shows trip defaults", () => {
+    expect(
+      resolveLoadedLastCurrencyIfStale({
+        isEditing: false,
+        lastCurrency: "USD",
+        currentCurrency: "EUR",
+        tripCurrency: "EUR",
+        mostRecentExpenseCurrency: "EUR",
+      })
+    ).toBe("USD");
   });
 });
 

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -54,8 +54,11 @@ import { useRangedMode } from "../../hooks/useRangedMode";
 import { useExpenseFx } from "../../hooks/useExpenseFx";
 import { useExpenseFormInputs } from "../../hooks/useExpenseFormInputs";
 import {
+  countryLabelForPicker,
   resolveDefaultNewExpenseCountry,
   resolveDefaultNewExpenseCurrency,
+  resolveLoadedLastCountryIfStale,
+  resolveLoadedLastCurrencyIfStale,
 } from "../../util/expense-form-inputs";
 import { useCategoryAutomap } from "../../hooks/useCategoryAutomap";
 import {
@@ -261,7 +264,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     defaultNewExpenseCurrency
   );
   const [countryPickerValue, setCountryPickerValue] = useState(
-    defaultNewExpenseCountry
+    () => countryLabelForPicker(defaultNewExpenseCountry)
   );
   const [loadingTravellers, setLoadingTravellers] = useState(
     !tripCtx.travellers && tripCtx.travellers?.length < 1
@@ -314,13 +317,17 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
         isValid: true,
       },
       country: {
-        value: editingValues ? editingValues.country : defaultNewExpenseCountry,
+        value:
+          isEditing && editingValues
+            ? editingValues.country
+            : defaultNewExpenseCountry,
         isValid: true,
       },
       currency: {
-        value: editingValues
-          ? editingValues.currency
-          : defaultNewExpenseCurrency,
+        value:
+          isEditing && editingValues
+            ? editingValues.currency
+            : defaultNewExpenseCurrency,
         isValid: true,
       },
       whoPaid: {
@@ -329,6 +336,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       },
     }),
     [
+      isEditing,
       editingValues,
       defaultNewExpenseCountry,
       defaultNewExpenseCurrency,
@@ -359,63 +367,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       autoExpenseLinearSplitAdjustRef.current(inputIdentifier, enteredValue);
     },
   });
-
-  useEffect(() => {
-    if (isEditing || !userCtx.lastCurrency) return;
-
-    const preferred = resolveDefaultNewExpenseCurrency({
-      lastCurrency: userCtx.lastCurrency,
-      tripCurrency: tripCtx.tripCurrency,
-      mostRecentExpenseCurrency: mostRecentExpense?.currency,
-    });
-    const beforeLastCurrencyLoaded = resolveDefaultNewExpenseCurrency({
-      lastCurrency: "",
-      tripCurrency: tripCtx.tripCurrency,
-      mostRecentExpenseCurrency: mostRecentExpense?.currency,
-    });
-
-    if (
-      inputs.currency.value === beforeLastCurrencyLoaded &&
-      preferred !== inputs.currency.value
-    ) {
-      inputChangedHandler("currency", preferred);
-      setCurrencyPickerValue(preferred);
-    }
-  }, [
-    isEditing,
-    inputChangedHandler,
-    inputs.currency.value,
-    mostRecentExpense?.currency,
-    tripCtx.tripCurrency,
-    userCtx.lastCurrency,
-  ]);
-
-  useEffect(() => {
-    if (isEditing || !userCtx.lastCountry) return;
-
-    const preferred = resolveDefaultNewExpenseCountry({
-      lastCountry: userCtx.lastCountry,
-      mostRecentExpenseCountry: mostRecentExpense?.country,
-    });
-    const beforeLastCountryLoaded = resolveDefaultNewExpenseCountry({
-      lastCountry: "",
-      mostRecentExpenseCountry: mostRecentExpense?.country,
-    });
-
-    if (
-      inputs.country.value === beforeLastCountryLoaded &&
-      preferred !== inputs.country.value
-    ) {
-      inputChangedHandler("country", preferred);
-      setCountryPickerValue(preferred);
-    }
-  }, [
-    isEditing,
-    inputChangedHandler,
-    inputs.country.value,
-    mostRecentExpense?.country,
-    userCtx.lastCountry,
-  ]);
 
   const [showDatePickerRange, setShowDatePickerRange] = useState(false);
   const [startDate, setStartDate] = useState(
@@ -1054,6 +1005,46 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     },
     [baseInputChangedHandler, debouncedAutoCategory, scheduleDraftSave]
   );
+
+  useEffect(() => {
+    const preferred = resolveLoadedLastCurrencyIfStale({
+      isEditing,
+      lastCurrency: userCtx.lastCurrency,
+      currentCurrency: inputs.currency.value,
+      tripCurrency: tripCtx.tripCurrency,
+      mostRecentExpenseCurrency: mostRecentExpense?.currency,
+    });
+    if (preferred) {
+      inputChangedHandler("currency", preferred);
+      setCurrencyPickerValue(preferred);
+    }
+  }, [
+    isEditing,
+    inputChangedHandler,
+    inputs.currency.value,
+    mostRecentExpense?.currency,
+    tripCtx.tripCurrency,
+    userCtx.lastCurrency,
+  ]);
+
+  useEffect(() => {
+    const preferred = resolveLoadedLastCountryIfStale({
+      isEditing,
+      lastCountry: userCtx.lastCountry,
+      currentCountry: inputs.country.value,
+      mostRecentExpenseCountry: mostRecentExpense?.country,
+    });
+    if (preferred) {
+      inputChangedHandler("country", preferred);
+      setCountryPickerValue(countryLabelForPicker(preferred));
+    }
+  }, [
+    isEditing,
+    inputChangedHandler,
+    inputs.country.value,
+    mostRecentExpense?.country,
+    userCtx.lastCountry,
+  ]);
 
   const openTravellerMultiPicker = useCallback(() => {
     if (!editingValues) {

--- a/TravelCostApp/util/expense-form-inputs.ts
+++ b/TravelCostApp/util/expense-form-inputs.ts
@@ -1,4 +1,6 @@
 import type { ExpenseFieldValidity } from "./expense-form-submit";
+import { countryToAlpha2 } from "country-to-iso";
+import i18nIsoCountries from "i18n-iso-countries";
 
 export type ExpenseFormInputField = {
   value: string;
@@ -37,6 +39,101 @@ export function resolveDefaultNewExpenseCountry(
     return input.lastCountry;
   }
   return input.mostRecentExpenseCountry?.trim() ?? "";
+}
+
+export function countriesRepresentSamePlace(a: string, b: string): boolean {
+  const normalize = (value: string): string => {
+    const trimmed = value?.trim() ?? "";
+    if (!trimmed) return "";
+    if (trimmed.length === 2) {
+      return trimmed.toUpperCase();
+    }
+    const alpha2 = countryToAlpha2(trimmed);
+    return alpha2?.toUpperCase() ?? trimmed.toLowerCase();
+  };
+
+  return normalize(a) === normalize(b);
+}
+
+/** English label used by CountryPicker for a stored country code or name. */
+export function countryLabelForPicker(country: string): string {
+  const trimmed = country?.trim() ?? "";
+  if (!trimmed) return "";
+  if (trimmed.length === 2) {
+    return i18nIsoCountries.getName(trimmed.toUpperCase(), "en") ?? trimmed;
+  }
+  return trimmed;
+}
+
+export type LoadedLastCountrySyncInput = {
+  isEditing: boolean;
+  lastCountry: string;
+  currentCountry: string;
+  mostRecentExpenseCountry?: string;
+};
+
+/** Country to apply after secure-storage lastCountry loads on a still-default form. */
+export function resolveLoadedLastCountryIfStale(
+  input: LoadedLastCountrySyncInput
+): string | null {
+  if (input.isEditing || !input.lastCountry?.trim()) {
+    return null;
+  }
+
+  const preferred = resolveDefaultNewExpenseCountry({
+    lastCountry: input.lastCountry,
+    mostRecentExpenseCountry: input.mostRecentExpenseCountry,
+  });
+  const beforeLastCountryLoaded = resolveDefaultNewExpenseCountry({
+    lastCountry: "",
+    mostRecentExpenseCountry: input.mostRecentExpenseCountry,
+  });
+
+  if (
+    countriesRepresentSamePlace(input.currentCountry, beforeLastCountryLoaded) &&
+    !countriesRepresentSamePlace(preferred, input.currentCountry)
+  ) {
+    return preferred;
+  }
+
+  return null;
+}
+
+export type LoadedLastCurrencySyncInput = {
+  isEditing: boolean;
+  lastCurrency: string;
+  currentCurrency: string;
+  tripCurrency: string;
+  mostRecentExpenseCurrency?: string;
+};
+
+/** Currency to apply after secure-storage lastCurrency loads on a still-default form. */
+export function resolveLoadedLastCurrencyIfStale(
+  input: LoadedLastCurrencySyncInput
+): string | null {
+  if (input.isEditing || !input.lastCurrency?.trim()) {
+    return null;
+  }
+
+  const preferred = resolveDefaultNewExpenseCurrency({
+    lastCurrency: input.lastCurrency,
+    tripCurrency: input.tripCurrency,
+    mostRecentExpenseCurrency: input.mostRecentExpenseCurrency,
+  });
+  const beforeLastCurrencyLoaded = resolveDefaultNewExpenseCurrency({
+    lastCurrency: "",
+    tripCurrency: input.tripCurrency,
+    mostRecentExpenseCurrency: input.mostRecentExpenseCurrency,
+  });
+
+  if (
+    input.currentCurrency === beforeLastCurrencyLoaded &&
+    preferred !== input.currentCurrency
+  ) {
+    return preferred;
+  }
+
+  return null;
 }
 
 export type ExpenseFormInputsState = {

--- a/TravelCostApp/util/expense-form-inputs.ts
+++ b/TravelCostApp/util/expense-form-inputs.ts
@@ -88,9 +88,12 @@ export function resolveLoadedLastCountryIfStale(
     lastCountry: "",
     mostRecentExpenseCountry: input.mostRecentExpenseCountry,
   });
+  const stillOnTripDefault =
+    countriesRepresentSamePlace(input.currentCountry, beforeLastCountryLoaded) ||
+    (!input.currentCountry?.trim() && beforeLastCountryLoaded?.trim());
 
   if (
-    countriesRepresentSamePlace(input.currentCountry, beforeLastCountryLoaded) &&
+    stillOnTripDefault &&
     !countriesRepresentSamePlace(preferred, input.currentCountry)
   ) {
     return preferred;


### PR DESCRIPTION
## Summary
- Fix new-expense country/currency init to use trip and latest-used defaults instead of the empty `defaultValues` shell passed for new expenses.
- Sync country when secure-storage `lastCountry` loads after mount, including ISO code vs English name matching and correct CountryPicker labels.
- Add regression tests for deferred `lastCountry` load and ranged date-span confirmation.

## Test plan
- [x] `pnpm test -- expense-form`
- [ ] Add a new expense on a trip whose recent expenses use a different country than `lastCountry`
- [ ] Open advanced options, pick a multi-day date range, confirm split/duplicate — country should stay on latest-used value