### PR TITLE
Optimistic ranged expense add/edit/delete with retry and offline queue

### DIFF
--- a/TravelCostApp/__tests__/util/notify-travelers-after-ranged-sync.test.ts
+++ b/TravelCostApp/__tests__/util/notify-travelers-after-ranged-sync.test.ts
@@ -1,0 +1,41 @@
+import { notifyTravelersAfterRangedSync } from "../../util/notify-travelers-after-ranged-sync";
+
+describe("notifyTravelersAfterRangedSync", () => {
+  it("notifies travellers only after ranged background sync settles", async () => {
+    let resolveSync!: () => void;
+    const syncPromise = new Promise<void>((resolve) => {
+      resolveSync = resolve;
+    });
+    const touchAllTravelers = jest.fn(async () => {});
+
+    notifyTravelersAfterRangedSync(
+      syncPromise,
+      "trip-1",
+      true,
+      touchAllTravelers,
+    );
+
+    expect(touchAllTravelers).not.toHaveBeenCalled();
+
+    resolveSync();
+    await syncPromise;
+    await Promise.resolve();
+
+    expect(touchAllTravelers).toHaveBeenCalledTimes(1);
+    expect(touchAllTravelers).toHaveBeenCalledWith("trip-1", true);
+  });
+
+  it("skips traveller notification when offline", async () => {
+    const touchAllTravelers = jest.fn(async () => {});
+
+    notifyTravelersAfterRangedSync(
+      Promise.resolve(),
+      "trip-1",
+      false,
+      touchAllTravelers,
+    );
+
+    await Promise.resolve();
+    expect(touchAllTravelers).not.toHaveBeenCalled();
+  });
+});

--- a/TravelCostApp/__tests__/util/offline-queue-single-attempt.test.ts
+++ b/TravelCostApp/__tests__/util/offline-queue-single-attempt.test.ts
@@ -1,0 +1,64 @@
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+}));
+
+jest.mock("../../util/connectionSpeed", () => ({
+  isConnectionFastEnough: jest.fn(async () => ({ isFastEnough: true })),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => "trip-1"),
+}));
+
+const mmkvStore: Record<string, unknown> = {};
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: {
+    OFFLINE_QUEUE: "offlineQueue",
+  },
+  getMMKVObject: jest.fn((key: string) => mmkvStore[key] ?? null),
+  setMMKVObject: jest.fn((key: string, value: unknown) => {
+    mmkvStore[key] = value;
+  }),
+}));
+
+jest.mock("../../util/http", () => ({
+  storeExpenseWithId: jest.fn(),
+  storeExpense: jest.fn(),
+  updateExpense: jest.fn(),
+  deleteExpense: jest.fn(),
+}));
+
+import { MMKV_KEYS } from "../../store/mmkv";
+import { storeExpenseWithId } from "../../util/http";
+import { storeExpenseOnlineOffline } from "../../util/offline-queue";
+import { makeExpense } from "../fixtures/expense";
+
+describe("storeExpenseOnlineOffline (single-attempt path)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+  });
+
+  it("queues after one online failure without retrying HTTP", async () => {
+    (storeExpenseWithId as jest.Mock).mockRejectedValue(new Error("network"));
+
+    const expenseData = makeExpense({ id: "client-id" });
+    await storeExpenseOnlineOffline(
+      {
+        type: "add",
+        expense: {
+          tripid: "trip-1",
+          uid: "u1",
+          id: "client-id",
+          expenseData,
+        },
+      },
+      true,
+    );
+
+    expect(storeExpenseWithId).toHaveBeenCalledTimes(1);
+    expect(mmkvStore[MMKV_KEYS.OFFLINE_QUEUE]).toHaveLength(1);
+  });
+});

