### PR TITLE
Fix split list input dropping comma decimal separators

### DIFF
--- a/TravelCostApp/__tests__/hooks/use-split-editor.test.ts
+++ b/TravelCostApp/__tests__/hooks/use-split-editor.test.ts
@@ -61,6 +61,17 @@ describe("useSplitEditor", () => {
     jest.clearAllMocks();
   });
 
+  it("preserves a trailing decimal while editing a split amount", () => {
+    const { result } = renderSplitEditor();
+
+    act(() => {
+      result.current.inputSplitListHandler(0, { userName: "A" }, "12.");
+    });
+
+    expect(result.current.splitList[0].amountInput).toBe("12.");
+    expect(result.current.splitList[0].amount).toBe(12);
+  });
+
   it("updates splitList and splitListValid when a split amount is edited", () => {
     const initialSplitList = resetEditOrder([
       makeSplit({ userName: "A", amount: 30, editOrder: 0 }),

--- a/TravelCostApp/__tests__/util/expense-form-draft.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-draft.test.ts
@@ -64,6 +64,23 @@ describe("toExpenseDraft", () => {
       buildExpenseData(snapshot).amount
     );
   });
+
+  it("strips ephemeral split form fields before autosave persistence", () => {
+    const draft = toExpenseDraft(
+      makeExpenseFormSnapshot({
+        splitList: [
+          {
+            userName: "Alice",
+            amount: 12,
+            amountInput: "12.",
+            editOrder: 0,
+          },
+        ],
+      })
+    );
+
+    expect(draft.splitList).toEqual([{ userName: "Alice", amount: 12 }]);
+  });
 });
 
 describe("applyDraftToForm", () => {

--- a/TravelCostApp/__tests__/util/expense-form-submit.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-submit.test.ts
@@ -39,6 +39,23 @@ describe("buildExpenseData", () => {
     expect(built.endDate).toEqual(dateFromIso("2026-01-16"));
   });
 
+  it("strips ephemeral split form fields from persisted splitList", () => {
+    const built = buildExpenseData(
+      makeExpenseFormSnapshot({
+        splitList: [
+          {
+            userName: "Alice",
+            amount: 12,
+            amountInput: "12.",
+            editOrder: 0,
+          },
+        ],
+      })
+    );
+
+    expect(built.splitList).toEqual([{ userName: "Alice", amount: 12 }]);
+  });
+
   it("uses pickedCat for category when newCat is true", () => {
     const built = buildExpenseData(
       makeExpenseFormSnapshot({

--- a/TravelCostApp/__tests__/util/split-edit-actions.test.ts
+++ b/TravelCostApp/__tests__/util/split-edit-actions.test.ts
@@ -1,6 +1,8 @@
 import {
   applySplitEdit,
+  parseSplitAmountInput,
   removeFromSplit,
+  splitAmountDisplayValue,
 } from "../../util/split";
 import type { Split } from "../../util/expense";
 
@@ -8,11 +10,41 @@ function makeSplit(overrides: Partial<Split> & Pick<Split, "userName">): Split {
   return {
     userName: overrides.userName,
     amount: overrides.amount ?? 0,
+    amountInput: overrides.amountInput,
     whoPaid: overrides.whoPaid,
     rate: overrides.rate,
     editOrder: overrides.editOrder,
   };
 }
+
+describe("parseSplitAmountInput", () => {
+  it("preserves a trailing decimal separator while the user is still typing", () => {
+    expect(parseSplitAmountInput("12.")).toEqual({
+      amount: 12,
+      amountInput: "12.",
+    });
+  });
+
+  it("normalizes comma decimal separators to dot notation", () => {
+    expect(parseSplitAmountInput("12,5")).toEqual({ amount: 12.5 });
+  });
+
+  it("treats a lone decimal separator as zero with visible input", () => {
+    expect(parseSplitAmountInput(".")).toEqual({ amount: 0, amountInput: "." });
+  });
+});
+
+describe("splitAmountDisplayValue", () => {
+  it("shows in-progress decimal text instead of coercing it away", () => {
+    expect(
+      splitAmountDisplayValue({
+        userName: "A",
+        amount: 12,
+        amountInput: "12.",
+      })
+    ).toBe("12.");
+  });
+});
 
 describe("applySplitEdit", () => {
   it("bumps edit order on the edited split, recalculates remainder, and reports validity for EXACT", () => {
@@ -37,6 +69,27 @@ describe("applySplitEdit", () => {
       makeSplit({ userName: "C", amount: 40 }),
     ]);
     expect(valid).toBe(true);
+  });
+
+  it("keeps a trailing decimal on the edited split while recalculating others", () => {
+    const splitList: Split[] = [
+      makeSplit({ userName: "A", amount: 30, editOrder: 0 }),
+      makeSplit({ userName: "B", amount: 20, editOrder: 1 }),
+      makeSplit({ userName: "C", amount: 50 }),
+    ];
+
+    const { splitList: result } = applySplitEdit(
+      splitList,
+      0,
+      "A",
+      "12.",
+      100,
+      "EXACT"
+    );
+
+    expect(result[0]).toEqual(
+      makeSplit({ userName: "A", amount: 12, amountInput: "12.", editOrder: 0 })
+    );
   });
 
   it("reports invalid when a split amount is cleared to zero", () => {

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -43,6 +43,7 @@ import {
   calcSplitList,
   recalcSplitsWithEditOrder,
   resetEditOrder,
+  splitAmountDisplayValue,
   splitType,
   splitTypesDropdown,
   travellerToDropdown,
@@ -1918,7 +1919,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
                         ></View>
                       }
                       renderItem={(itemData) => {
-                        const splitValue = itemData.item.amount.toString();
+                        const splitValue = splitAmountDisplayValue(itemData.item);
                         return (
                           <View style={styles.splitEditorCard}>
                             <View
@@ -2005,7 +2006,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
                                     itemData.index,
                                     itemData.item
                                   ),
-                                  value: splitValue ? splitValue : "",
+                                  value: splitValue,
                                 }}
                               ></Input>
                               <Text

--- a/TravelCostApp/util/expense-form-draft.ts
+++ b/TravelCostApp/util/expense-form-draft.ts
@@ -52,7 +52,7 @@ export function toExpenseDraft(
     whoPaid: snapshot.whoPaid as string,
     splitType: snapshot.splitType,
     listEQUAL: snapshot.listEQUAL,
-    splitList: snapshot.splitList,
+    splitList: resetEditOrder(snapshot.splitList),
     duplOrSplit: snapshot.duplOrSplit,
     calcAmount: resolvedAmount,
     paidBack: snapshot.paidBack,

--- a/TravelCostApp/util/expense-form-submit.ts
+++ b/TravelCostApp/util/expense-form-submit.ts
@@ -7,7 +7,7 @@ import {
   paidBackStatus,
   Split,
 } from "./expense";
-import { splitType } from "./split";
+import { resetEditOrder, splitType } from "./split";
 
 export type ExpenseFormSnapshot = {
   uid: string;
@@ -60,7 +60,7 @@ function sharedExpenseCore(snapshot: ExpenseFormSnapshot) {
     uid: snapshot.uid,
     amount: +snapshot.amountValue,
     splitType: snapshot.splitType,
-    splitList: snapshot.splitList,
+    splitList: resetEditOrder(snapshot.splitList),
     iconName: snapshot.iconName,
     paidBack: snapshot.paidBack,
     isSpecialExpense: snapshot.isSpecialExpense,

--- a/TravelCostApp/util/expense.ts
+++ b/TravelCostApp/util/expense.ts
@@ -180,6 +180,8 @@ export function toExpenseOnline(expense: ExpenseData): ExpenseDataOnline {
 export interface Split {
   userName: string;
   amount: number;
+  /** Raw amount text while the user is mid-decimal entry in the expense form. */
+  amountInput?: string;
   whoPaid?: string;
   rate?: number;
   editOrder?: number; // 0 = most recent edit, higher = older edits, undefined = never edited

--- a/TravelCostApp/util/split.ts
+++ b/TravelCostApp/util/split.ts
@@ -196,9 +196,43 @@ export function recalcSplitsWithEditOrder(
 export function resetEditOrder(splits: Split[]): Split[] {
   if (!splits) return [];
   return splits.map((split) => {
-    const { editOrder, ...splitWithoutOrder } = split;
+    const { editOrder, amountInput, ...splitWithoutOrder } = split;
     return splitWithoutOrder;
   });
+}
+
+/** Parses split amount field text into a numeric amount and optional in-progress display text. */
+export function parseSplitAmountInput(
+  value: string | number
+): { amount: number; amountInput?: string } {
+  if (typeof value === "number") {
+    return { amount: value };
+  }
+
+  const normalized = value.replace(/,/g, ".");
+  if (normalized === "") {
+    return { amount: 0, amountInput: "" };
+  }
+  if (normalized === ".") {
+    return { amount: 0, amountInput: "." };
+  }
+  if (normalized.endsWith(".")) {
+    const whole = normalized.slice(0, -1);
+    return {
+      amount: whole === "" ? 0 : Number(whole) || 0,
+      amountInput: normalized,
+    };
+  }
+
+  return { amount: Number(normalized) || 0 };
+}
+
+/** Value shown in the split amount TextInput while editing. */
+export function splitAmountDisplayValue(split: Split): string {
+  if (split.amountInput !== undefined) {
+    return split.amountInput;
+  }
+  return split.amount ? split.amount.toString() : "";
 }
 
 /**
@@ -213,7 +247,7 @@ export function applySplitEdit(
   amount: number,
   splitType: splitType
 ): { splitList: Split[]; valid: boolean } {
-  const tempList = splitList.map((split) => ({ ...split }));
+  const tempList = splitList.map((split) => ({ ...split, amountInput: undefined }));
 
   tempList.forEach((split, i) => {
     if (i === index) {
@@ -223,11 +257,15 @@ export function applySplitEdit(
     }
   });
 
+  const parsed = parseSplitAmountInput(value);
   tempList[index] = {
     ...tempList[index],
-    amount: Number(value) || 0,
+    amount: parsed.amount,
     userName,
     editOrder: 0,
+    ...(parsed.amountInput !== undefined
+      ? { amountInput: parsed.amountInput }
+      : {}),
   };
 
   const recalculatedList = recalcSplitsWithEditOrder(tempList, amount);


### PR DESCRIPTION
## Summary
- Preserve in-progress decimal text (`amountInput`) while editing EXACT split amounts so trailing commas/dots are not coerced away mid-entry
- Parse split amount input with `parseSplitAmountInput` and display via `splitAmountDisplayValue`
- Strip ephemeral split form fields on submit via `resetEditOrder`

## Test plan
- [x] `pnpm test` (480 tests pass)
- [ ] On device: open expense form → EXACT split → type `12,5` in a split row and confirm it stays visible while typing
- [ ] Confirm saved expense stores numeric split amounts without `amountInput`