### PR TITLE
Fix CurrencyTicker locale digit groups (leading zeros)

### DIFF
--- a/TravelCostApp/__tests__/util/split-formatted-currency-parts.test.ts
+++ b/TravelCostApp/__tests__/util/split-formatted-currency-parts.test.ts
@@ -1,0 +1,44 @@
+import { splitFormattedCurrencyParts } from "../../components/UI/AnimatedNumber/CurrencyTicker";
+
+describe("splitFormattedCurrencyParts", () => {
+  it("keeps leading zeros in German thousand and fraction groups", () => {
+    expect(splitFormattedCurrencyParts("1.063,06€")).toEqual({
+      prefix: "",
+      tokens: ["1", ".", "063", ",", "06"],
+      suffix: "€",
+    });
+  });
+
+  it("keeps French narrow-space thousand groups and suffix currency", () => {
+    // Intl fr-FR uses U+202F (narrow no-break space) as the grouping separator
+    expect(splitFormattedCurrencyParts("1\u202F063,06\u00A0€")).toEqual({
+      prefix: "",
+      tokens: ["1", "\u202F", "063", ",", "06"],
+      suffix: "\u00A0€",
+    });
+  });
+
+  it("keeps English prefix currency and comma thousands", () => {
+    expect(splitFormattedCurrencyParts("€1,063.06")).toEqual({
+      prefix: "€",
+      tokens: ["1", ",", "063", ".", "06"],
+      suffix: "",
+    });
+  });
+
+  it("keeps Russian space thousand groups", () => {
+    expect(splitFormattedCurrencyParts("1\u00A0063,06\u00A0€")).toEqual({
+      prefix: "",
+      tokens: ["1", "\u00A0", "063", ",", "06"],
+      suffix: "\u00A0€",
+    });
+  });
+
+  it("keeps compact German suffix after the number", () => {
+    expect(splitFormattedCurrencyParts("1,3k€")).toEqual({
+      prefix: "",
+      tokens: ["1", ",", "3"],
+      suffix: "k€",
+    });
+  });
+});

--- a/TravelCostApp/components/UI/AnimatedNumber/CurrencyTicker.tsx
+++ b/TravelCostApp/components/UI/AnimatedNumber/CurrencyTicker.tsx
@@ -20,6 +20,40 @@ interface CurrencyTickerProps {
   testID?: string;
 }
 
+export type FormattedCurrencyParts = {
+  prefix: string;
+  tokens: string[];
+  suffix: string;
+};
+
+/**
+ * Split a localized currency display string into prefix, number tokens
+ * (digit groups + separators), and suffix — without parseFloat so leading
+ * zeros in groups like "063" / "06" stay intact.
+ */
+export function splitFormattedCurrencyParts(
+  formattedValue: string
+): FormattedCurrencyParts {
+  const firstDigit = formattedValue.search(/\d/);
+  if (firstDigit === -1) {
+    return { prefix: formattedValue, tokens: [], suffix: "" };
+  }
+
+  let lastDigit = firstDigit;
+  for (let i = firstDigit; i < formattedValue.length; i++) {
+    if (/\d/.test(formattedValue[i])) {
+      lastDigit = i;
+    }
+  }
+
+  const prefix = formattedValue.slice(0, firstDigit);
+  const numberStr = formattedValue.slice(firstDigit, lastDigit + 1);
+  const suffix = formattedValue.slice(lastDigit + 1);
+  const tokens = numberStr.split(/([^\d])/).filter((token) => token !== "");
+
+  return { prefix, tokens, suffix };
+}
+
 /**
  * CurrencyTicker component that displays an animated number with currency formatting
  */
@@ -36,26 +70,10 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
 
   const formattedValue = displayText;
 
