### PR TITLE
Fit large currency amounts with compact overflow formatting

### DIFF
--- a/TravelCostApp/__tests__/components/currency-ticker-fitting.test.tsx
+++ b/TravelCostApp/__tests__/components/currency-ticker-fitting.test.tsx
@@ -1,0 +1,54 @@
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageTag: "de-DE", languageCode: "de" }],
+}));
+
+jest.mock("../../i18n/i18n", () => ({
+  i18n: { locale: "de", t: (k: string) => k },
+}));
+
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import CurrencyTicker from "../../components/UI/AnimatedNumber/CurrencyTicker";
+
+describe("CurrencyTicker fitting", () => {
+  it("shows compact trip-currency text when the full amount overflows the container", () => {
+    render(
+      <CurrencyTicker
+        value={10_000}
+        currency="EUR"
+        fontSize={32}
+        disableAnimation
+        testID="currency-ticker"
+      />
+    );
+
+    fireEvent(screen.getByTestId("currency-ticker"), "layout", {
+      nativeEvent: { layout: { width: 40, height: 20, x: 0, y: 0 } },
+    });
+    fireEvent(
+      screen.getByTestId("currency-ticker-full-probe", {
+        includeHiddenElements: true,
+      }),
+      "textLayout",
+      {
+        nativeEvent: {
+          lines: [
+            {
+              width: 80,
+              height: 20,
+              x: 0,
+              y: 0,
+              ascender: 0,
+              capHeight: 0,
+              descender: 0,
+              xHeight: 0,
+            },
+          ],
+        },
+      }
+    );
+
+    expect(screen.getByText("10k€")).toBeTruthy();
+  });
+});

