### PR TITLE
Unify country and currency picker shortcuts from trip expenses

### DIFF
--- a/TravelCostApp/__tests__/components/expense-form.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-form.test.tsx
@@ -38,7 +38,6 @@ jest.mock("../../store/mmkv", () => ({
   clearExpenseCat: jest.fn(),
   getMMKVObject: jest.fn(() => undefined),
   setExpenseCat: jest.fn(),
-  getRecentCurrencies: jest.fn(() => []),
   MMKV_KEYS: { CATEGORY_LIST: "categoryList" },
 }));
 

--- a/TravelCostApp/__tests__/util/picker-recent-items.test.ts
+++ b/TravelCostApp/__tests__/util/picker-recent-items.test.ts
@@ -1,5 +1,6 @@
 import { makeExpense } from "../fixtures/expense";
 import {
+  buildPinnedPickerDropdownItems,
   getRecentPickerCountries,
   getRecentPickerCurrencies,
 } from "../../util/picker-recent-items";
@@ -118,6 +119,23 @@ describe("getRecentPickerCurrencies", () => {
     ]);
   });
 
+  it("dedupes when last-used currency already appears in recent expenses", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        currency: "EUR",
+        date: new Date("2026-01-15T12:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "e2",
+        currency: "USD",
+        date: new Date("2026-01-12T12:00:00.000Z"),
+      }),
+    ];
+
+    expect(getRecentPickerCurrencies(expenses, "EUR")).toEqual(["EUR", "USD"]);
+  });
+
   it("returns at most 5 currencies", () => {
     const expenses = [
       makeExpense({ id: "e1", currency: "EUR", date: new Date("2026-01-20") }),
@@ -135,6 +153,35 @@ describe("getRecentPickerCurrencies", () => {
       "USD",
       "GBP",
       "JPY",
+    ]);
+  });
+});
+
+describe("buildPinnedPickerDropdownItems", () => {
+  it("returns all items when there are no pinned entries", () => {
+    const allItems = [
+      { label: "Germany", value: "Germany" },
+      { label: "France", value: "France" },
+    ];
+
+    expect(buildPinnedPickerDropdownItems([], allItems)).toEqual(allItems);
+  });
+
+  it("prepends pinned items, a separator, and then the full list", () => {
+    const allItems = [
+      { label: "Germany", value: "Germany" },
+      { label: "France", value: "France" },
+    ];
+    const pinned = [{ label: "Italy", value: "Italy" }];
+
+    expect(buildPinnedPickerDropdownItems(pinned, allItems)).toEqual([
+      { label: "Italy", value: "Italy" },
+      {
+        label: "────────────────────────",
+        value: "__separator__",
+        disabled: true,
+      },
+      ...allItems,
     ]);
   });
 });