-  // Split the formatted value into parts
-  const parts = useMemo(() => {
-    // More comprehensive regex to capture currency, number with formatting, and suffix
-    const matches = formattedValue.match(/([^\d]*)([\d,.]*)([^\d]*)/);
-    if (!matches) return { prefix: "", number: value, suffix: "" };
-
-    // Extract the numeric part and clean it up
-    const numberStr = matches[2] || "0";
-    const cleanNumber = parseFloat(numberStr.replace(/,/g, "")) || 0;
-
-    // Split the formatted number to preserve decimal point and commas
-    const formattedNumber = numberStr.split(/([,.])/);
-
-    return {
-      prefix: matches[1] || "",
-      number: cleanNumber,
-      suffix: matches[3] || "",
-      formattedNumber: formattedNumber,
-    };
-  }, [formattedValue, value]);
+  const parts = useMemo(
+    () => splitFormattedCurrencyParts(formattedValue),
+    [formattedValue]
+  );
 
   const textStyle = [
     {
@@ -114,47 +132,43 @@ const CurrencyTicker: React.FC<CurrencyTickerProps> = ({
         {fullText}
       </Text>
       <View style={styles.row}>
-        {parts.prefix && (
+        {parts.prefix ? (
           <Tick
             fontSize={fontSize * 0.8}
             style={[styles.symbol, { color: (style as TextStyle)?.color }]}
           >
             {parts.prefix}
           </Tick>
-        )}
-        {parts.formattedNumber.map((part, index) => {
-          if (part === "," || part === ".") {
-            return (
-              <Tick
-                key={index}
-                fontSize={fontSize}
-                style={[styles.symbol, { color: (style as TextStyle)?.color }]}
-              >
-                {part}
-              </Tick>
-            );
-          }
-          const num = parseFloat(part);
-          if (!isNaN(num)) {
+        ) : null}
+        {parts.tokens.map((token, index) => {
+          if (/^\d+$/.test(token)) {
             return (
               <Ticker
                 key={index}
-                value={num}
+                value={token}
                 fontSize={fontSize}
                 textStyle={{ color: (style as TextStyle)?.color }}
               />
             );
           }
-          return null;
+          return (
+            <Tick
+              key={index}
+              fontSize={fontSize}
+              style={[styles.symbol, { color: (style as TextStyle)?.color }]}
+            >
+              {token}
+            </Tick>
+          );
         })}
-        {parts.suffix && (
+        {parts.suffix ? (
           <Tick
             fontSize={fontSize * 0.8}
             style={[styles.symbol, { color: (style as TextStyle)?.color }]}
           >
             {parts.suffix}
           </Tick>
-        )}
+        ) : null}
       </View>
     </View>
   );

--- a/TravelCostApp/components/UI/AnimatedNumber/Ticker.tsx
+++ b/TravelCostApp/components/UI/AnimatedNumber/Ticker.tsx
@@ -11,7 +11,7 @@ import TickerDigit from "./TickerDigit";
 import Tick from "./Tick";
 
 interface TickerProps {
-  value: number;
+  value: number | string;
   fontSize?: number;
   style?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
@@ -28,8 +28,9 @@ const Ticker: React.FC<TickerProps> = ({
 }) => {
   const [calculatedFontSize, setCalculatedFontSize] = useState(fontSize);
 
-  // Convert number to string and split into digits
-  const splitValue = value.toString().split("");
+  // Keep digit strings as-is (e.g. "063") so leading zeros are not dropped
+  const splitValue = String(value).split("");
+  const displayValue = String(value);
 
   return (
     <View style={[styles.container, style]}>
@@ -52,7 +53,7 @@ const Ticker: React.FC<TickerProps> = ({
           }
         }}
       >
-        {value}
+        {displayValue}
       </Text>
 
       {/* Visible animated digits */}


### PR DESCRIPTION
## Summary
- Animated Overview totals dropped leading zeros in localized amounts (e.g. German `1.063,06€` → `1.63,6€`) because digit groups were `parseFloat`’d.
- Add `splitFormattedCurrencyParts` and render digit-group strings as-is; also keep FR/RU space grouping separators intact.

## Test plan
- [ ] Overview with animations on, German locale: amount like `1063.06` shows `1.063,06€` (not `1.63,6€`)
- [ ] Same for English (`€1,063.06`), French (narrow-space thousands), Russian (NBSP thousands)
- [ ] Compact overflow still animates correctly (e.g. `1,3k€`)
- [ ] `pnpm test -- __tests__/util/split-formatted-currency-parts.test.ts`