### PR TITLE
Fix new-expense currency default when lastCurrency differs from trip

### DIFF
--- a/TravelCostApp/__tests__/components/expense-form.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-form.test.tsx
@@ -117,15 +117,26 @@ jest.mock("../../components/Currency/CurrencyPicker", () => {
   const { Text } = require("react-native");
   return function MockCurrencyPicker({
     countryValue,
+    inputCurrencyCode,
     placeholder,
   }: {
     countryValue?: string;
+    inputCurrencyCode?: string;
     placeholder?: string;
   }) {
     return React.createElement(
-      Text,
-      { testID: "expense-form-currency-value" },
-      countryValue ?? placeholder ?? ""
+      React.Fragment,
+      null,
+      React.createElement(
+        Text,
+        { testID: "expense-form-currency-value" },
+        countryValue ?? placeholder ?? ""
+      ),
+      React.createElement(
+        Text,
+        { testID: "expense-form-currency-input" },
+        inputCurrencyCode ?? ""
+      )
     );
   };
 });
@@ -136,6 +147,46 @@ import { makeExpense } from "../fixtures/expense";
 import { AppProviders, renderWithAppProviders } from "../fixtures/app-providers";
 import { Alert } from "react-native";
 import { getExpenseDraft } from "../../store/mmkv";
+import type { RenderAPI } from "@testing-library/react-native";
+
+function mockRangedSplitAlert() {
+  return jest
+    .spyOn(Alert, "alert")
+    .mockImplementation((_title, _message, buttons) => {
+      const splitButton = buttons?.find(
+        (button) => button.text === i18n.t("splitUpExpenses")
+      );
+      splitButton?.onPress?.();
+    });
+}
+
+function mockDraftRestoreAlert() {
+  return jest
+    .spyOn(Alert, "alert")
+    .mockImplementation((_title, _message, buttons) => {
+      const restoreButton = buttons?.find(
+        (button) => button.text === i18n.t("restore")
+      );
+      restoreButton?.onPress?.();
+    });
+}
+
+function confirmRangedDateSpan(screen: RenderAPI) {
+  fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+  fireEvent.press(screen.getByTestId("open-date-range"));
+  fireEvent.press(screen.getByTestId("confirm-ranged-dates"));
+}
+
+async function expectExpenseFormCurrencyInput(
+  screen: RenderAPI,
+  currency: string
+) {
+  await waitFor(() => {
+    expect(screen.getByTestId("expense-form-currency-input")).toHaveTextContent(
+      currency
+    );
+  });
+}
 
 function renderNewExpenseForm(
   overrides: Parameters<typeof renderWithAppProviders>[1] = {}
@@ -187,7 +238,7 @@ function renderNewExpenseForm(
   );
 }
 