--- a/TravelCostApp/__tests__/util/ranged-expense-persist.test.ts
+++ b/TravelCostApp/__tests__/util/ranged-expense-persist.test.ts
@@ -1,0 +1,226 @@
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+}));
+
+jest.mock("../../util/connectionSpeed", () => ({
+  isConnectionFastEnough: jest.fn(async () => ({ isFastEnough: true })),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => "trip-1"),
+}));
+
+const mmkvStore: Record<string, unknown> = {};
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: {
+    OFFLINE_QUEUE: "offlineQueue",
+  },
+  getMMKVObject: jest.fn((key: string) => mmkvStore[key] ?? null),
+  setMMKVObject: jest.fn((key: string, value: unknown) => {
+    mmkvStore[key] = value;
+  }),
+}));
+
+jest.mock("../../util/http", () => ({
+  storeExpenseWithId: jest.fn(),
+  updateExpense: jest.fn(),
+  deleteExpense: jest.fn(),
+}));
+
+import Toast from "react-native-toast-message";
+import { MMKV_KEYS } from "../../store/mmkv";
+import { storeExpenseWithId } from "../../util/http";
+import {
+  persistRangedExpenseAdd,
+  persistRangedExpenseInPlaceEdit,
+  persistRangedExpenseReplace,
+} from "../../util/ranged-expense-persist";
+import { makeExpense } from "../fixtures/expense";
+import { collectUserDeleteTargets } from "../../util/user-delete-expense";
+import type { ExpenseData } from "../../util/expense";
+
+function makeRangedInstances(): ExpenseData[] {
+  const rangeId = "range-1";
+  return [
+    makeExpense({
+      id: "",
+      rangeId,
+      date: new Date("2026-01-15T12:00:00.000Z"),
+      startDate: new Date("2026-01-15T12:00:00.000Z"),
+      endDate: new Date("2026-01-17T12:00:00.000Z"),
+      amount: 30,
+      calcAmount: 30,
+    }),
+    makeExpense({
+      id: "",
+      rangeId,
+      date: new Date("2026-01-16T12:00:00.000Z"),
+      startDate: new Date("2026-01-15T12:00:00.000Z"),
+      endDate: new Date("2026-01-17T12:00:00.000Z"),
+      amount: 30,
+      calcAmount: 30,
+    }),
+    makeExpense({
+      id: "",
+      rangeId,
+      date: new Date("2026-01-17T12:00:00.000Z"),
+      startDate: new Date("2026-01-15T12:00:00.000Z"),
+      endDate: new Date("2026-01-17T12:00:00.000Z"),
+      amount: 30,
+      calcAmount: 30,
+    }),
+  ];
+}
+
+describe("persistRangedExpenseAdd", () => {
+  const expenseCtx = {
+    addExpense: jest.fn(),
+    updateExpense: jest.fn(),
+    deleteExpense: jest.fn(),
+    updateExpenseId: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+    (storeExpenseWithId as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it("adds every ranged day to the ledger immediately without a loading toast", async () => {
+    const instances = makeRangedInstances();
+    const { syncPromise } = persistRangedExpenseAdd(instances, {
+      tripid: "trip-1",
+      uid: "u1",
+      isOnline: true,
+      expenseCtx,
+    });
+
+    expect(expenseCtx.addExpense).toHaveBeenCalledTimes(3);
+    const loadingToast = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "loading",
+    );
+    expect(loadingToast).toBeUndefined();
+
+    await syncPromise;
+  });
+
+  it("retries online store 3 times then queues without reverting the ledger", async () => {
+    jest.useFakeTimers();
+    (storeExpenseWithId as jest.Mock).mockRejectedValue(new Error("network"));
+
+    const instances = makeRangedInstances().slice(0, 1);
+    const { syncPromise } = persistRangedExpenseAdd(instances, {
+      tripid: "trip-1",
+      uid: "u1",
+      isOnline: true,
+      expenseCtx,
+    });
+
+    const sync = syncPromise.catch(() => {});
+    await jest.runAllTimersAsync();
+    await sync;
+
+    expect(storeExpenseWithId).toHaveBeenCalledTimes(3);
+    const queue = mmkvStore[MMKV_KEYS.OFFLINE_QUEUE] as unknown[];
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({ type: "add" });
+    expect(expenseCtx.addExpense).toHaveBeenCalledTimes(1);
+    expect(expenseCtx.deleteExpense).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+});
+
+describe("persistRangedExpenseInPlaceEdit", () => {
+  const expenseCtx = {
+    addExpense: jest.fn(),
+    updateExpense: jest.fn(),
+    deleteExpense: jest.fn(),
+    updateExpenseId: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+  });
+
+  it("updates every ranged day in the ledger immediately without a loading toast", () => {
+    const updates = [
+      {
+        id: "day-1",
+        expenseData: makeExpense({ id: "day-1", description: "rent jan 15" }),
+      },
+      {
+        id: "day-2",
+        expenseData: makeExpense({ id: "day-2", description: "rent jan 16" }),
+      },
+    ];
+
+    const { syncPromise } = persistRangedExpenseInPlaceEdit(updates, {
+      tripid: "trip-1",
+      uid: "u1",
+      isOnline: true,
+      expenseCtx,
+    });
+
+    expect(expenseCtx.updateExpense).toHaveBeenCalledTimes(2);
+    expect(expenseCtx.updateExpense).toHaveBeenCalledWith(
+      "day-1",
+      updates[0].expenseData,
+    );
+    const loadingToast = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "loading",
+    );
+    expect(loadingToast).toBeUndefined();
+
+    return syncPromise;
+  });
+});
+
+describe("persistRangedExpenseReplace", () => {
+  const expenseCtx = {
+    addExpense: jest.fn(),
+    updateExpense: jest.fn(),
+    deleteExpense: jest.fn(),
+    updateExpenseId: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+    (storeExpenseWithId as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it("soft-deletes the old range and adds new days immediately without a loading toast", async () => {
+    const oldExpenses = [
+      makeExpense({ id: "old-1", rangeId: "range-1" }),
+      makeExpense({ id: "old-2", rangeId: "range-1" }),
+    ];
+    const deleteTargets = collectUserDeleteTargets("trip-1", oldExpenses, [
+      "old-1",
+    ]);
+    const newInstances = makeRangedInstances();
+
+    const { syncPromise } = persistRangedExpenseReplace(
+      deleteTargets,
+      newInstances,
+      {
+        tripid: "trip-1",
+        uid: "u1",
+        isOnline: true,
+        expenseCtx,
+      },
+    );
+
+    expect(expenseCtx.deleteExpense).toHaveBeenCalledTimes(2);
+    expect(expenseCtx.addExpense).toHaveBeenCalledTimes(3);
+    const loadingToast = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "loading",
+    );
+    expect(loadingToast).toBeUndefined();
+
+    await syncPromise;
+  });
+});

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -55,6 +55,7 @@ import LoadingOverlay from "../components/UI/LoadingOverlay";
 import { trackEvent } from "../util/vexo-tracking";
 import { isConnectionFastEnoughAsBool } from "../util/connectionSpeed";
 import { dynamicScale } from "../util/scalingUtil";
+import { notifyTravelersAfterRangedSync } from "../util/notify-travelers-after-ranged-sync";
 import { VexoEvents } from "../util/vexo-constants";
 
 interface ManageExpenseProps {
@@ -264,7 +265,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
     expenseCtx,
   };
 
-  const createRangedData = (expenseData: ExpenseData) => {
+  const createRangedData = (expenseData: ExpenseData): Promise<void> => {
     const rangeId = newRangeId();
     const dates = buildRangedExpenseDatesFromSpan(
       expenseData.startDate,
@@ -276,11 +277,10 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
       dates,
     });
 
-    const { syncPromise } = persistRangedExpenseAdd(instances, rangedPersistParams);
-    void syncPromise.catch(safeLogError);
+    return persistRangedExpenseAdd(instances, rangedPersistParams).syncPromise;
   };
 
-  const editRangedData = (expenseData: ExpenseData) => {
+  const editRangedData = (expenseData: ExpenseData): Promise<void> => {
     const expensesInRange = expenseCtx.expenses.filter(
       (expense) =>
         expense.rangeId && expense.rangeId === selectedExpense?.rangeId
@@ -296,12 +296,11 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
           id: editedExpenseId,
         },
       };
-      void deleteExpenseOnlineOffline(item, isOnline).catch(safeLogError);
-
+      const deleteSync = deleteExpenseOnlineOffline(item, isOnline);
       const instances = planNonRangedToRangedInstances(expenseData, newRangeId());
-      const { syncPromise } = persistRangedExpenseAdd(instances, rangedPersistParams);
-      void syncPromise.catch(safeLogError);
-      return;
+      const addSync = persistRangedExpenseAdd(instances, rangedPersistParams)
+        .syncPromise;
+      return Promise.all([deleteSync, addSync]).then(() => {});
     }
 
     if (shouldReplaceRangedExpenseInstances(expensesInRange, expenseData)) {
@@ -309,24 +308,18 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
         selectedExpense.id!,
       ]);
       const instances = planRangedExpenseReplacement(expenseData, newRangeId());
-      const { syncPromise } = persistRangedExpenseReplace(
+      return persistRangedExpenseReplace(
         deleteTargets,
         instances,
         rangedPersistParams,
-      );
-      void syncPromise.catch(safeLogError);
-      return;
+      ).syncPromise;
     }
 
     const updates = planRangedExpenseInPlaceUpdates(expenseData, expensesInRange);