--- a/TravelCostApp/__tests__/components/fitting-currency-amount.test.tsx
+++ b/TravelCostApp/__tests__/components/fitting-currency-amount.test.tsx
@@ -1,0 +1,65 @@
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageTag: "de-DE", languageCode: "de" }],
+}));
+
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { FittingCurrencyAmount } from "../../components/UI/FittingCurrencyAmount";
+
+describe("FittingCurrencyAmount", () => {
+  it("shows compact currency text when the full amount is wider than the container", () => {
+    render(
+      <FittingCurrencyAmount
+        amount={10_000}
+        currency="EUR"
+        locale="de"
+        testID="fitting-currency"
+      />
+    );
+
+    fireEvent(screen.getByTestId("fitting-currency"), "layout", {
+      nativeEvent: { layout: { width: 40, height: 20, x: 0, y: 0 } },
+    });
+    fireEvent(
+      screen.getByTestId("fitting-currency-full-probe", {
+        includeHiddenElements: true,
+      }),
+      "layout",
+      {
+        nativeEvent: { layout: { width: 80, height: 20, x: 0, y: 0 } },
+      }
+    );
+
+    expect(screen.getByText("10k€")).toBeTruthy();
+  });
+
+  it("shows the full currency text when the amount fits the container", () => {
+    render(
+      <FittingCurrencyAmount
+        amount={10_000}
+        currency="EUR"
+        locale="de"
+        testID="fitting-currency"
+      />
+    );
+
+    fireEvent(screen.getByTestId("fitting-currency"), "layout", {
+      nativeEvent: { layout: { width: 120, height: 20, x: 0, y: 0 } },
+    });
+    fireEvent(
+      screen.getByTestId("fitting-currency-full-probe", {
+        includeHiddenElements: true,
+      }),
+      "layout",
+      {
+        nativeEvent: { layout: { width: 80, height: 20, x: 0, y: 0 } },
+      }
+    );
+
+    expect(screen.queryByText("10k€")).toBeNull();
+    expect(
+      screen.getAllByText(/10\.000/, { includeHiddenElements: true }).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/TravelCostApp/__tests__/components/fitting-currency-amount.test.tsx
+++ b/TravelCostApp/__tests__/components/fitting-currency-amount.test.tsx
@@ -7,6 +7,20 @@ import { fireEvent, render, screen } from "@testing-library/react-native";
 
 import { FittingCurrencyAmount } from "../../components/UI/FittingCurrencyAmount";
 
+function fireFullProbeTextLayout(width: number) {
+  fireEvent(
+    screen.getByTestId("fitting-currency-full-probe", {
+      includeHiddenElements: true,
+    }),
+    "textLayout",
+    {
+      nativeEvent: {
+        lines: [{ width, height: 20, x: 0, y: 0, ascender: 0, capHeight: 0, descender: 0, xHeight: 0 }],
+      },
+    }
+  );
+}
+
 describe("FittingCurrencyAmount", () => {
   it("shows compact currency text when the full amount is wider than the container", () => {
     render(
@@ -21,15 +35,7 @@ describe("FittingCurrencyAmount", () => {
     fireEvent(screen.getByTestId("fitting-currency"), "layout", {
       nativeEvent: { layout: { width: 40, height: 20, x: 0, y: 0 } },
     });
-    fireEvent(
-      screen.getByTestId("fitting-currency-full-probe", {
-        includeHiddenElements: true,
-      }),
-      "layout",
-      {
-        nativeEvent: { layout: { width: 80, height: 20, x: 0, y: 0 } },
-      }
-    );
+    fireFullProbeTextLayout(80);
 
     expect(screen.getByText("10k€")).toBeTruthy();
   });
@@ -47,15 +53,7 @@ describe("FittingCurrencyAmount", () => {
     fireEvent(screen.getByTestId("fitting-currency"), "layout", {
       nativeEvent: { layout: { width: 120, height: 20, x: 0, y: 0 } },
     });
-    fireEvent(
-      screen.getByTestId("fitting-currency-full-probe", {
-        includeHiddenElements: true,
-      }),
-      "layout",
-      {
-        nativeEvent: { layout: { width: 80, height: 20, x: 0, y: 0 } },
-      }
-    );
+    fireFullProbeTextLayout(80);
 
     expect(screen.queryByText("10k€")).toBeNull();
     expect(

--- a/TravelCostApp/__tests__/util/format-compact-expense-with-currency.test.ts
+++ b/TravelCostApp/__tests__/util/format-compact-expense-with-currency.test.ts
@@ -1,4 +1,7 @@
-import { formatCompactExpenseWithCurrency } from "../../util/string";
+import {
+  formatCompactExpenseWithCurrency,
+  formatExpenseWithCurrency,
+} from "../../util/string";
 
 describe("formatCompactExpenseWithCurrency", () => {
   it("renders a German thousands amount as 1,3k€", () => {
@@ -26,6 +29,22 @@ describe("formatCompactExpenseWithCurrency", () => {
   });
 
   it("does not compact amounts under 1000", () => {
-    expect(formatCompactExpenseWithCurrency(999, "EUR", "de")).not.toMatch(/k/);
+    expect(formatCompactExpenseWithCurrency(999, "EUR", "de")).toBe(
+      formatExpenseWithCurrency(999, "EUR", undefined, "de")
+    );
+  });
+
+  it("rounds 9999 EUR in German to 10k€ not 10,0k€", () => {
+    expect(formatCompactExpenseWithCurrency(9999, "EUR", "de")).toBe("10k€");
+  });
+
+  it("carries 999999 EUR in German to 1 Mio.€ not 1000,0k€", () => {
+    expect(formatCompactExpenseWithCurrency(999_999, "EUR", "de")).toBe(
+      "1 Mio.€"
+    );
+  });
+
+  it("rounds 1999 EUR in German to 2k€", () => {
+    expect(formatCompactExpenseWithCurrency(1999, "EUR", "de")).toBe("2k€");
   });
 });

--- a/TravelCostApp/__tests__/util/format-compact-expense-with-currency.test.ts
+++ b/TravelCostApp/__tests__/util/format-compact-expense-with-currency.test.ts
@@ -1,0 +1,31 @@
+import { formatCompactExpenseWithCurrency } from "../../util/string";
+
+describe("formatCompactExpenseWithCurrency", () => {
+  it("renders a German thousands amount as 1,3k€", () => {
+    expect(formatCompactExpenseWithCurrency(1300, "EUR", "de")).toBe("1,3k€");
+  });
+
+  it("renders a German millions amount as 1,3 Mio.€", () => {
+    expect(formatCompactExpenseWithCurrency(1_300_000, "EUR", "de")).toBe(
+      "1,3 Mio.€"
+    );
+  });
+
+  it("renders an English thousands amount as €1.3k", () => {
+    expect(formatCompactExpenseWithCurrency(1300, "EUR", "en")).toBe("€1.3k");
+  });
+
+  it("renders a German billions amount as 1,3 Mrd.€", () => {
+    expect(formatCompactExpenseWithCurrency(1_300_000_000, "EUR", "de")).toBe(
+      "1,3 Mrd.€"
+    );
+  });
+
+  it("renders a French thousands amount as 1,3k€", () => {
+    expect(formatCompactExpenseWithCurrency(1300, "EUR", "fr")).toBe("1,3k€");
+  });
+
+  it("does not compact amounts under 1000", () => {
+    expect(formatCompactExpenseWithCurrency(999, "EUR", "de")).not.toMatch(/k/);
+  });
+});

--- a/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
@@ -221,8 +221,6 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
           currency={tripCurrency}
           fontSize={periodHeaderLabelFontSize}
           style={{ color: budgetColor }}
-          truncate={true}
-          truncateLimit={1000}
           disableAnimation={settings.disableNumberAnimations}
         />
       </View>

--- a/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
@@ -250,6 +250,8 @@ ExpensesSummary.propTypes = {
 const styles = StyleSheet.create({
   sumTextContainer: {
     alignItems: "center",
+    alignSelf: "stretch",
+    width: "100%",
   },
   offlineText: {
     color: GlobalStyles.colors.primary500,

--- a/TravelCostApp/components/ProfileOutput/TripHistoryItem.tsx
+++ b/TravelCostApp/components/ProfileOutput/TripHistoryItem.tsx
@@ -17,9 +17,9 @@ import { TripContext } from "../../store/trip-context";
 import {
   formatExpenseWithCurrency,
   truncateString,
-  truncateNumber,
 } from "../../util/string";
 import { TravellerNames, fetchTripName, getTravellers } from "../../util/http";
+import { FittingCurrencyAmount } from "../UI/FittingCurrencyAmount";
 
 import { i18n } from "../../i18n/i18n";
 
@@ -328,18 +328,12 @@ function TripHistoryItem({ tripid, trips }) {
     totalBudget == "" ||
     isNaN(Number(totalBudget)) ||
     totalBudget >= MAX_JS_NUMBER.toString();
-  const totalBudgetString = noTotalBudget
-    ? "∞"
-    : formatExpenseWithCurrency(
-        truncateNumber(Number(totalBudget)),
-        tripCurrency
-      );
   const dailyBudgetString = formatExpenseWithCurrency(
-    truncateNumber(Number(dailyBudget)),
+    Number(dailyBudget),
     tripCurrency
   );
   const sumOfExpensesString = formatExpenseWithCurrency(
-    truncateNumber(Number(sumOfExpenses)),
+    Number(sumOfExpenses),
     tripCurrency
   );
 
@@ -369,6 +363,11 @@ function TripHistoryItem({ tripid, trips }) {
   const isOverBudget = noTotalBudget
     ? false
     : Number(sumOfExpenses) > Number(totalBudget);
+
+  const amountTextStyle = [
+    styles.amount,
+    isOverBudget && { color: GlobalStyles.colors.errorGrayed },
+  ];
 
   if (!tripid) return <Text>no id</Text>;
   if (isFetching || (tripid && !totalBudget)) {
@@ -478,22 +477,49 @@ function TripHistoryItem({ tripid, trips }) {
             >
               {truncateString(tripName, dimensionChars)}
             </Text>
-            <Text
-              style={[styles.textBase, isScaledUp && { textAlign: "center" }]}
-            >
-              {i18n.t("daily") + (isDynamicDailyBudget ? "*" : "")}
-              {": " + dailyBudgetString}
-            </Text>
-          </View>
-          <View style={styles.amountContainer}>
-            <Text
+            <View
               style={[
-                styles.amount,
-                isOverBudget && { color: GlobalStyles.colors.errorGrayed },
+                styles.dailyRow,
+                isScaledUp && { justifyContent: "center" },
               ]}
             >
-              {sumOfExpensesString}/{totalBudgetString}
-            </Text>
+              <Text
+                style={[styles.textBase, isScaledUp && { textAlign: "center" }]}
+              >
+                {i18n.t("daily") + (isDynamicDailyBudget ? "*" : "")}
+                {": "}
+              </Text>
+              <FittingCurrencyAmount
+                amount={Number(dailyBudget) || 0}
+                currency={tripCurrency}
+                locale={i18n.locale}
+                style={[styles.textBase, isScaledUp && { textAlign: "center" }]}
+                containerStyle={styles.dailyAmountFit}
+              />
+            </View>
+          </View>
+          <View style={styles.amountContainer}>
+            <View style={styles.amountRow}>
+              <FittingCurrencyAmount
+                amount={Number(sumOfExpenses) || 0}
+                currency={tripCurrency}
+                locale={i18n.locale}
+                style={amountTextStyle}
+                containerStyle={styles.amountFit}
+              />
+              <Text style={amountTextStyle}>/</Text>
+              {noTotalBudget ? (
+                <Text style={amountTextStyle}>∞</Text>
+              ) : (
+                <FittingCurrencyAmount
+                  amount={Number(totalBudget) || 0}
+                  currency={tripCurrency}
+                  locale={i18n.locale}
+                  style={amountTextStyle}
+                  containerStyle={styles.amountFit}
+                />
+              )}
+            </View>
             <Progress.Bar
               color={
                 isOverBudget
@@ -565,6 +591,16 @@ const styles = StyleSheet.create({
     fontSize: dynamicScale(14, false, 0.5),
     fontWeight: "300",
   },
+  dailyRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    maxWidth: dynamicScale(150),
+  },
+  dailyAmountFit: {
+    flexShrink: 1,
+    maxWidth: dynamicScale(100),
+  },
   description: {
     fontSize: dynamicScale(16, false, 0.5),
     marginBottom: dynamicScale(4, true),
@@ -579,6 +615,17 @@ const styles = StyleSheet.create({
     alignItems: "center",
     borderRadius: dynamicScale(4, false, 0.5),
     minWidth: dynamicScale(80),
+    width: dynamicScale(150, true, 1),
+  },
+  amountRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+  },
+  amountFit: {
+    flexShrink: 1,
+    maxWidth: "45%",
   },
   amount: {
     fontSize: dynamicScale(12, false, 0.5),

--- a/TravelCostApp/components/UI/AnimatedNumber/CurrencyTicker.tsx
+++ b/TravelCostApp/components/UI/AnimatedNumber/CurrencyTicker.tsx
@@ -5,20 +5,25 @@ import {
   TextStyle,
   Text,
   Platform,
+  LayoutChangeEvent,
 } from "react-native";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Ticker, Tick } from "./index";
 import {
+  formatCompactExpenseWithCurrency,
   formatExpenseWithCurrency,
-  truncateNumber,
 } from "../../../util/string";
+import { pickFittingCurrencyText } from "../FittingCurrencyAmount";
+import { i18n } from "../../../i18n/i18n";
 
 interface CurrencyTickerProps {
   value: number;
   currency: string;
   fontSize?: number;
   style?: StyleProp<TextStyle>;
+  /** @deprecated Fitting is layout-based; kept for call-site compat. */
   truncate?: boolean;
+  /** @deprecated Unused; fitting uses container measure. */
   truncateLimit?: number;
   disableAnimation?: boolean;
 }
@@ -31,17 +36,26 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
   currency,
   fontSize = 50,
   style,
-  truncate = true,
-  truncateLimit = 1000,
   disableAnimation = false,
 }) => {
-  // Format the number with currency
-  const formattedValue = useMemo(() => {
-    const truncatedValue = truncate
-      ? truncateNumber(value, truncateLimit, true)
-      : value;
-    return formatExpenseWithCurrency(truncatedValue, currency);
-  }, [value, currency, truncate, truncateLimit]);
+  const [containerWidth, setContainerWidth] = useState<number | null>(null);
+  const [fullWidth, setFullWidth] = useState<number | null>(null);
+
+  const fullText = useMemo(
+    () => formatExpenseWithCurrency(value, currency),
+    [value, currency]
+  );
+  const compactText = useMemo(
+    () => formatCompactExpenseWithCurrency(value, currency, i18n.locale),
+    [value, currency]
+  );
+
+  const formattedValue = pickFittingCurrencyText(
+    fullText,
+    compactText,
+    fullWidth,
+    containerWidth
+  );
 
   // Split the formatted value into parts
   const parts = useMemo(() => {
@@ -64,32 +78,66 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
     };
   }, [formattedValue, value]);
 
+  function onContainerLayout(event: LayoutChangeEvent) {
+    setContainerWidth(event.nativeEvent.layout.width);
+  }
+
+  function onFullProbeLayout(event: LayoutChangeEvent) {
+    setFullWidth(event.nativeEvent.layout.width);
+  }
+
+  const textStyle = [
+    {
+      fontSize,
+      fontWeight: "bold" as const,
+      ...Platform.select({
+        android: {
+          textShadowColor: "rgba(0, 0, 0, 0.15)",
+          textShadowOffset: { width: 2, height: 2 },
+          textShadowRadius: 8,
+        },
+      }),
+    },
+    style,
+  ];
+
   // If animation is disabled, render simple Text with original styling
   if (disableAnimation) {
     return (
-      <Text
-        style={[
-          {
-            fontSize,
-            fontWeight: "bold",
-            ...Platform.select({
-              android: {
-                textShadowColor: "rgba(0, 0, 0, 0.15)",
-                textShadowOffset: { width: 2, height: 2 },
-                textShadowRadius: 8,
-              },
-            }),
-          },
-          style,
-        ]}
+      <View
+        style={[styles.container, styles.stretch]}
+        onLayout={onContainerLayout}
       >
-        {formattedValue}
-      </Text>
+        <Text
+          style={[textStyle, styles.fullProbe]}
+          onLayout={onFullProbeLayout}
+          numberOfLines={1}
+          importantForAccessibility="no-hide-descendants"
+          accessibilityElementsHidden
+        >
+          {fullText}
+        </Text>
+        <Text style={textStyle} numberOfLines={1}>
+          {formattedValue}
+        </Text>
+      </View>
     );
   }
 
   return (
-    <View style={[styles.container, style]}>
+    <View
+      style={[styles.container, styles.stretch, style]}
+      onLayout={onContainerLayout}
+    >
+      <Text
+        style={[{ fontSize, fontWeight: "bold" }, styles.fullProbe]}
+        onLayout={onFullProbeLayout}
+        numberOfLines={1}
+        importantForAccessibility="no-hide-descendants"
+        accessibilityElementsHidden
+      >
+        {fullText}
+      </Text>
       <View style={styles.row}>
         {parts.prefix && (
           <Tick
@@ -141,14 +189,25 @@ const styles = StyleSheet.create({
   container: {
     alignItems: "center",
   },
+  stretch: {
+    alignSelf: "stretch",
+    overflow: "hidden",
+  },
   row: {
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "center",
   },
   symbol: {
     opacity: 0.8,
     marginHorizontal: 1,
     fontWeight: "600",
+  },
+  fullProbe: {
+    position: "absolute",
+    opacity: 0,
+    left: 0,
+    top: 0,
   },
 });
 

--- a/TravelCostApp/components/UI/AnimatedNumber/CurrencyTicker.tsx
+++ b/TravelCostApp/components/UI/AnimatedNumber/CurrencyTicker.tsx
@@ -5,15 +5,10 @@ import {
   TextStyle,
   Text,
   Platform,
-  LayoutChangeEvent,
 } from "react-native";
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { Ticker, Tick } from "./index";
-import {
-  formatCompactExpenseWithCurrency,
-  formatExpenseWithCurrency,
-} from "../../../util/string";
-import { pickFittingCurrencyText } from "../FittingCurrencyAmount";
+import { useFittingCurrencyText } from "../FittingCurrencyAmount";
 import { i18n } from "../../../i18n/i18n";
 
 interface CurrencyTickerProps {
@@ -21,11 +16,8 @@ interface CurrencyTickerProps {
   currency: string;
   fontSize?: number;
   style?: StyleProp<TextStyle>;
-  /** @deprecated Fitting is layout-based; kept for call-site compat. */
-  truncate?: boolean;
-  /** @deprecated Unused; fitting uses container measure. */
-  truncateLimit?: number;
   disableAnimation?: boolean;
+  testID?: string;
 }
 
 /**
@@ -37,25 +29,12 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
   fontSize = 50,
   style,
   disableAnimation = false,
+  testID = "currency-ticker",
 }) => {
-  const [containerWidth, setContainerWidth] = useState<number | null>(null);
-  const [fullWidth, setFullWidth] = useState<number | null>(null);
+  const { displayText, fullText, onContainerLayout, onFullProbeTextLayout } =
+    useFittingCurrencyText(value, currency, i18n.locale);
 
-  const fullText = useMemo(
-    () => formatExpenseWithCurrency(value, currency),
-    [value, currency]
-  );
-  const compactText = useMemo(
-    () => formatCompactExpenseWithCurrency(value, currency, i18n.locale),
-    [value, currency]
-  );
-
-  const formattedValue = pickFittingCurrencyText(
-    fullText,
-    compactText,
-    fullWidth,
-    containerWidth
-  );
+  const formattedValue = displayText;
 
   // Split the formatted value into parts
   const parts = useMemo(() => {
@@ -78,14 +57,6 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
     };
   }, [formattedValue, value]);
 
-  function onContainerLayout(event: LayoutChangeEvent) {
-    setContainerWidth(event.nativeEvent.layout.width);
-  }
-
-  function onFullProbeLayout(event: LayoutChangeEvent) {
-    setFullWidth(event.nativeEvent.layout.width);
-  }
-
   const textStyle = [
     {
       fontSize,
@@ -105,12 +76,14 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
   if (disableAnimation) {
     return (
       <View
+        testID={testID}
         style={[styles.container, styles.stretch]}
         onLayout={onContainerLayout}
       >
         <Text
+          testID={`${testID}-full-probe`}
           style={[textStyle, styles.fullProbe]}
-          onLayout={onFullProbeLayout}
+          onTextLayout={onFullProbeTextLayout}
           numberOfLines={1}
           importantForAccessibility="no-hide-descendants"
           accessibilityElementsHidden
@@ -126,12 +99,14 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
 
   return (
     <View
+      testID={testID}
       style={[styles.container, styles.stretch, style]}
       onLayout={onContainerLayout}
     >
       <Text
+        testID={`${testID}-full-probe`}
         style={[{ fontSize, fontWeight: "bold" }, styles.fullProbe]}
-        onLayout={onFullProbeLayout}
+        onTextLayout={onFullProbeTextLayout}
         numberOfLines={1}
         importantForAccessibility="no-hide-descendants"
         accessibilityElementsHidden
@@ -142,7 +117,7 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
         {parts.prefix && (
           <Tick
             fontSize={fontSize * 0.8}
-            style={[styles.symbol, { color: (style as any)?.color }]}
+            style={[styles.symbol, { color: (style as TextStyle)?.color }]}
           >
             {parts.prefix}
           </Tick>
@@ -153,7 +128,7 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
               <Tick
                 key={index}
                 fontSize={fontSize}
-                style={[styles.symbol, { color: (style as any)?.color }]}
+                style={[styles.symbol, { color: (style as TextStyle)?.color }]}
               >
                 {part}
               </Tick>
@@ -166,7 +141,7 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
                 key={index}
                 value={num}
                 fontSize={fontSize}
-                textStyle={{ color: (style as any)?.color }}
+                textStyle={{ color: (style as TextStyle)?.color }}
               />
             );
           }
@@ -175,7 +150,7 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
         {parts.suffix && (
           <Tick
             fontSize={fontSize * 0.8}
-            style={[styles.symbol, { color: (style as any)?.color }]}
+            style={[styles.symbol, { color: (style as TextStyle)?.color }]}
           >
             {parts.suffix}
           </Tick>

--- a/TravelCostApp/components/UI/FittingCurrencyAmount.tsx
+++ b/TravelCostApp/components/UI/FittingCurrencyAmount.tsx
@@ -1,13 +1,16 @@
 import React, { useMemo, useState } from "react";
 import {
   LayoutChangeEvent,
+  NativeSyntheticEvent,
   StyleProp,
   StyleSheet,
   Text,
+  TextLayoutEventData,
   TextStyle,
   View,
   ViewStyle,
 } from "react-native";
+import * as Localization from "expo-localization";
 
 import {
   formatCompactExpenseWithCurrency,
@@ -34,29 +37,33 @@ export function pickFittingCurrencyText(
   return fullWidth > containerWidth ? compactText : fullText;
 }
 
+export function resolveFittingLocale(locale?: string): string {
+  if (locale) return locale;
+  const device = Localization.getLocales()[0];
+  return device?.languageTag || device?.languageCode || "en";
+}
+
 /**
- * Shows full currency formatting when it fits the container; otherwise
- * space-saving compact form. Full width is measured via a hidden probe
- * so the visible text never feeds back into the fit decision.
+ * Shared fit decision for currency amounts: measure full-form intrinsic width
+ * via onTextLayout, compare to container onLayout, pick compact on overflow.
  */
-export function FittingCurrencyAmount({
-  amount,
-  currency,
-  locale = "en",
-  style,
-  containerStyle,
-  testID = "fitting-currency",
-}: FittingCurrencyAmountProps) {
+export function useFittingCurrencyText(
+  amount: number,
+  currency: string,
+  locale?: string
+) {
   const [containerWidth, setContainerWidth] = useState<number | null>(null);
   const [fullWidth, setFullWidth] = useState<number | null>(null);
 
+  const resolvedLocale = resolveFittingLocale(locale);
+
   const fullText = useMemo(
-    () => formatExpenseWithCurrency(amount, currency),
-    [amount, currency]
+    () => formatExpenseWithCurrency(amount, currency, undefined, resolvedLocale),
+    [amount, currency, resolvedLocale]
   );
   const compactText = useMemo(
-    () => formatCompactExpenseWithCurrency(amount, currency, locale),
-    [amount, currency, locale]
+    () => formatCompactExpenseWithCurrency(amount, currency, resolvedLocale),
+    [amount, currency, resolvedLocale]
   );
 
   const displayText = pickFittingCurrencyText(
@@ -70,9 +77,38 @@ export function FittingCurrencyAmount({
     setContainerWidth(event.nativeEvent.layout.width);
   }
 
-  function onFullProbeLayout(event: LayoutChangeEvent) {
-    setFullWidth(event.nativeEvent.layout.width);
+  function onFullProbeTextLayout(
+    event: NativeSyntheticEvent<TextLayoutEventData>
+  ) {
+    const lineWidth = event.nativeEvent.lines[0]?.width;
+    if (lineWidth != null) {
+      setFullWidth(lineWidth);
+    }
   }
+
+  return {
+    displayText,
+    fullText,
+    onContainerLayout,
+    onFullProbeTextLayout,
+  };
+}
+
+/**
+ * Shows full currency formatting when it fits the container; otherwise
+ * space-saving compact form. Full width is measured via a hidden probe
+ * so the visible text never feeds back into the fit decision.
+ */
+export function FittingCurrencyAmount({
+  amount,
+  currency,
+  locale,
+  style,
+  containerStyle,
+  testID = "fitting-currency",
+}: FittingCurrencyAmountProps) {
+  const { displayText, fullText, onContainerLayout, onFullProbeTextLayout } =
+    useFittingCurrencyText(amount, currency, locale);
 
   return (
     <View
@@ -83,7 +119,7 @@ export function FittingCurrencyAmount({
       <Text
         testID={`${testID}-full-probe`}
         style={[style, styles.fullProbe]}
-        onLayout={onFullProbeLayout}
+        onTextLayout={onFullProbeTextLayout}
         numberOfLines={1}
         importantForAccessibility="no-hide-descendants"
         accessibilityElementsHidden

--- a/TravelCostApp/components/UI/FittingCurrencyAmount.tsx
+++ b/TravelCostApp/components/UI/FittingCurrencyAmount.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo, useState } from "react";
+import {
+  LayoutChangeEvent,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextStyle,
+  View,
+  ViewStyle,
+} from "react-native";
+
+import {
+  formatCompactExpenseWithCurrency,
+  formatExpenseWithCurrency,
+} from "../../util/string";
+
+type FittingCurrencyAmountProps = {
+  amount: number;
+  currency: string;
+  locale?: string;
+  style?: StyleProp<TextStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+/** Chooses compact only after both widths are known and full text overflows. */
+export function pickFittingCurrencyText(
+  fullText: string,
+  compactText: string,
+  fullWidth: number | null,
+  containerWidth: number | null
+): string {
+  if (containerWidth == null || fullWidth == null) return fullText;
+  return fullWidth > containerWidth ? compactText : fullText;
+}
+
+/**
+ * Shows full currency formatting when it fits the container; otherwise
+ * space-saving compact form. Full width is measured via a hidden probe
+ * so the visible text never feeds back into the fit decision.
+ */
+export function FittingCurrencyAmount({
+  amount,
+  currency,
+  locale = "en",
+  style,
+  containerStyle,
+  testID = "fitting-currency",
+}: FittingCurrencyAmountProps) {
+  const [containerWidth, setContainerWidth] = useState<number | null>(null);
+  const [fullWidth, setFullWidth] = useState<number | null>(null);
+
+  const fullText = useMemo(
+    () => formatExpenseWithCurrency(amount, currency),
+    [amount, currency]
+  );
+  const compactText = useMemo(
+    () => formatCompactExpenseWithCurrency(amount, currency, locale),
+    [amount, currency, locale]
+  );
+
+  const displayText = pickFittingCurrencyText(
+    fullText,
+    compactText,
+    fullWidth,
+    containerWidth
+  );
+
+  function onContainerLayout(event: LayoutChangeEvent) {
+    setContainerWidth(event.nativeEvent.layout.width);
+  }
+
+  function onFullProbeLayout(event: LayoutChangeEvent) {
+    setFullWidth(event.nativeEvent.layout.width);
+  }
+
+  return (
+    <View
+      testID={testID}
+      style={[styles.container, containerStyle]}
+      onLayout={onContainerLayout}
+    >
+      <Text
+        testID={`${testID}-full-probe`}
+        style={[style, styles.fullProbe]}
+        onLayout={onFullProbeLayout}
+        numberOfLines={1}
+        importantForAccessibility="no-hide-descendants"
+        accessibilityElementsHidden
+      >
+        {fullText}
+      </Text>
+      <Text style={style} numberOfLines={1}>
+        {displayText}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexShrink: 1,
+    alignSelf: "stretch",
+    overflow: "hidden",
+  },
+  fullProbe: {
+    position: "absolute",
+    opacity: 0,
+    left: 0,
+    top: 0,
+  },
+});

--- a/TravelCostApp/util/string.ts
+++ b/TravelCostApp/util/string.ts
@@ -6,7 +6,8 @@ import { getCurrencySymbol } from "./currencySymbol";
 export function formatExpenseWithCurrency(
   amount: number | string,
   currency?: string,
-  options?: Intl.NumberFormatOptions
+  options?: Intl.NumberFormatOptions,
+  localeOverride?: string
 ): string {
   if (typeof amount === "string") amount = Number(amount);
   if (isNaN(amount)) {
@@ -18,9 +19,10 @@ export function formatExpenseWithCurrency(
     return amount.toFixed(2);
   }
   const locale =
-    Localization.getLocales()[0] && Localization.getLocales()[0].languageTag
+    localeOverride ||
+    (Localization.getLocales()[0] && Localization.getLocales()[0].languageTag
       ? Localization.getLocales()[0].languageTag
-      : "en-US";
+      : "en-US");
 
   const fractionOptions: Intl.NumberFormatOptions = {
     style: "currency",
@@ -123,16 +125,34 @@ function languageFromLocale(locale: string): string {
   return locale.slice(0, 2).toLowerCase();
 }
 
-function compactSuffix(language: string, absAmount: number): { scale: number; suffix: string } | null {
-  for (const { threshold, suffixes } of COMPACT_SCALES) {
-    if (absAmount >= threshold) {
-      return {
-        scale: threshold,
-        suffix: suffixes[language] ?? suffixes.en,
-      };
-    }
+function formatCompactMantissa(
+  absAmount: number,
+  language: string
+): { mantissa: string; suffix: string } | null {
+  let scaleEntry =
+    COMPACT_SCALES.find(({ threshold }) => absAmount >= threshold) ?? null;
+  if (!scaleEntry) return null;
+
+  let scale = scaleEntry.threshold;
+  let rounded = Number((absAmount / scale).toFixed(1));
+
+  // Carry to the next larger scale when rounding reaches 1000 (e.g. 999999 → 1 Mio.)
+  const scaleIndex = COMPACT_SCALES.findIndex((s) => s.threshold === scale);
+  if (rounded >= 1000 && scaleIndex > 0) {
+    scaleEntry = COMPACT_SCALES[scaleIndex - 1];
+    scale = scaleEntry.threshold;
+    rounded = Number((absAmount / scale).toFixed(1));
   }
-  return null;
+
+  const decimalSep = language === "en" ? "." : ",";
+  const mantissa = Number.isInteger(rounded)
+    ? String(rounded)
+    : rounded.toFixed(1).replace(".", decimalSep);
+
+  return {
+    mantissa,
+    suffix: scaleEntry.suffixes[language] ?? scaleEntry.suffixes.en,
+  };
 }
 
 function currencySymbolGoesFirst(locale: string, currency: string): boolean {
@@ -166,62 +186,21 @@ export function formatCompactExpenseWithCurrency(
     return "";
   }
   if (!currency) {
-    return formatExpenseWithCurrency(amount, currency);
+    return formatExpenseWithCurrency(amount, currency, undefined, locale);
   }
 
   const abs = Math.abs(amount);
   const language = languageFromLocale(locale);
-  const compact = compactSuffix(language, abs);
+  const compact = formatCompactMantissa(abs, language);
   if (!compact) {
-    return formatExpenseWithCurrency(amount, currency);
+    return formatExpenseWithCurrency(amount, currency, undefined, locale);
   }
 
-  const scaled = abs / compact.scale;
-  const decimalSep =
-    language === "en" ? "." : ",";
-  const mantissa = Number.isInteger(scaled)
-    ? String(scaled)
-    : scaled.toFixed(1).replace(".", decimalSep);
   const sign = amount < 0 ? "-" : "";
-  const body = `${sign}${mantissa}${compact.suffix}`;
+  const body = `${sign}${compact.mantissa}${compact.suffix}`;
   const symbol = getCurrencySymbol(currency);
 
   return currencySymbolGoesFirst(locale, currency)
     ? `${symbol}${body}`
     : `${body}${symbol}`;
-}
-
-/**
- * Truncates or limits a number to a specified border value,
- * with options for formatting.
- * @param num The number to truncate.
- * @param border The border value to truncate the number. Default is 1000.
- * @param asNumber Determines whether to return the result as a number (true) or string (false). Default is true.
- * @param digits The number of digits after the decimal point for the truncated number. Default is 0.
- * @returns The truncated number or string based on the provided parameters.
- */
-export function truncateNumber(
-  num: number | undefined,
-  border = 1000,
-  asNumber = true,
-  digits = 0
-) {
-  if (num === undefined || num === null || isNaN(num)) {
-    return asNumber ? 0 : "";
-  }
-
-  const isNumGreaterThanBorder = num > border;
-
-  if (asNumber) {
-    if (isNumGreaterThanBorder) {
-      return Number(num.toFixed(digits));
-    }
-    return num;
-  }
-
-  if (isNumGreaterThanBorder) {
-    return num.toFixed(digits);
-  }
-
-  return num.toFixed(0);
 }

--- a/TravelCostApp/util/string.ts
+++ b/TravelCostApp/util/string.ts
@@ -102,6 +102,95 @@ export function truncateString(str: string, n: number) {
   return str?.length > n ? str.slice(0, n - 1) + "..." : str;
 }
 
+type CompactScale = { threshold: number; suffixes: Record<string, string> };
+
+const COMPACT_SCALES: CompactScale[] = [
+  {
+    threshold: 1_000_000_000,
+    suffixes: { en: "b", de: " Mrd.", fr: " Md", ru: " млрд" },
+  },
+  {
+    threshold: 1_000_000,
+    suffixes: { en: "m", de: " Mio.", fr: " M", ru: " млн" },
+  },
+  {
+    threshold: 1_000,
+    suffixes: { en: "k", de: "k", fr: "k", ru: "k" },
+  },
+];
+
+function languageFromLocale(locale: string): string {
+  return locale.slice(0, 2).toLowerCase();
+}
+
+function compactSuffix(language: string, absAmount: number): { scale: number; suffix: string } | null {
+  for (const { threshold, suffixes } of COMPACT_SCALES) {
+    if (absAmount >= threshold) {
+      return {
+        scale: threshold,
+        suffix: suffixes[language] ?? suffixes.en,
+      };
+    }
+  }
+  return null;
+}
+
+function currencySymbolGoesFirst(locale: string, currency: string): boolean {
+  try {
+    const parts = new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+      currencyDisplay: "narrowSymbol",
+    }).formatToParts(1);
+    const currencyIndex = parts.findIndex((p) => p.type === "currency");
+    const numberIndex = parts.findIndex(
+      (p) => p.type === "integer" || p.type === "decimal"
+    );
+    return currencyIndex !== -1 && numberIndex !== -1 && currencyIndex < numberIndex;
+  } catch {
+    return languageFromLocale(locale) === "en";
+  }
+}
+
+/**
+ * Space-saving compact currency amount (k / Mio. / Mrd. etc.).
+ * Used when the full formatExpenseWithCurrency string does not fit.
+ */
+export function formatCompactExpenseWithCurrency(
+  amount: number | string,
+  currency?: string,
+  locale = "en"
+): string {
+  if (typeof amount === "string") amount = Number(amount);
+  if (isNaN(amount)) {
+    return "";
+  }
+  if (!currency) {
+    return formatExpenseWithCurrency(amount, currency);
+  }
+
+  const abs = Math.abs(amount);
+  const language = languageFromLocale(locale);
+  const compact = compactSuffix(language, abs);
+  if (!compact) {
+    return formatExpenseWithCurrency(amount, currency);
+  }
+
+  const scaled = abs / compact.scale;
+  const decimalSep =
+    language === "en" ? "." : ",";
+  const mantissa = Number.isInteger(scaled)
+    ? String(scaled)
+    : scaled.toFixed(1).replace(".", decimalSep);
+  const sign = amount < 0 ? "-" : "";
+  const body = `${sign}${mantissa}${compact.suffix}`;
+  const symbol = getCurrencySymbol(currency);
+
+  return currencySymbolGoesFirst(locale, currency)
+    ? `${symbol}${body}`
+    : `${body}${symbol}`;
+}
+
 /**
  * Truncates or limits a number to a specified border value,
  * with options for formatting.


### PR DESCRIPTION
## Summary
- Add `formatCompactExpenseWithCurrency` with locale suffixes (k / Mio.·m / Mrd.·b for en/de/fr/ru).
- Add `FittingCurrencyAmount`: hidden full-form measure vs container width; compact only on overflow (no flicker loop).
- Wire into ExpensesSummary `CurrencyTicker` and TripHistoryItem; drop broken `truncateNumber` usage there.

## Test plan
- [ ] Period sum in top-right: amounts under ~4 digits stay full; `10000+` switches to compact (e.g. `10k€` / `1,3k€`) when the 50% header card is tight
- [ ] Toggle number animations off/on — both paths show fitted amounts
- [ ] My Budgets / trip history cards: daily + spent/total use fitting; ∞ total budget still works
- [ ] Spot-check DE / EN (and FR if available) decimal separators and suffixes
- [ ] `pnpm exec jest __tests__/util/format-compact-expense-with-currency.test.ts __tests__/components/fitting-currency-amount.test.tsx`