--- a/TravelCostApp/__tests__/util/picker-recent-items.test.ts
+++ b/TravelCostApp/__tests__/util/picker-recent-items.test.ts
@@ -1,0 +1,140 @@
+import { makeExpense } from "../fixtures/expense";
+import {
+  getRecentPickerCountries,
+  getRecentPickerCurrencies,
+} from "../../util/picker-recent-items";
+
+describe("getRecentPickerCountries", () => {
+  it("pins last-used country first, then unique countries from newest expenses, capped at 5", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        country: "FR",
+        date: new Date("2026-01-10T12:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "e2",
+        country: "DE",
+        date: new Date("2026-01-15T12:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "e3",
+        country: "US",
+        date: new Date("2026-01-12T12:00:00.000Z"),
+      }),
+    ];
+
+    expect(getRecentPickerCountries(expenses, "IT")).toEqual([
+      "IT",
+      "DE",
+      "US",
+      "FR",
+    ]);
+  });
+
+  it("dedupes when last-used country already appears in recent expenses", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        country: "DE",
+        date: new Date("2026-01-15T12:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "e2",
+        country: "US",
+        date: new Date("2026-01-12T12:00:00.000Z"),
+      }),
+    ];
+
+    expect(getRecentPickerCountries(expenses, "DE")).toEqual(["DE", "US"]);
+  });
+
+  it("skips deleted expenses and expenses without a country", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        country: "DE",
+        date: new Date("2026-01-15T12:00:00.000Z"),
+        isDeleted: true,
+      }),
+      makeExpense({
+        id: "e2",
+        country: "",
+        date: new Date("2026-01-14T12:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "e3",
+        country: "US",
+        date: new Date("2026-01-13T12:00:00.000Z"),
+      }),
+    ];
+
+    expect(getRecentPickerCountries(expenses, "")).toEqual(["US"]);
+  });
+
+  it("treats country codes and English names as the same place", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        country: "Germany",
+        date: new Date("2026-01-15T12:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "e2",
+        country: "US",
+        date: new Date("2026-01-12T12:00:00.000Z"),
+      }),
+    ];
+
+    expect(getRecentPickerCountries(expenses, "DE")).toEqual(["DE", "US"]);
+  });
+});
+
+describe("getRecentPickerCurrencies", () => {
+  it("pins last-used currency first, then unique currencies from newest expenses, capped at 5", () => {
+    const expenses = [
+      makeExpense({
+        id: "e1",
+        currency: "GBP",
+        date: new Date("2026-01-10T12:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "e2",
+        currency: "EUR",
+        date: new Date("2026-01-15T12:00:00.000Z"),
+      }),
+      makeExpense({
+        id: "e3",
+        currency: "USD",
+        date: new Date("2026-01-12T12:00:00.000Z"),
+      }),
+    ];
+
+    expect(getRecentPickerCurrencies(expenses, "JPY")).toEqual([
+      "JPY",
+      "EUR",
+      "USD",
+      "GBP",
+    ]);
+  });
+
+  it("returns at most 5 currencies", () => {
+    const expenses = [
+      makeExpense({ id: "e1", currency: "EUR", date: new Date("2026-01-20") }),
+      makeExpense({ id: "e2", currency: "USD", date: new Date("2026-01-19") }),
+      makeExpense({ id: "e3", currency: "GBP", date: new Date("2026-01-18") }),
+      makeExpense({ id: "e4", currency: "JPY", date: new Date("2026-01-17") }),
+      makeExpense({ id: "e5", currency: "CHF", date: new Date("2026-01-16") }),
+      makeExpense({ id: "e6", currency: "CAD", date: new Date("2026-01-15") }),
+    ];
+
+    expect(getRecentPickerCurrencies(expenses, "AUD")).toHaveLength(5);
+    expect(getRecentPickerCurrencies(expenses, "AUD")).toEqual([
+      "AUD",
+      "EUR",
+      "USD",
+      "GBP",
+      "JPY",
+    ]);
+  });
+});

--- a/TravelCostApp/components/Currency/CountryPicker.tsx
+++ b/TravelCostApp/components/Currency/CountryPicker.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import React, { StyleSheet, View } from "react-native";
+import React, { useContext, useMemo, useState, useEffect } from "react";
+import { StyleSheet, View } from "react-native";
 
 import DropDownPicker from "react-native-dropdown-picker";
 import * as i18nIsoCountries from "i18n-iso-countries";
-import { useState } from "react";
 
 import { GlobalStyles } from "../../constants/styles";
 import { i18n } from "../../i18n/i18n";
@@ -12,6 +12,19 @@ import * as Haptics from "expo-haptics";
 import PropTypes from "prop-types";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
+import { ExpensesContext } from "../../store/expenses-context";
+import { UserContext } from "../../store/user-context";
+import {
+  getRecentPickerCountries,
+  normalizePickerCountryKey,
+} from "../../util/picker-recent-items";
+
+const countries = require("i18n-iso-countries");
+
+i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/en.json"));
+i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/de.json"));
+i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/fr.json"));
+i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/ru.json"));
 
 const CountryPicker = ({
   countryValue,
@@ -20,47 +33,72 @@ const CountryPicker = ({
   placeholder,
   valid = true,
 }) => {
-  // Users Device CountryCode CC to translate Country names in picker
-  // enforce a language we have registered, otherwise, english
-  let CC =
-    Localization.getLocales()[0] && Localization.getLocales()[0].languageCode
-      ? Localization.getLocales()[0].languageCode.slice(0, 2)
-      : "en";
-  if (CC !== "de" && CC !== "en" && CC !== "fr" && CC !== "ru") CC = "en";
-  //   const CC = "en";
+  const expCtx = useContext(ExpensesContext);
+  const userCtx = useContext(UserContext);
 
-  const countries = require("i18n-iso-countries");
-  i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/en.json"));
-  i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/de.json"));
-  i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/fr.json"));
-  i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/ru.json"));
-  // i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/es.json"));
-  // i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/zh.json"));
-  // i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/hi.json"));
-  // i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/ar.json"));
-  // i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/pt.json"));
-  // i18nIsoCountries.registerLocale(require("i18n-iso-countries/langs/ja.json"));
+  const CC = useMemo(() => {
+    const locale = Localization.getLocales()[0]?.languageCode ?? "en";
+    const normalized = locale.slice(0, 2);
+    return ["de", "en", "fr", "ru"].includes(normalized) ? normalized : "en";
+  }, []);
 
-  const nonEnglish = CC !== "en";
-  const nonEnglishCountryString = (code) => {
-    if (!nonEnglish) return "";
-    return ` - ${nonEnglish && countries.getName(code, CC)}`;
-  };
+  const allCountryOptions = useMemo(() => {
+    const nonEnglish = CC !== "en";
+    const nonEnglishCountryString = (code: string) =>
+      nonEnglish ? ` - ${countries.getName(code, CC)}` : "";
 
-  const countryOptions = Object.keys(countries.getNames("en")).map((code) => ({
-    label: `${countries.getName(code, "en")}` + nonEnglishCountryString(code),
-    value: `${countries.getName(code, "en")}` + nonEnglishCountryString(code),
-    // icon: () => (
-    //   <ExpenseCountryFlag
-    //     countryName={code}
-    //     style={GlobalStyles.countryFlagStyleBig}
-    //     containerStyle={GlobalStyles.countryFlagStyleBig}
-    //   />
-    // ),
-  }));
+    return Object.keys(countries.getNames("en")).map((code) => {
+      const label =
+        `${countries.getName(code, "en")}` + nonEnglishCountryString(code);
+
+      return {
+        label,
+        value: label,
+        countryCode: code,
+      };
+    });
+  }, [CC]);
+
+  const memoizedItems = useMemo(() => {
+    const recentCountries = getRecentPickerCountries(
+      expCtx.expenses,
+      userCtx.lastCountry
+    );
+
+    const recentItems = recentCountries
+      .map((country) => {
+        const countryKey = normalizePickerCountryKey(country);
+        return allCountryOptions.find(
+          (option) => option.countryCode === countryKey
+        );
+      })
+      .filter(Boolean);
+
+    if (recentItems.length === 0) {
+      return allCountryOptions;
+    }
+
+    return [
+      ...recentItems,
+      ...(allCountryOptions.length
+        ? [
+            {
+              label: "────────────────────────",
+              value: "__separator__",
+              disabled: true,
+            },
+          ]
+        : []),
+      ...allCountryOptions,
+    ];
+  }, [allCountryOptions, expCtx.expenses, userCtx.lastCountry]);
 
   const [open, setOpen] = useState(false);
-  const [items, setItems] = useState(countryOptions);
+  const [items, setItems] = useState(memoizedItems);
+
+  useEffect(() => {
+    setItems(memoizedItems);
+  }, [memoizedItems]);
 
   return (
     <View style={styles.container}>
@@ -83,8 +121,7 @@ const CountryPicker = ({
         }}
         onSelectItem={(item) => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-          // Track country selection
-          if (item.value) {
+          if (item.value && item.value !== "__separator__") {
             trackEvent(VexoEvents.COUNTRY_PICKED, {
               country: item.value,
             });

--- a/TravelCostApp/components/Currency/CountryPicker.tsx
+++ b/TravelCostApp/components/Currency/CountryPicker.tsx
@@ -14,9 +14,10 @@ import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 import { ExpensesContext } from "../../store/expenses-context";
 import { UserContext } from "../../store/user-context";
+import { normalizeCountryKey } from "../../util/expense-form-inputs";
 import {
+  buildPinnedPickerDropdownItems,
   getRecentPickerCountries,
-  normalizePickerCountryKey,
 } from "../../util/picker-recent-items";
 
 const countries = require("i18n-iso-countries");
@@ -67,30 +68,14 @@ const CountryPicker = ({
 
     const recentItems = recentCountries
       .map((country) => {
-        const countryKey = normalizePickerCountryKey(country);
+        const countryKey = normalizeCountryKey(country);
         return allCountryOptions.find(
           (option) => option.countryCode === countryKey
         );
       })
-      .filter(Boolean);
+      .filter((item): item is (typeof allCountryOptions)[number] => item != null);
 
-    if (recentItems.length === 0) {
-      return allCountryOptions;
-    }
-
-    return [
-      ...recentItems,
-      ...(allCountryOptions.length
-        ? [
-            {
-              label: "────────────────────────",
-              value: "__separator__",
-              disabled: true,
-            },
-          ]
-        : []),
-      ...allCountryOptions,
-    ];
+    return buildPinnedPickerDropdownItems(recentItems, allCountryOptions);
   }, [allCountryOptions, expCtx.expenses, userCtx.lastCountry]);
 
   const [open, setOpen] = useState(false);

--- a/TravelCostApp/components/Currency/CurrencyPicker.tsx
+++ b/TravelCostApp/components/Currency/CurrencyPicker.tsx
@@ -16,6 +16,7 @@ import { VexoEvents } from "../../util/vexo-constants";
 import { ExpensesContext } from "../../store/expenses-context";
 import { UserContext } from "../../store/user-context";
 import {
+  buildPinnedPickerDropdownItems,
   getRecentPickerCurrencies,
   normalizePickerCurrencyKey,
 } from "../../util/picker-recent-items";
@@ -76,7 +77,7 @@ const CurrencyPicker = ({
             normalizePickerCurrencyKey(option.currencyCode) === currencyKey
         );
       })
-      .filter(Boolean)
+      .filter((item): item is (typeof allCountryOptions)[number] => item != null)
       .map((option) => {
         const shortLabel = `${option.currencyCode} | ${getCurrencySymbol(
           option.currencyCode
@@ -88,23 +89,7 @@ const CurrencyPicker = ({
         };
       });
 
-    if (recentItems.length === 0) {
-      return allCountryOptions;
-    }
-
-    return [
-      ...recentItems,
-      ...(allCountryOptions.length
-        ? [
-            {
-              label: "────────────────────────",
-              value: "__separator__",
-              disabled: true,
-            },
-          ]
-        : []),
-      ...allCountryOptions,
-    ];
+    return buildPinnedPickerDropdownItems(recentItems, allCountryOptions);
   }, [allCountryOptions, expCtx.expenses, userCtx.lastCurrency]);
 
   const [open, setOpen] = useState(false);

--- a/TravelCostApp/components/Currency/CurrencyPicker.tsx
+++ b/TravelCostApp/components/Currency/CurrencyPicker.tsx
@@ -13,13 +13,12 @@ import PropTypes from "prop-types";
 import { getCurrencySymbol } from "../../util/currencySymbol";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
-import {
-  addRecentCurrency,
-  getRecentCurrencies,
-  initializeRecentCurrencies,
-} from "../../store/mmkv";
-import { TripContext } from "../../store/trip-context";
+import { ExpensesContext } from "../../store/expenses-context";
 import { UserContext } from "../../store/user-context";
+import {
+  getRecentPickerCurrencies,
+  normalizePickerCurrencyKey,
+} from "../../util/picker-recent-items";
 
 const countryToCurrency = require("country-to-currency");
 const countries = require("i18n-iso-countries");
@@ -36,7 +35,7 @@ const CurrencyPicker = ({
   placeholder,
   valid = true,
 }) => {
-  const tripCtx = useContext(TripContext);
+  const expCtx = useContext(ExpensesContext);
   const userCtx = useContext(UserContext);
 
   const CC = useMemo(() => {
@@ -44,11 +43,6 @@ const CurrencyPicker = ({
     const normalized = locale.slice(0, 2);
     return ["de", "en", "fr", "ru"].includes(normalized) ? normalized : "en";
   }, []);
-
-  const homeCurrency = useMemo(() => {
-    const localeCurrency = Localization.getLocales()[0]?.currencyCode;
-    return localeCurrency || tripCtx.tripCurrency || "USD";
-  }, [tripCtx.tripCurrency]);
 
   const allCountryOptions = useMemo(() => {
     const nonEnglish = CC !== "en";
@@ -68,31 +62,20 @@ const CurrencyPicker = ({
     });
   }, [CC]);
 
-  // Initialize recent currencies from trip if empty
-  useEffect(() => {
-    if (tripCtx.tripCurrency) {
-      initializeRecentCurrencies(tripCtx.tripCurrency);
-    }
-  }, [tripCtx.tripCurrency]);
-
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
-
   const memoizedItems = useMemo(() => {
-    // refreshTrigger is intentionally referenced to rebuild the list after updates
-    void refreshTrigger;
+    const recentCurrencies = getRecentPickerCurrencies(
+      expCtx.expenses,
+      userCtx.lastCurrency
+    );
 
-    const preferredCurrencyCodes = [
-      tripCtx.tripCurrency,
-      homeCurrency,
-      userCtx.lastCurrency,
-      ...getRecentCurrencies(),
-    ].filter(Boolean);
-
-    const recentCurrencyCodes = Array.from(new Set(preferredCurrencyCodes));
-    const recentItems = recentCurrencyCodes
-      .map((currencyCode) =>
-        allCountryOptions.find((option) => option.currencyCode === currencyCode)
-      )
+    const recentItems = recentCurrencies
+      .map((currency) => {
+        const currencyKey = normalizePickerCurrencyKey(currency);
+        return allCountryOptions.find(
+          (option) =>
+            normalizePickerCurrencyKey(option.currencyCode) === currencyKey
+        );
+      })
       .filter(Boolean)
       .map((option) => {
         const shortLabel = `${option.currencyCode} | ${getCurrencySymbol(
@@ -122,13 +105,7 @@ const CurrencyPicker = ({
         : []),
       ...allCountryOptions,
     ];
-  }, [
-    allCountryOptions,
-    homeCurrency,
-    refreshTrigger,
-    tripCtx.tripCurrency,
-    userCtx.lastCurrency,
-  ]);
+  }, [allCountryOptions, expCtx.expenses, userCtx.lastCurrency]);
 
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState(memoizedItems);
@@ -155,14 +132,8 @@ const CurrencyPicker = ({
         }}
         onSelectItem={(item) => {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-          // Extract currency from the value string
           const currency = item.value?.split(" | ")[0]?.trim();
           if (currency && item.value !== "__separator__") {
-            // Add to recent currencies
-            addRecentCurrency(currency);
-            // Trigger rebuild of items list
-            setRefreshTrigger((prev) => prev + 1);
-
             trackEvent(VexoEvents.CURRENCY_PICKED, {
               currency: currency,
             });

--- a/TravelCostApp/store/mmkv-helpers.ts
+++ b/TravelCostApp/store/mmkv-helpers.ts
@@ -41,32 +41,3 @@ export const getExpenseDraft = (expenseId: string) => {
 export const clearExpenseDraft = (expenseId: string) => {
   deleteMMKVObject(MMKV_KEY_PATTERNS.EXPENSE_DRAFT(expenseId));
 };
-
-// Recent currencies storage (max 5)
-const MAX_RECENT_CURRENCIES = 5;
-
-export const getRecentCurrencies = (): string[] => {
-  const currencies = getMMKVObject(MMKV_KEYS.RECENT_CURRENCIES);
-  return Array.isArray(currencies) ? currencies : [];
-};
-
-export const addRecentCurrency = (currencyCode: string) => {
-  if (!currencyCode) return;
-
-  const recent = getRecentCurrencies();
-  // Remove if already exists
-  const filtered = recent.filter((c) => c !== currencyCode);
-  // Add to front
-  const updated = [currencyCode, ...filtered].slice(0, MAX_RECENT_CURRENCIES);
-  setMMKVObject(MMKV_KEYS.RECENT_CURRENCIES, updated);
-};
-
-export const initializeRecentCurrencies = (tripCurrency: string) => {
-  if (!tripCurrency) return;
-
-  const recent = getRecentCurrencies();
-  // Only initialize if empty
-  if (recent.length === 0) {
-    setMMKVObject(MMKV_KEYS.RECENT_CURRENCIES, [tripCurrency]);
-  }
-};

--- a/TravelCostApp/store/mmkv-keys.ts
+++ b/TravelCostApp/store/mmkv-keys.ts
@@ -18,7 +18,6 @@ export const MMKV_KEYS = {
   CATEGORY_LIST: "categoryList",
 
   // Currency related
-  RECENT_CURRENCIES: "recentCurrencies",
   CURRENCY_EXCHANGE_LAST_UPDATE: "currencyExchange_lastUpdate",
 
   // UI/App state

--- a/TravelCostApp/store/mmkv.tsx
+++ b/TravelCostApp/store/mmkv.tsx
@@ -110,9 +110,6 @@ export {
   setExpenseDraft,
   getExpenseDraft,
   clearExpenseDraft,
-  getRecentCurrencies,
-  addRecentCurrency,
-  initializeRecentCurrencies,
   type IDCat,
 } from "./mmkv-helpers";
 

--- a/TravelCostApp/util/expense-form-inputs.ts
+++ b/TravelCostApp/util/expense-form-inputs.ts
@@ -41,18 +41,18 @@ export function resolveDefaultNewExpenseCountry(
   return input.mostRecentExpenseCountry?.trim() ?? "";
 }
 
-export function countriesRepresentSamePlace(a: string, b: string): boolean {
-  const normalize = (value: string): string => {
-    const trimmed = value?.trim() ?? "";
-    if (!trimmed) return "";
-    if (trimmed.length === 2) {
-      return trimmed.toUpperCase();
-    }
-    const alpha2 = countryToAlpha2(trimmed);
-    return alpha2?.toUpperCase() ?? trimmed.toLowerCase();
-  };
+export function normalizeCountryKey(country: string): string {
+  const trimmed = country?.trim() ?? "";
+  if (!trimmed) return "";
+  if (trimmed.length === 2) {
+    return trimmed.toUpperCase();
+  }
+  const alpha2 = countryToAlpha2(trimmed);
+  return alpha2?.toUpperCase() ?? trimmed.toLowerCase();
+}
 
-  return normalize(a) === normalize(b);
+export function countriesRepresentSamePlace(a: string, b: string): boolean {
+  return normalizeCountryKey(a) === normalizeCountryKey(b);
 }
 
 /** English label used by CountryPicker for a stored country code or name. */

--- a/TravelCostApp/util/picker-recent-items.ts
+++ b/TravelCostApp/util/picker-recent-items.ts
@@ -1,20 +1,36 @@
 import type { ExpenseData } from "./expense";
-import { countryToAlpha2 } from "country-to-iso";
+import { normalizeCountryKey } from "./expense-form-inputs";
 
 const MAX_RECENT_PICKER_ITEMS = 5;
 
-export function normalizePickerCountryKey(country: string): string {
-  const trimmed = country?.trim() ?? "";
-  if (!trimmed) return "";
-  if (trimmed.length === 2) {
-    return trimmed.toUpperCase();
-  }
-  const alpha2 = countryToAlpha2(trimmed);
-  return alpha2?.toUpperCase() ?? trimmed.toLowerCase();
-}
-
 export function normalizePickerCurrencyKey(currency: string): string {
   return currency?.trim().toUpperCase() ?? "";
+}
+
+export type PickerDropdownItem = {
+  label: string;
+  value: string;
+  disabled?: boolean;
+};
+
+export function buildPinnedPickerDropdownItems<T extends PickerDropdownItem>(
+  recentItems: Array<T | null | undefined>,
+  allItems: T[]
+): Array<T | PickerDropdownItem> {
+  const pinned = recentItems.filter((item): item is T => item != null);
+  if (pinned.length === 0) {
+    return allItems;
+  }
+
+  const separator: PickerDropdownItem = {
+    label: "────────────────────────",
+    value: "__separator__",
+    disabled: true,
+  };
+
+  return allItems.length > 0
+    ? [...pinned, separator, ...allItems]
+    : [...pinned];
 }
 
 function buildRecentPickerItems(
@@ -60,7 +76,7 @@ export function getRecentPickerCountries(
     expenses,
     lastCountry,
     (expense) => expense.country,
-    normalizePickerCountryKey
+    normalizeCountryKey
   );
 }
 

--- a/TravelCostApp/util/picker-recent-items.ts
+++ b/TravelCostApp/util/picker-recent-items.ts
@@ -1,0 +1,77 @@
+import type { ExpenseData } from "./expense";
+import { countryToAlpha2 } from "country-to-iso";
+
+const MAX_RECENT_PICKER_ITEMS = 5;
+
+export function normalizePickerCountryKey(country: string): string {
+  const trimmed = country?.trim() ?? "";
+  if (!trimmed) return "";
+  if (trimmed.length === 2) {
+    return trimmed.toUpperCase();
+  }
+  const alpha2 = countryToAlpha2(trimmed);
+  return alpha2?.toUpperCase() ?? trimmed.toLowerCase();
+}
+
+export function normalizePickerCurrencyKey(currency: string): string {
+  return currency?.trim().toUpperCase() ?? "";
+}
+
+function buildRecentPickerItems(
+  expenses: ExpenseData[],
+  lastUsed: string,
+  getValue: (expense: ExpenseData) => string | undefined,
+  normalizeKey: (value: string) => string
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const add = (raw: string) => {
+    const trimmed = raw?.trim();
+    if (!trimmed) return;
+    const key = normalizeKey(trimmed);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    result.push(trimmed);
+  };
+
+  if (lastUsed?.trim()) {
+    add(lastUsed);
+  }
+
+  const sortedExpenses = [...expenses]
+    .filter((expense) => !expense.isDeleted)
+    .sort((a, b) => b.date.getTime() - a.date.getTime());
+
+  for (const expense of sortedExpenses) {
+    if (result.length >= MAX_RECENT_PICKER_ITEMS) break;
+    const value = getValue(expense);
+    if (value) add(value);
+  }
+
+  return result;
+}
+
+export function getRecentPickerCountries(
+  expenses: ExpenseData[],
+  lastCountry: string
+): string[] {
+  return buildRecentPickerItems(
+    expenses,
+    lastCountry,
+    (expense) => expense.country,
+    normalizePickerCountryKey
+  );
+}
+
+export function getRecentPickerCurrencies(
+  expenses: ExpenseData[],
+  lastCurrency: string
+): string[] {
+  return buildRecentPickerItems(
+    expenses,
+    lastCurrency,
+    (expense) => expense.currency,
+    normalizePickerCurrencyKey
+  );
+}


### PR DESCRIPTION
## Summary
- Add shared `picker-recent-items` util: last-used first, then unique countries/currencies from newest trip expenses, capped at 5
- Wire CountryPicker to show pinned recent countries above the full list
- Align CurrencyPicker with the same algorithm (replaces MMKV/trip/home pinned shortcuts)
- **Note:** TripForm also uses CurrencyPicker for new-trip setup — device home currency and trip currency are no longer auto-pinned; shortcuts now come from last-used + active trip expenses only

## Test plan
- [x] `pnpm test` (491 tests pass)
- [ ] Open expense form → country picker shows last-used + recent trip countries at top
- [ ] Open expense form → currency picker shows last-used + recent trip currencies at top
- [ ] Verify separator appears between pinned section and full list
- [ ] New trip form → currency picker still usable without expense history