-function renderNewExpenseWithDeferredLastCountry(
+function renderNewExpenseWithDeferredLastLocale(
   onSubmit: jest.Mock = jest.fn(async () => {})
 ) {
   const navigation = {
@@ -353,15 +404,11 @@ describe("ExpenseForm", () => {
 
     fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
 
-    await waitFor(() => {
-      expect(screen.getByTestId("expense-form-currency-value")).toHaveTextContent(
-        "USD"
-      );
-    });
+    await expectExpenseFormCurrencyInput(screen, "USD");
   });
 
   it("applies latest-used country after secure storage loads on a new expense", async () => {
-    const screen = renderNewExpenseWithDeferredLastCountry();
+    const screen = renderNewExpenseWithDeferredLastLocale();
 
     fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
 
@@ -373,20 +420,10 @@ describe("ExpenseForm", () => {
   });
 
   it("keeps latest-used country after confirming a ranged date span", async () => {
-    const alertSpy = jest
-      .spyOn(Alert, "alert")
-      .mockImplementation((_title, _message, buttons) => {
-        const splitButton = buttons?.find(
-          (button) => button.text === i18n.t("splitUpExpenses")
-        );
-        splitButton?.onPress?.();
-      });
+    const alertSpy = mockRangedSplitAlert();
+    const screen = renderNewExpenseWithDeferredLastLocale();
 
-    const screen = renderNewExpenseWithDeferredLastCountry();
-
-    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
-    fireEvent.press(screen.getByTestId("open-date-range"));
-    fireEvent.press(screen.getByTestId("confirm-ranged-dates"));
+    confirmRangedDateSpan(screen);
 
     await waitFor(() => {
       expect(screen.getByTestId("expense-form-country-flag")).toHaveTextContent(
@@ -398,26 +435,12 @@ describe("ExpenseForm", () => {
   });
 
   it("keeps latest-used currency after confirming a ranged date span", async () => {
-    const alertSpy = jest
-      .spyOn(Alert, "alert")
-      .mockImplementation((_title, _message, buttons) => {
-        const splitButton = buttons?.find(
-          (button) => button.text === i18n.t("splitUpExpenses")
-        );
-        splitButton?.onPress?.();
-      });
+    const alertSpy = mockRangedSplitAlert();
+    const screen = renderNewExpenseWithDeferredLastLocale();
 
-    const screen = renderNewExpenseWithDeferredLastCountry();
+    confirmRangedDateSpan(screen);
 
-    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
-    fireEvent.press(screen.getByTestId("open-date-range"));
-    fireEvent.press(screen.getByTestId("confirm-ranged-dates"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("expense-form-currency-value")
-      ).toHaveTextContent("USD");
-    });
+    await expectExpenseFormCurrencyInput(screen, "USD");
 
     alertSpy.mockRestore();
   });
@@ -425,7 +448,7 @@ describe("ExpenseForm", () => {
   it("submits latest-used country on advanced save after secure storage loads", async () => {
     jest.useFakeTimers();
     const onSubmit = jest.fn(async () => {});
-    const screen = renderNewExpenseWithDeferredLastCountry(onSubmit);
+    const screen = renderNewExpenseWithDeferredLastLocale(onSubmit);
 
     fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
 
@@ -448,15 +471,11 @@ describe("ExpenseForm", () => {
   it("submits latest-used currency on advanced save after secure storage loads", async () => {
     jest.useFakeTimers();
     const onSubmit = jest.fn(async () => {});
-    const screen = renderNewExpenseWithDeferredLastCountry(onSubmit);
+    const screen = renderNewExpenseWithDeferredLastLocale(onSubmit);
 
     fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("expense-form-currency-value")
-      ).toHaveTextContent("USD");
-    });
+    await expectExpenseFormCurrencyInput(screen, "USD");
 
     await act(async () => {
       fireEvent.press(screen.getAllByText(i18n.t("add")).pop()!);
@@ -470,26 +489,13 @@ describe("ExpenseForm", () => {
 
   it("submits latest-used currency after confirming a ranged date span", async () => {
     jest.useFakeTimers();
-    const alertSpy = jest
-      .spyOn(Alert, "alert")
-      .mockImplementation((_title, _message, buttons) => {
-        const splitButton = buttons?.find(
-          (button) => button.text === i18n.t("splitUpExpenses")
-        );
-        splitButton?.onPress?.();
-      });
+    const alertSpy = mockRangedSplitAlert();
     const onSubmit = jest.fn(async () => {});
-    const screen = renderNewExpenseWithDeferredLastCountry(onSubmit);
+    const screen = renderNewExpenseWithDeferredLastLocale(onSubmit);
 
-    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
-    fireEvent.press(screen.getByTestId("open-date-range"));
-    fireEvent.press(screen.getByTestId("confirm-ranged-dates"));
+    confirmRangedDateSpan(screen);
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("expense-form-currency-value")
-      ).toHaveTextContent("USD");
-    });
+    await expectExpenseFormCurrencyInput(screen, "USD");
 
     await act(async () => {
       fireEvent.press(screen.getAllByText(i18n.t("add")).pop()!);
@@ -512,16 +518,8 @@ describe("ExpenseForm", () => {
     });
     (getExpenseDraft as jest.Mock).mockReturnValue(draftExpense);
 
-    const alertSpy = jest
-      .spyOn(Alert, "alert")
-      .mockImplementation((_title, _message, buttons) => {
-        const restoreButton = buttons?.find(
-          (button) => button.text === i18n.t("restore")
-        );
-        restoreButton?.onPress?.();
-      });
-
-    const screen = renderNewExpenseWithDeferredLastCountry();
+    const alertSpy = mockDraftRestoreAlert();
+    const screen = renderNewExpenseWithDeferredLastLocale();
 
     fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
 
@@ -544,24 +542,12 @@ describe("ExpenseForm", () => {
     });
     (getExpenseDraft as jest.Mock).mockReturnValue(draftExpense);
 
-    const alertSpy = jest
-      .spyOn(Alert, "alert")
-      .mockImplementation((_title, _message, buttons) => {
-        const restoreButton = buttons?.find(
-          (button) => button.text === i18n.t("restore")
-        );
-        restoreButton?.onPress?.();
-      });
-
-    const screen = renderNewExpenseWithDeferredLastCountry();
+    const alertSpy = mockDraftRestoreAlert();
+    const screen = renderNewExpenseWithDeferredLastLocale();
 
     fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("expense-form-currency-value")
-      ).toHaveTextContent("USD");
-    });
+    await expectExpenseFormCurrencyInput(screen, "USD");
 
     alertSpy.mockRestore();
     (getExpenseDraft as jest.Mock).mockReturnValue(undefined);

--- a/TravelCostApp/__tests__/components/expense-form.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-form.test.tsx
@@ -116,11 +116,17 @@ jest.mock("../../components/Currency/CurrencyPicker", () => {
   const React = require("react");
   const { Text } = require("react-native");
   return function MockCurrencyPicker({
+    countryValue,
     placeholder,
   }: {
+    countryValue?: string;
     placeholder?: string;
   }) {
-    return React.createElement(Text, null, placeholder ?? "");
+    return React.createElement(
+      Text,
+      { testID: "expense-form-currency-value" },
+      countryValue ?? placeholder ?? ""
+    );
   };
 });
 
@@ -348,7 +354,9 @@ describe("ExpenseForm", () => {
     fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
 
     await waitFor(() => {
-      expect(screen.getByText("USD | $")).toBeTruthy();
+      expect(screen.getByTestId("expense-form-currency-value")).toHaveTextContent(
+        "USD"
+      );
     });
   });
 
@@ -389,6 +397,31 @@ describe("ExpenseForm", () => {
     alertSpy.mockRestore();
   });
 
+  it("keeps latest-used currency after confirming a ranged date span", async () => {
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _message, buttons) => {
+        const splitButton = buttons?.find(
+          (button) => button.text === i18n.t("splitUpExpenses")
+        );
+        splitButton?.onPress?.();
+      });
+
+    const screen = renderNewExpenseWithDeferredLastCountry();
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+    fireEvent.press(screen.getByTestId("open-date-range"));
+    fireEvent.press(screen.getByTestId("confirm-ranged-dates"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("expense-form-currency-value")
+      ).toHaveTextContent("USD");
+    });
+
+    alertSpy.mockRestore();
+  });
+
   it("submits latest-used country on advanced save after secure storage loads", async () => {
     jest.useFakeTimers();
     const onSubmit = jest.fn(async () => {});
@@ -409,6 +442,64 @@ describe("ExpenseForm", () => {
 
     expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0].country).toBe("US");
+    jest.useRealTimers();
+  });
+
+  it("submits latest-used currency on advanced save after secure storage loads", async () => {
+    jest.useFakeTimers();
+    const onSubmit = jest.fn(async () => {});
+    const screen = renderNewExpenseWithDeferredLastCountry(onSubmit);
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("expense-form-currency-value")
+      ).toHaveTextContent("USD");
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getAllByText(i18n.t("add")).pop()!);
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(onSubmit).toHaveBeenCalled();
+    expect(onSubmit.mock.calls[0][0].currency).toBe("USD");
+    jest.useRealTimers();
+  });
+
+  it("submits latest-used currency after confirming a ranged date span", async () => {
+    jest.useFakeTimers();
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _message, buttons) => {
+        const splitButton = buttons?.find(
+          (button) => button.text === i18n.t("splitUpExpenses")
+        );
+        splitButton?.onPress?.();
+      });
+    const onSubmit = jest.fn(async () => {});
+    const screen = renderNewExpenseWithDeferredLastCountry(onSubmit);
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+    fireEvent.press(screen.getByTestId("open-date-range"));
+    fireEvent.press(screen.getByTestId("confirm-ranged-dates"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("expense-form-currency-value")
+      ).toHaveTextContent("USD");
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getAllByText(i18n.t("add")).pop()!);
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(onSubmit).toHaveBeenCalled();
+    expect(onSubmit.mock.calls[0][0].currency).toBe("USD");
+
+    alertSpy.mockRestore();
     jest.useRealTimers();
   });
 
@@ -438,6 +529,38 @@ describe("ExpenseForm", () => {
       expect(screen.getByTestId("expense-form-country-flag")).toHaveTextContent(
         "US"
       );
+    });
+
+    alertSpy.mockRestore();
+    (getExpenseDraft as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it("applies latest-used currency after restoring a draft with an empty currency", async () => {
+    const draftExpense = makeExpense({
+      amount: 25,
+      description: "Hotel stay",
+      country: "DE",
+      currency: "",
+    });
+    (getExpenseDraft as jest.Mock).mockReturnValue(draftExpense);
+
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _message, buttons) => {
+        const restoreButton = buttons?.find(
+          (button) => button.text === i18n.t("restore")
+        );
+        restoreButton?.onPress?.();
+      });
+
+    const screen = renderNewExpenseWithDeferredLastCountry();
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("expense-form-currency-value")
+      ).toHaveTextContent("USD");
     });
 
     alertSpy.mockRestore();

--- a/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-inputs.test.ts
@@ -158,6 +158,18 @@ describe("resolveLoadedLastCurrencyIfStale", () => {
       })
     ).toBeNull();
   });
+
+  it("returns latest-used currency when a restored draft left currency empty", () => {
+    expect(
+      resolveLoadedLastCurrencyIfStale({
+        isEditing: false,
+        lastCurrency: "USD",
+        currentCurrency: "",
+        tripCurrency: "EUR",
+        mostRecentExpenseCurrency: "EUR",
+      })
+    ).toBe("USD");
+  });
 });
 
 describe("resolveAmountValue", () => {

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -1535,6 +1535,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
                     setCountryValue={setCurrencyPickerValue}
                     onChangeValue={updateCurrency}
                     placeholder={currencyPlaceholder}
+                    inputCurrencyCode={inputs.currency.value}
                   ></CurrencyPicker>
                 </View>
                 <View style={[styles.inputsRowSecond]}>

--- a/TravelCostApp/util/expense-form-inputs.ts
+++ b/TravelCostApp/util/expense-form-inputs.ts
@@ -128,11 +128,11 @@ export function resolveLoadedLastCurrencyIfStale(
     tripCurrency: input.tripCurrency,
     mostRecentExpenseCurrency: input.mostRecentExpenseCurrency,
   });
+  const stillOnTripDefault =
+    input.currentCurrency === beforeLastCurrencyLoaded ||
+    (!input.currentCurrency?.trim() && beforeLastCurrencyLoaded?.trim());
 
-  if (
-    input.currentCurrency === beforeLastCurrencyLoaded &&
-    preferred !== input.currentCurrency
-  ) {
+  if (stillOnTripDefault && preferred !== input.currentCurrency) {
     return preferred;
   }
 


### PR DESCRIPTION
## Summary
- Mirror the country fix in `resolveLoadedLastCurrencyIfStale`: treat an empty current currency as a stale trip default when secure-storage `lastCurrency` loads.
- Add regression coverage for ranged date spans, advanced submit, and draft restore with empty currency.

## Test plan
- [x] `pnpm test -- __tests__/util/expense-form-inputs.test.ts __tests__/components/expense-form.test.tsx`
- [ ] New expense with `lastCurrency` ≠ trip currency — currency picker shows latest-used value
- [ ] Confirm a ranged date span — currency stays on latest-used value through submit
- [ ] Restore a draft with empty currency — latest-used currency applies after storage loads