-    const { syncPromise } = persistRangedExpenseInPlaceEdit(
-      updates,
-      {
-        ...rangedPersistParams,
-        uid: selectedExpenseAuthorUid,
-      },
-    );
-    void syncPromise.catch(safeLogError);
+    return persistRangedExpenseInPlaceEdit(updates, {
+      ...rangedPersistParams,
+      uid: selectedExpenseAuthorUid,
+    }).syncPromise;
   };
 
   const editSingleData = async (expenseData: ExpenseData) => {
@@ -375,6 +368,8 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
         expenseData.splitList = [];
       }
 
+      let rangedSyncPromise: Promise<void> | null = null;
+
       if (isEditing) {
         // editing the expense
         if (
@@ -383,7 +378,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
           selectedExpense.rangeId
         ) {
           // editing ranged Data
-          editRangedData(expenseData);
+          rangedSyncPromise = editRangedData(expenseData);
         } else {
           // editing normal expense (no-ranged)
           await editSingleData(expenseData);
@@ -410,7 +405,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
           expenseData.endDate.toString().slice(0, 10)
         ) {
           // adding a new ranged expense (no-editing)
-          createRangedData(expenseData);
+          rangedSyncPromise = createRangedData(expenseData);
         } else {
           // adding a new normal expense (no-editing, no-ranged)
           await createSingleData(expenseData);
@@ -431,8 +426,19 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
       // Clear draft data after successful submission
       clearExpenseDraft(editedExpenseId);
       navigation.popToTop();
-      if (isOnline && (await isConnectionFastEnoughAsBool()))
+      const shouldTouchTravelers =
+        isOnline && (await isConnectionFastEnoughAsBool());
+      if (rangedSyncPromise) {
+        void rangedSyncPromise.catch(safeLogError);
+        notifyTravelersAfterRangedSync(
+          rangedSyncPromise,
+          tripid,
+          shouldTouchTravelers,
+          touchAllTravelers,
+        );
+      } else if (shouldTouchTravelers) {
         await touchAllTravelers(tripid, true);
+      }
     } catch (error) {
       safeLogError(error);
       return Promise.reject(error);

--- a/TravelCostApp/screens/ManageExpense.tsx
+++ b/TravelCostApp/screens/ManageExpense.tsx
@@ -25,7 +25,15 @@ import {
   storeExpenseOnlineOffline,
   updateExpenseOnlineOffline,
 } from "../util/offline-queue";
-import { deleteUserExpenses } from "../util/user-delete-expense";
+import {
+  collectUserDeleteTargets,
+  deleteUserExpenses,
+} from "../util/user-delete-expense";
+import {
+  persistRangedExpenseAdd,
+  persistRangedExpenseInPlaceEdit,
+  persistRangedExpenseReplace,
+} from "../util/ranged-expense-persist";
 
 import { i18n } from "../i18n/i18n";
 
@@ -249,42 +257,14 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
   const newRangeId = () =>
     Date.now().toString() + Math.random().toString(36).substring(2, 15);
 
-  const persistNewRangedInstances = async (instances: ExpenseData[]) => {
-    const progressMax = Math.max(instances.length - 1, 0);
-
-    for (let i = 0; i < instances.length; i++) {
-      Toast.show({
-        type: "loading",
-        text1: i18n.t("toastSaving1"),
-        text2: i18n.t("toastSaving2"),
-        autoHide: false,
-        props: {
-          progress: progressMax === 0 ? 0 : i / progressMax,
-          progressAt: i,
-          progressMax,
-          size: "small",
-        },
-      });
-
-      const expenseToPersist = {
-        ...instances[i],
-        editedTimestamp: Date.now(),
-      };
-
-      const item: OfflineQueueManageExpenseItem = {
-        type: "add",
-        expense: {
-          tripid: tripid,
-          uid: uid,
-          expenseData: expenseToPersist,
-        },
-      };
-      const id = await storeExpenseOnlineOffline(item, isOnline);
-      expenseCtx.addExpense({ ...expenseToPersist, id: id ?? "" });
-    }
+  const rangedPersistParams = {
+    tripid,
+    uid,
+    isOnline,
+    expenseCtx,
   };
 
-  const createRangedData = async (expenseData: ExpenseData) => {
+  const createRangedData = (expenseData: ExpenseData) => {
     const rangeId = newRangeId();
     const dates = buildRangedExpenseDatesFromSpan(
       expenseData.startDate,
@@ -296,25 +276,11 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
       dates,
     });
 
-    await persistNewRangedInstances(instances);
+    const { syncPromise } = persistRangedExpenseAdd(instances, rangedPersistParams);
+    void syncPromise.catch(safeLogError);
   };
 
-  const editSingleData = async (expenseData: ExpenseData) => {
-    expenseData.editedTimestamp = Date.now();
-    const item: OfflineQueueManageExpenseItem = {
-      type: "update",
-      expense: {
-        tripid: tripid,
-        uid: selectedExpenseAuthorUid,
-        expenseData: expenseData,
-        id: editedExpenseId,
-      },
-    };
-    expenseCtx.updateExpense(editedExpenseId, expenseData);
-    await updateExpenseOnlineOffline(item, isOnline);
-  };
-
-  const editRangedData = async (expenseData: ExpenseData) => {
+  const editRangedData = (expenseData: ExpenseData) => {
     const expensesInRange = expenseCtx.expenses.filter(
       (expense) =>
         expense.rangeId && expense.rangeId === selectedExpense?.rangeId
@@ -330,57 +296,52 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
           id: editedExpenseId,
         },
       };
-      await deleteExpenseOnlineOffline(item, isOnline);
+      void deleteExpenseOnlineOffline(item, isOnline).catch(safeLogError);
 
       const instances = planNonRangedToRangedInstances(expenseData, newRangeId());
-      await persistNewRangedInstances(instances);
+      const { syncPromise } = persistRangedExpenseAdd(instances, rangedPersistParams);
+      void syncPromise.catch(safeLogError);
       return;
     }
 
     if (shouldReplaceRangedExpenseInstances(expensesInRange, expenseData)) {
-      await deleteAllExpensesByRangedId(
-        tripid,
-        selectedExpense,
-        isOnline,
-        expenseCtx,
-        { showUndoToast: false },
-      );
-
+      const deleteTargets = collectUserDeleteTargets(tripid, expenseCtx.expenses, [
+        selectedExpense.id!,
+      ]);
       const instances = planRangedExpenseReplacement(expenseData, newRangeId());
-      await persistNewRangedInstances(instances);
+      const { syncPromise } = persistRangedExpenseReplace(
+        deleteTargets,
+        instances,
+        rangedPersistParams,
+      );
+      void syncPromise.catch(safeLogError);
       return;
     }
 
     const updates = planRangedExpenseInPlaceUpdates(expenseData, expensesInRange);
-    const progressMax = updates.length;
+    const { syncPromise } = persistRangedExpenseInPlaceEdit(
+      updates,
+      {
+        ...rangedPersistParams,
+        uid: selectedExpenseAuthorUid,
+      },
+    );
+    void syncPromise.catch(safeLogError);
+  };
 
-    for (let i = 0; i < updates.length; i++) {
-      Toast.show({
-        type: "loading",
-        text1: i18n.t("toastSaving1"),
-        text2: i18n.t("toastSaving2"),
-        autoHide: false,
-        props: {
-          progress: i / progressMax,
-          progressAt: i,
-          progressMax,
-          size: "small",
-        },
-      });
-
-      const { id, expenseData: updatedExpenseData } = updates[i];
-      const item: OfflineQueueManageExpenseItem = {
-        type: "update",
-        expense: {
-          tripid: tripid,
-          uid: selectedExpenseAuthorUid,
-          expenseData: updatedExpenseData,
-          id,
-        },
-      };
-      expenseCtx.updateExpense(id, updatedExpenseData);
-      await updateExpenseOnlineOffline(item, isOnline);
-    }
+  const editSingleData = async (expenseData: ExpenseData) => {
+    expenseData.editedTimestamp = Date.now();
+    const item: OfflineQueueManageExpenseItem = {
+      type: "update",
+      expense: {
+        tripid: tripid,
+        uid: selectedExpenseAuthorUid,
+        expenseData: expenseData,
+        id: editedExpenseId,
+      },
+    };
+    expenseCtx.updateExpense(editedExpenseId, expenseData);
+    await updateExpenseOnlineOffline(item, isOnline);
   };
 
   async function confirmHandler(payload: ExpenseFormSubmitPayload): Promise<void> {
@@ -422,7 +383,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
           selectedExpense.rangeId
         ) {
           // editing ranged Data
-          await editRangedData(expenseData);
+          editRangedData(expenseData);
         } else {
           // editing normal expense (no-ranged)
           await editSingleData(expenseData);
@@ -449,7 +410,7 @@ const ManageExpense = ({ route, navigation }: ManageExpenseProps) => {
           expenseData.endDate.toString().slice(0, 10)
         ) {
           // adding a new ranged expense (no-editing)
-          await createRangedData(expenseData);
+          createRangedData(expenseData);
         } else {
           // adding a new normal expense (no-editing, no-ranged)
           await createSingleData(expenseData);

--- a/TravelCostApp/util/notify-travelers-after-ranged-sync.ts
+++ b/TravelCostApp/util/notify-travelers-after-ranged-sync.ts
@@ -1,0 +1,16 @@
+import safeLogError from "./error";
+
+export function notifyTravelersAfterRangedSync(
+  syncPromise: Promise<void>,
+  tripid: string,
+  isOnline: boolean,
+  touchAllTravelers: (tripid: string, notify: boolean) => Promise<void>,
+): void {
+  if (!isOnline) {
+    return;
+  }
+
+  void syncPromise
+    .finally(() => touchAllTravelers(tripid, true))
+    .catch(safeLogError);
+}

--- a/TravelCostApp/util/offline-queue.ts
+++ b/TravelCostApp/util/offline-queue.ts
@@ -19,6 +19,7 @@ import { isConnectionFastEnough } from "./connectionSpeed";
 import { secureStoreGetItem } from "../store/secure-storage";
 import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "../store/mmkv";
 import safeLogError from "./error";
+import { withRetries } from "./sync-with-retries";
 
 // interface of offline queue manage expense item
 export interface OfflineQueueManageExpenseItem {
@@ -90,50 +91,104 @@ export const removePendingDeleteFromOfflineQueue = (
   return true;
 };
 
-/**
- * Deletes an expense either online or offline based on the provided parameters.
- * @async
- * @param {OfflineQueueManageExpenseItem} item - The expense item to be deleted.
- * @param {boolean} online - A boolean value indicating whether the deletion should be performed online or offline.
- * @throws {Error} Throws an error if no tripid is found in asyncStore.
- * @returns {Promise<void>} Returns a Promise that resolves when the deletion is complete.
- */
-export const deleteExpenseOnlineOffline = async (
+const resolveTripidOrThrow = async (
   item: OfflineQueueManageExpenseItem,
-  online: boolean,
+  errorMessage: string,
+  toastKey: "toastErrorStoreExp" | "toastErrorUpdateExp" | "toastErrorDeleteExp",
 ) => {
-  // load tripid from asyncstore to fix the tripctx tripid bug
   const tripid = await secureStoreGetItem("currentTripId");
   if (!tripid) {
     Toast.show({
       type: "error",
       text1: i18n.t("error"),
-      text2: i18n.t("toastErrorDeleteExp"),
+      text2: i18n.t(toastKey),
     });
-    throw new Error(
-      "No tripid found in asyncStore! (storeExpenseOnlineOffline)",
-    );
+    throw new Error(errorMessage);
   }
   item.expense.tripid = tripid;
+  return tripid;
+};
 
-  // if the internet is not fast enough, store in offline queue
+const attemptStoreExpenseOnline = async (
+  item: OfflineQueueManageExpenseItem,
+): Promise<string> => {
+  const expenseId = ensureAddItemId(item);
+  if (expenseId && item.expense.expenseData) {
+    await storeExpenseWithId(
+      item.expense.tripid,
+      item.expense.uid,
+      expenseId,
+      item.expense.expenseData,
+    );
+    return expenseId;
+  }
+  return storeExpense(
+    item.expense.tripid,
+    item.expense.uid,
+    item.expense.expenseData,
+  );
+};
+
+const attemptUpdateExpenseOnline = async (
+  item: OfflineQueueManageExpenseItem,
+): Promise<void> => {
+  await updateExpense(
+    item.expense.tripid,
+    item.expense.uid,
+    item.expense.id,
+    item.expense.expenseData,
+  );
+};
+
+const attemptDeleteExpenseOnline = async (
+  item: OfflineQueueManageExpenseItem,
+): Promise<void> => {
+  await deleteExpense(
+    item.expense.tripid,
+    item.expense.uid,
+    item.expense.id,
+  );
+};
+
+/**
+ * Deletes an expense either online or offline based on the provided parameters.
+ */
+export const deleteExpenseWithRetryAndQueue = async (
+  item: OfflineQueueManageExpenseItem,
+  online: boolean,
+): Promise<void> => {
+  await resolveTripidOrThrow(
+    item,
+    "No tripid found in asyncStore! (deleteExpenseWithRetryAndQueue)",
+    "toastErrorDeleteExp",
+  );
+
   const { isFastEnough } = await isConnectionFastEnough();
   if (online && isFastEnough) {
-    // delete item online
     try {
-      await deleteExpense(
-        item.expense.tripid,
-        item.expense.uid,
-        item.expense.id,
-      );
+      await withRetries(() => attemptDeleteExpenseOnline(item));
+      return;
     } catch (error) {
-      await pushQueueReturnRndID(item);
+      safeLogError("deleteExpenseWithRetryAndQueue online failed: " + error);
     }
-  } else {
-    // delete item offline
+  }
+
+  try {
     await pushQueueReturnRndID(item);
+  } catch (error) {
+    Toast.show({
+      type: "error",
+      text1: i18n.t("error"),
+      text2: i18n.t("toastErrorDeleteExp"),
+    });
+    throw error;
   }
 };
+
+export const deleteExpenseOnlineOffline = async (
+  item: OfflineQueueManageExpenseItem,
+  online: boolean,
+) => deleteExpenseWithRetryAndQueue(item, online);
 
 /**
  * Restores a soft-deleted expense on the server or offline queue (mirrors deleteExpenseOnlineOffline).
@@ -195,96 +250,95 @@ export const restoreExpenseOnlineOffline = async (
 export const updateExpenseOnlineOffline = async (
   item: OfflineQueueManageExpenseItem,
   online = true,
-) => {
-  // load tripid from asyncstore to fix the tripctx tripid bug
-  const tripid = await secureStoreGetItem("currentTripId");
-  if (!tripid) {
-    Toast.show({
-      type: "error",
-      text1: i18n.t("error"),
-      text2: i18n.t("toastErrorUpdateExp"),
-    });
-    throw new Error(
-      "No tripid found in asyncStore! (storeExpenseOnlineOffline)",
-    );
-  }
-  item.expense.tripid = tripid;
-  // if the internet is not fast enough, store in offline queue
-  const { isFastEnough } = await isConnectionFastEnough();
-  if (online && isFastEnough) {
-    // update item online
-    try {
-      await updateExpense(
-        item.expense.tripid,
-        item.expense.uid,
-        item.expense.id,
-        item.expense.expenseData,
-      );
-    } catch (error) {
-      await pushQueueReturnRndID(item);
-    }
-  } else {
-    // update item offline
-    await pushQueueReturnRndID(item);
-  }
-};
+) => updateExpenseWithRetryAndQueue(item, online);
 
-/**
- * This function stores an expense either online or offline based on the internet speed and availability.
- * @param {OfflineQueueManageExpenseItem} item - The expense item to be stored.
- * @param {boolean} online - A boolean value indicating whether the device is online or not.
- * @returns {Promise<string>} - A promise that resolves to the ID of the stored expense.
- * @throws {Error} - If there is no trip ID found in the async store.
- */
-export const storeExpenseOnlineOffline = async (
+export const storeExpenseWithRetryAndQueue = async (
   item: OfflineQueueManageExpenseItem,
   online: boolean,
-  forceTripid = null,
-) => {
-  // load tripid from asyncstore to fix the tripctx tripid bug
-  const tripid = forceTripid ?? (await secureStoreGetItem("currentTripId"));
-  if (!tripid) {
+): Promise<string> => {
+  await resolveTripidOrThrow(
+    item,
+    "No tripid found in asyncStore! (storeExpenseWithRetryAndQueue)",
+    "toastErrorStoreExp",
+  );
+  ensureAddItemId(item);
+
+  const { isFastEnough } = await isConnectionFastEnough();
+  if (online && isFastEnough) {
+    try {
+      return await withRetries(() => attemptStoreExpenseOnline(item));
+    } catch (error) {
+      safeLogError("storeExpenseWithRetryAndQueue online failed: " + error);
+    }
+  }
+
+  try {
+    return await pushQueueReturnRndID(item);
+  } catch (error) {
     Toast.show({
       type: "error",
       text1: i18n.t("error"),
       text2: i18n.t("toastErrorStoreExp"),
     });
-    throw new Error(
-      "No tripid found in asyncStore! (storeExpenseOnlineOffline)",
-    );
+    throw error;
   }
-  item.expense.tripid = tripid;
-  const expenseId = ensureAddItemId(item);
-  // if the internet is not fast enough, store in offline queue
+};
+
+export const updateExpenseWithRetryAndQueue = async (
+  item: OfflineQueueManageExpenseItem,
+  online = true,
+): Promise<void> => {
+  await resolveTripidOrThrow(
+    item,
+    "No tripid found in asyncStore! (updateExpenseWithRetryAndQueue)",
+    "toastErrorUpdateExp",
+  );
+
   const { isFastEnough } = await isConnectionFastEnough();
   if (online && isFastEnough) {
-    // store item online
     try {
-      if (expenseId && item.expense.expenseData) {
-        await storeExpenseWithId(
-          item.expense.tripid,
-          item.expense.uid,
-          expenseId,
-          item.expense.expenseData,
-        );
-        return expenseId;
-      }
-      return await storeExpense(
-        item.expense.tripid,
-        item.expense.uid,
-        item.expense.expenseData,
-      );
+      await withRetries(() => attemptUpdateExpenseOnline(item));
+      return;
     } catch (error) {
-      safeLogError("error1: could not store expense " + error);
-      const id = await pushQueueReturnRndID(item);
-      return id;
+      safeLogError("updateExpenseWithRetryAndQueue online failed: " + error);
     }
-  } else {
-    // store item offline
-    safeLogError("error2 : network is not online && fast enough");
-    const id = await pushQueueReturnRndID(item);
-    return id;
   }
+
+  try {
+    await pushQueueReturnRndID(item);
+  } catch (error) {
+    Toast.show({
+      type: "error",
+      text1: i18n.t("error"),
+      text2: i18n.t("toastErrorUpdateExp"),
+    });
+    throw error;
+  }
+};
+
+/**
+ * Stores an expense online with retries, or queues it when offline or after failures.
+ */
+export const storeExpenseOnlineOffline = async (
+  item: OfflineQueueManageExpenseItem,
+  online: boolean,
+  forceTripid: string | null = null,
+) => {
+  if (forceTripid) {
+    item.expense.tripid = forceTripid;
+    ensureAddItemId(item);
+    const { isFastEnough } = await isConnectionFastEnough();
+    if (online && isFastEnough) {
+      try {
+        return await withRetries(() => attemptStoreExpenseOnline(item));
+      } catch (error) {
+        safeLogError("error1: could not store expense " + error);
+        return pushQueueReturnRndID(item);
+      }
+    }
+    return pushQueueReturnRndID(item);
+  }
+  return storeExpenseWithRetryAndQueue(item, online);
 };
 
 /**

--- a/TravelCostApp/util/offline-queue.ts
+++ b/TravelCostApp/util/offline-queue.ts
@@ -188,7 +188,25 @@ export const deleteExpenseWithRetryAndQueue = async (
 export const deleteExpenseOnlineOffline = async (
   item: OfflineQueueManageExpenseItem,
   online: boolean,
-) => deleteExpenseWithRetryAndQueue(item, online);
+): Promise<void> => {
+  await resolveTripidOrThrow(
+    item,
+    "No tripid found in asyncStore! (deleteExpenseOnlineOffline)",
+    "toastErrorDeleteExp",
+  );
+
+  const { isFastEnough } = await isConnectionFastEnough();
+  if (online && isFastEnough) {
+    try {
+      await attemptDeleteExpenseOnline(item);
+      return;
+    } catch (error) {
+      await pushQueueReturnRndID(item);
+    }
+  } else {
+    await pushQueueReturnRndID(item);
+  }
+};
 
 /**
  * Restores a soft-deleted expense on the server or offline queue (mirrors deleteExpenseOnlineOffline).
@@ -250,7 +268,25 @@ export const restoreExpenseOnlineOffline = async (
 export const updateExpenseOnlineOffline = async (
   item: OfflineQueueManageExpenseItem,
   online = true,
-) => updateExpenseWithRetryAndQueue(item, online);
+): Promise<void> => {
+  await resolveTripidOrThrow(
+    item,
+    "No tripid found in asyncStore! (updateExpenseOnlineOffline)",
+    "toastErrorUpdateExp",
+  );
+
+  const { isFastEnough } = await isConnectionFastEnough();
+  if (online && isFastEnough) {
+    try {
+      await attemptUpdateExpenseOnline(item);
+      return;
+    } catch (error) {
+      await pushQueueReturnRndID(item);
+    }
+  } else {
+    await pushQueueReturnRndID(item);
+  }
+};
 
 export const storeExpenseWithRetryAndQueue = async (
   item: OfflineQueueManageExpenseItem,
@@ -323,22 +359,33 @@ export const storeExpenseOnlineOffline = async (
   item: OfflineQueueManageExpenseItem,
   online: boolean,
   forceTripid: string | null = null,
-) => {
-  if (forceTripid) {
-    item.expense.tripid = forceTripid;
-    ensureAddItemId(item);
-    const { isFastEnough } = await isConnectionFastEnough();
-    if (online && isFastEnough) {
-      try {
-        return await withRetries(() => attemptStoreExpenseOnline(item));
-      } catch (error) {
-        safeLogError("error1: could not store expense " + error);
-        return pushQueueReturnRndID(item);
-      }
-    }
-    return pushQueueReturnRndID(item);
+): Promise<string> => {
+  const tripid = forceTripid ?? (await secureStoreGetItem("currentTripId"));
+  if (!tripid) {
+    Toast.show({
+      type: "error",
+      text1: i18n.t("error"),
+      text2: i18n.t("toastErrorStoreExp"),
+    });
+    throw new Error(
+      "No tripid found in asyncStore! (storeExpenseOnlineOffline)",
+    );
   }
-  return storeExpenseWithRetryAndQueue(item, online);
+  item.expense.tripid = tripid;
+  ensureAddItemId(item);
+
+  const { isFastEnough } = await isConnectionFastEnough();
+  if (online && isFastEnough) {
+    try {
+      return await attemptStoreExpenseOnline(item);
+    } catch (error) {
+      safeLogError("error1: could not store expense " + error);
+      return pushQueueReturnRndID(item);
+    }
+  }
+
+  safeLogError("error2 : network is not online && fast enough");
+  return pushQueueReturnRndID(item);
 };
 
 /**

--- a/TravelCostApp/util/ranged-expense-persist.ts
+++ b/TravelCostApp/util/ranged-expense-persist.ts
@@ -1,0 +1,144 @@
+import type { ExpenseData } from "./expense";
+import {
+  deleteExpenseWithRetryAndQueue,
+  OfflineQueueManageExpenseItem,
+  storeExpenseWithRetryAndQueue,
+  updateExpenseWithRetryAndQueue,
+} from "./offline-queue";
+import type { UserDeleteExpenseTarget } from "./user-delete-expense";
+
+export interface RangedExpensePersistContext {
+  addExpense: (expense: ExpenseData) => void;
+  updateExpense: (id: string, expenseData: ExpenseData) => void;
+  deleteExpense: (id: string) => void;
+  updateExpenseId?: (oldId: string, newId: string) => void;
+}
+
+export interface RangedExpensePersistParams {
+  tripid: string;
+  uid: string;
+  isOnline: boolean;
+  expenseCtx: RangedExpensePersistContext;
+}
+
+const assignClientIds = (instances: ExpenseData[], editedTimestamp: number) =>
+  instances.map((instance) => {
+    const id =
+      instance.id ||
+      `${Date.now()}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
+    return {
+      ...instance,
+      id,
+      editedTimestamp,
+    };
+  });
+
+async function syncRangedAdds(
+  expenses: ExpenseData[],
+  { tripid, uid, isOnline }: RangedExpensePersistParams,
+): Promise<void> {
+  for (const expenseData of expenses) {
+    const item: OfflineQueueManageExpenseItem = {
+      type: "add",
+      expense: {
+        tripid,
+        uid,
+        id: expenseData.id,
+        expenseData,
+      },
+    };
+    await storeExpenseWithRetryAndQueue(item, isOnline);
+  }
+}
+
+export function persistRangedExpenseAdd(
+  instances: ExpenseData[],
+  params: RangedExpensePersistParams,
+): { syncPromise: Promise<void> } {
+  const editedTimestamp = Date.now();
+  const prepared = assignClientIds(instances, editedTimestamp);
+
+  for (const expense of prepared) {
+    params.expenseCtx.addExpense(expense);
+  }
+
+  return {
+    syncPromise: syncRangedAdds(prepared, params),
+  };
+}
+
+export type RangedExpenseInPlaceUpdate = {
+  id: string;
+  expenseData: ExpenseData;
+};
+
+async function syncRangedInPlaceUpdates(
+  updates: RangedExpenseInPlaceUpdate[],
+  { tripid, uid, isOnline }: RangedExpensePersistParams,
+): Promise<void> {
+  for (const { id, expenseData } of updates) {
+    const item: OfflineQueueManageExpenseItem = {
+      type: "update",
+      expense: {
+        tripid,
+        uid,
+        id,
+        expenseData,
+      },
+    };
+    await updateExpenseWithRetryAndQueue(item, isOnline);
+  }
+}
+
+export function persistRangedExpenseInPlaceEdit(
+  updates: RangedExpenseInPlaceUpdate[],
+  params: RangedExpensePersistParams,
+): { syncPromise: Promise<void> } {
+  for (const { id, expenseData } of updates) {
+    params.expenseCtx.updateExpense(id, expenseData);
+  }
+
+  return {
+    syncPromise: syncRangedInPlaceUpdates(updates, params),
+  };
+}
+
+async function syncRangedDeletes(
+  targets: UserDeleteExpenseTarget[],
+  isOnline: boolean,
+): Promise<void> {
+  for (const target of targets) {
+    const item: OfflineQueueManageExpenseItem = {
+      type: "delete",
+      expense: {
+        tripid: target.tripid,
+        uid: target.uid,
+        id: target.id,
+      },
+    };
+    await deleteExpenseWithRetryAndQueue(item, isOnline);
+  }
+}
+
+export function persistRangedExpenseReplace(
+  deleteTargets: UserDeleteExpenseTarget[],
+  newInstances: ExpenseData[],
+  params: RangedExpensePersistParams,
+): { syncPromise: Promise<void> } {
+  for (const target of deleteTargets) {
+    params.expenseCtx.deleteExpense(target.id);
+  }
+
+  const editedTimestamp = Date.now();
+  const prepared = assignClientIds(newInstances, editedTimestamp);
+  for (const expense of prepared) {
+    params.expenseCtx.addExpense(expense);
+  }
+
+  return {
+    syncPromise: (async () => {
+      await syncRangedDeletes(deleteTargets, params.isOnline);
+      await syncRangedAdds(prepared, params);
+    })(),
+  };
+}

--- a/TravelCostApp/util/sync-with-retries.ts
+++ b/TravelCostApp/util/sync-with-retries.ts
@@ -1,0 +1,27 @@
+const DEFAULT_DELAYS_MS = [1000, 2000, 4000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withRetries<T>(
+  fn: () => Promise<T>,
+  options?: { maxAttempts?: number; delaysMs?: number[] },
+): Promise<T> {
+  const maxAttempts = options?.maxAttempts ?? 3;
+  const delaysMs = options?.delaysMs ?? DEFAULT_DELAYS_MS;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxAttempts - 1) {
+        await sleep(delaysMs[attempt] ?? delaysMs[delaysMs.length - 1]);
+      }
+    }
+  }
+
+  throw lastError;
+}

--- a/TravelCostApp/util/user-delete-expense.ts
+++ b/TravelCostApp/util/user-delete-expense.ts
@@ -148,12 +148,6 @@ export async function deleteUserExpenses({
 
   clearPendingUndoDelete();
   Toast.hide();
-  Toast.show({
-    type: "loading",
-    text1: i18n.t("toastDeleting1"),
-    text2: i18n.t("toastDeleting2"),
-    autoHide: false,
-  });
 
   try {
     for (const target of targets) {


### PR DESCRIPTION
## Summary
- Extract ranged expense persistence into `ranged-expense-persist` so add, in-place edit, and span-replace update the ledger immediately and sync in the background (no progress loading toasts).
- Add 3× retry with backoff before falling back to the offline queue; keep optimistic local state on failure instead of reverting.
- Remove the delete loading toast so ranged and single deletes feel instant while undo + queue sync still apply.

## Test plan
- [x] `pnpm test -- __tests__/util/ranged-expense-persist.test.ts`
- [x] `pnpm test -- __tests__/util/user-delete-expense.test.ts __tests__/util/offline-queue-sync.test.ts __tests__/util/offline-expense-sync-vertical.test.ts`
- [ ] Add a multi-day ranged expense online — form closes immediately, days appear in ledger without progress bar
- [ ] Edit ranged expense in place — updates visible immediately, no loading toast
- [ ] Change ranged span (replace) — old days removed and new days added optimistically
- [ ] Delete ranged expense (one day / all days) — instant soft-delete with undo toast, no deleting spinner
- [ ] Simulate network failure — retries then offline queue entry; ledger unchanged