### PR TITLE
Trip form: promote, add-another, edit + budget-free (#354)

### DIFF
--- a/TravelCostApp/__tests__/components/expenses-summary.test.tsx
+++ b/TravelCostApp/__tests__/components/expenses-summary.test.tsx
@@ -74,6 +74,78 @@ describe("ExpensesSummary", () => {
     expect(screen.getByText(/40/)).toBeTruthy();
   });
 
+  it("hides progress when the Active trip is budget-free", () => {
+    const expenses = [makeExpense({ calcAmount: 40, amount: 40 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="month" />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+        trip: {
+          tripid: "t-implicit",
+          tripCurrency: "EUR",
+          isImplicitDefault: true,
+          dailyBudget: "0",
+          totalBudget: "0",
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    expect(screen.getByTestId("expenses-summary-pressable")).toBeTruthy();
+    expect(screen.queryByTestId("expenses-summary-progress")).toBeNull();
+  });
+
+  it("hides total progress for daily-only trips", () => {
+    const expenses = [makeExpense({ calcAmount: 40, amount: 40 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="total" />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+        trip: {
+          dailyBudget: "50",
+          totalBudget: "0",
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    expect(screen.getByTestId("expenses-summary-pressable")).toBeTruthy();
+    expect(screen.queryByTestId("expenses-summary-progress")).toBeNull();
+  });
+
+  it("hides period progress for total-only trips", () => {
+    const expenses = [makeExpense({ calcAmount: 40, amount: 40 })];
+
+    const screen = renderWithAppProviders(
+      <ExpensesSummary expenses={expenses} periodName="month" />,
+      {
+        wrapNavigation: false,
+        expenses: {
+          expenses,
+          getRecentExpenses: () => expenses,
+        },
+        trip: {
+          dailyBudget: "0",
+          totalBudget: "2000",
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    expect(screen.getByTestId("expenses-summary-pressable")).toBeTruthy();
+    expect(screen.queryByTestId("expenses-summary-progress")).toBeNull();
+  });
+
   it("uses dropdown-matching shadow chrome on the budget summary pressable", () => {
     const expenses = [makeExpense({ calcAmount: 75, amount: 75 })];
 
@@ -201,14 +273,18 @@ describe("ExpensesSummary", () => {
     ).toBeNull();
   });
 
-  it("shows an error toast instead of the modal when the period budget is unlimited", () => {
+  it("hides total progress when total budget is unset (MAX sentinel)", () => {
     const expenses = [makeExpense({ calcAmount: 50, amount: 50 })];
 
     const screen = renderWithAppProviders(
       <ExpensesSummary expenses={expenses} periodName="total" />,
       {
         wrapNavigation: false,
-        trip: { totalBudget: "", travellers: ["Alice"] },
+        trip: {
+          totalBudget: "3435973836",
+          dailyBudget: "50",
+          travellers: ["Alice"],
+        },
         expenses: {
           expenses,
           getRecentExpenses: () => expenses,
@@ -216,16 +292,8 @@ describe("ExpensesSummary", () => {
       },
     );
 
-    fireEvent.press(screen.getByTestId("expenses-summary-pressable"));
-
-    expect(screen.queryByText(i18n.t("overview"))).toBeNull();
-    expect(mockToastShow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        text1: i18n.t("noTotalBudget"),
-        text2: i18n.t("infinityLeftToSpend"),
-      }),
-    );
+    expect(screen.getByTestId("expenses-summary-pressable")).toBeTruthy();
+    expect(screen.queryByTestId("expenses-summary-progress")).toBeNull();
   });
 
   it("dismisses the budget overview modal on Android back", () => {

--- a/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
@@ -1,0 +1,142 @@
+import * as React from "react";
+
+jest.mock("../../util/http", () => ({
+  storeTrip: jest.fn(),
+  storeTripHistory: jest.fn(),
+  updateUser: jest.fn(),
+  fetchTrip: jest.fn(async () => ({
+    tripName: "",
+    tripCurrency: "EUR",
+    dailyBudget: "0",
+    totalBudget: "0",
+    isDynamicDailyBudget: false,
+    isImplicitDefault: true,
+    travellers: [],
+  })),
+  updateTripHistory: jest.fn(),
+  updateTrip: jest.fn(),
+  getAllExpenses: jest.fn(async () => []),
+  putTravelerInTrip: jest.fn(),
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+jest.mock("@react-navigation/elements", () => ({
+  useHeaderHeight: () => 0,
+}));
+
+jest.mock("../../components/Currency/CurrencyPicker", () => () => null);
+jest.mock("../../components/UI/DatePickerModal", () => () => null);
+jest.mock("../../components/UI/DatePickerContainer", () => () => null);
+
+import { fireEvent } from "@testing-library/react-native";
+
+import TripForm from "../../components/ManageTrip/TripForm";
+import { i18n } from "../../i18n/i18n";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+const navigation = {
+  navigate: jest.fn(),
+  pop: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+describe("TripForm budget form modes", () => {
+  it("shows Name your budget for promote mode with optional details collapsed", () => {
+    const screen = renderWithAppProviders(
+      <TripForm
+        navigation={navigation}
+        route={{ params: { tripId: "t-implicit", mode: "promote" } }}
+      />,
+      {
+        network: { isConnected: true, strongConnection: true },
+        trip: {
+          tripid: "t-implicit",
+          tripName: "",
+          tripCurrency: "EUR",
+          dailyBudget: "0",
+          totalBudget: "0",
+          isImplicitDefault: true,
+          travellers: ["Alice"],
+        },
+        expenses: { expenses: [] },
+      }
+    );
+
+    expect(screen.getByTestId("trip-form-title").props.children).toBe(
+      i18n.t("tripFormTitlePromote")
+    );
+    expect(screen.queryByTestId("trip-form-optional-section")).toBeNull();
+  });
+
+  it("shows Add another budget subtitle and collapses optional details", () => {
+    const screen = renderWithAppProviders(
+      <TripForm navigation={navigation} route={{ params: {} }} />,
+      {
+        network: { isConnected: true, strongConnection: true },
+        expenses: { expenses: [] },
+      }
+    );
+
+    expect(screen.getByTestId("trip-form-title").props.children).toBe(
+      i18n.t("tripFormTitleAddAnother")
+    );
+    expect(screen.getByTestId("trip-form-subtitle").props.children).toBe(
+      i18n.t("tripFormSubtitleAddAnother")
+    );
+    expect(screen.queryByTestId("trip-form-optional-section")).toBeNull();
+
+    fireEvent.press(screen.getByTestId("trip-form-optional-toggle"));
+    expect(screen.getByTestId("trip-form-optional-section")).toBeTruthy();
+  });
+
+  it("auto-expands optional details when editing a trip with budgets set", async () => {
+    const { fetchTrip } = require("../../util/http");
+    fetchTrip.mockResolvedValueOnce({
+      tripName: "Japan",
+      tripCurrency: "EUR",
+      dailyBudget: "50",
+      totalBudget: "2000",
+      startDate: "2026-01-01",
+      endDate: "2026-01-10",
+      isDynamicDailyBudget: false,
+      travellers: ["Alice"],
+    });
+
+    const screen = renderWithAppProviders(
+      <TripForm
+        navigation={navigation}
+        route={{ params: { tripId: "t-japan" } }}
+      />,
+      {
+        network: { isConnected: true, strongConnection: true },
+        trip: {
+          tripid: "other",
+          tripName: "Other",
+          dailyBudget: "10",
+          totalBudget: "100",
+        },
+        expenses: { expenses: [] },
+      }
+    );
+
+    expect(
+      await screen.findByTestId("trip-form-optional-section")
+    ).toBeTruthy();
+    expect(screen.getByTestId("trip-form-title").props.children).toBe(
+      i18n.t("tripFormTitleEdit")
+    );
+  });
+});

--- a/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
@@ -41,11 +41,20 @@ jest.mock("../../components/Currency/CurrencyPicker", () => () => null);
 jest.mock("../../components/UI/DatePickerModal", () => () => null);
 jest.mock("../../components/UI/DatePickerContainer", () => () => null);
 
-import { fireEvent } from "@testing-library/react-native";
+jest.mock("../../util/appState", () => ({
+  sleep: jest.fn(async () => {}),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreSetItem: jest.fn(async () => {}),
+}));
+
+import { fireEvent, waitFor } from "@testing-library/react-native";
 
 import TripForm from "../../components/ManageTrip/TripForm";
 import { i18n } from "../../i18n/i18n";
 import { renderWithAppProviders } from "../fixtures/app-providers";
+import { updateTrip } from "../../util/http";
 
 const navigation = {
   navigate: jest.fn(),
@@ -54,6 +63,10 @@ const navigation = {
 };
 
 describe("TripForm budget form modes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (updateTrip as jest.Mock).mockResolvedValue({});
+  });
   it("shows Name your budget for promote mode with optional details collapsed", () => {
     const screen = renderWithAppProviders(
       <TripForm
@@ -138,5 +151,57 @@ describe("TripForm budget form modes", () => {
     expect(screen.getByTestId("trip-form-title").props.children).toBe(
       i18n.t("tripFormTitleEdit")
     );
+  });
+
+  it("naming an implicit default Active trip without mode clears isImplicitDefault via updateTrip", async () => {
+    const screen = renderWithAppProviders(
+      <TripForm
+        navigation={navigation}
+        route={{ params: { tripId: "t-implicit" } }}
+      />,
+      {
+        network: { isConnected: true, strongConnection: true },
+        trip: {
+          tripid: "t-implicit",
+          tripName: "",
+          tripCurrency: "EUR",
+          dailyBudget: "0",
+          totalBudget: "0",
+          isImplicitDefault: true,
+          travellers: ["Alice"],
+          saveTripDataInStorage: jest.fn(async () => {}),
+          setCurrentTrip: jest.fn(async () => {}),
+          fetchAndSetTravellers: jest.fn(async () => true),
+          setdailyBudget: jest.fn(),
+        },
+        user: {
+          setFreshlyCreatedTo: jest.fn(async () => {}),
+        },
+        expenses: {
+          expenses: [],
+          mergeExpenses: jest.fn(),
+        },
+        auth: { uid: "u1" },
+      }
+    );
+
+    expect(await screen.findByTestId("trip-form-title")).toBeTruthy();
+    expect(screen.getByTestId("trip-form-title").props.children).toBe(
+      i18n.t("tripFormTitlePromote")
+    );
+
+    const nameInput = screen.getByDisplayValue("");
+    fireEvent.changeText(nameInput, "Home budget");
+    fireEvent.press(screen.getByText(i18n.t("saveChanges")));
+
+    await waitFor(() => {
+      expect(updateTrip).toHaveBeenCalledWith(
+        "t-implicit",
+        expect.objectContaining({
+          tripName: "Home budget",
+          isImplicitDefault: false,
+        })
+      );
+    });
   });
 });

--- a/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
@@ -232,7 +232,7 @@ describe("RecentExpenses screen", () => {
     );
   });
 
-  it("shows period summary for an implicit default Active trip", () => {
+  it("hides period progress on a budget-free implicit default Active trip", () => {
     const navigation = { navigate: jest.fn() };
     const screen = renderWithAppProviders(
       <RecentExpenses navigation={navigation as any} />,
@@ -255,6 +255,7 @@ describe("RecentExpenses screen", () => {
     );
 
     expect(screen.getByTestId("expenses-summary-pressable")).toBeTruthy();
+    expect(screen.queryByTestId("expenses-summary-progress")).toBeNull();
   });
 
   it("keeps the add-expense entry point on Recent Expenses for an implicit default Active trip", () => {

--- a/TravelCostApp/__tests__/util/budget-free.test.ts
+++ b/TravelCostApp/__tests__/util/budget-free.test.ts
@@ -1,0 +1,78 @@
+import {
+  hasDailyBudget,
+  hasTotalBudget,
+  isBudgetFree,
+  periodProgressApplies,
+} from "../../util/budget-free";
+import { MAX_JS_NUMBER } from "../../confAppConstants";
+
+describe("budget-free", () => {
+  describe("hasTotalBudget", () => {
+    it("treats missing, empty, zero, and MAX_JS_NUMBER as unset", () => {
+      expect(hasTotalBudget({})).toBe(false);
+      expect(hasTotalBudget({ totalBudget: "" })).toBe(false);
+      expect(hasTotalBudget({ totalBudget: "0" })).toBe(false);
+      expect(hasTotalBudget({ totalBudget: MAX_JS_NUMBER.toString() })).toBe(
+        false
+      );
+    });
+
+    it("treats a positive total as set", () => {
+      expect(hasTotalBudget({ totalBudget: "3000" })).toBe(true);
+    });
+  });
+
+  describe("hasDailyBudget", () => {
+    it("treats missing, empty, and zero as unset", () => {
+      expect(hasDailyBudget({})).toBe(false);
+      expect(hasDailyBudget({ dailyBudget: "" })).toBe(false);
+      expect(hasDailyBudget({ dailyBudget: "0" })).toBe(false);
+    });
+
+    it("treats a positive daily as set", () => {
+      expect(hasDailyBudget({ dailyBudget: "50" })).toBe(true);
+    });
+  });
+
+  describe("isBudgetFree", () => {
+    it("is true when neither total nor daily is set", () => {
+      expect(
+        isBudgetFree({ totalBudget: "0", dailyBudget: "0" })
+      ).toBe(true);
+    });
+
+    it("is false when only daily is set", () => {
+      expect(
+        isBudgetFree({ totalBudget: "0", dailyBudget: "40" })
+      ).toBe(false);
+    });
+
+    it("is false when only total is set", () => {
+      expect(
+        isBudgetFree({ totalBudget: "2000", dailyBudget: "0" })
+      ).toBe(false);
+    });
+  });
+
+  describe("periodProgressApplies", () => {
+    it("hides all periods when budget-free", () => {
+      const trip = { totalBudget: "0", dailyBudget: "0" };
+      expect(periodProgressApplies(trip, "month")).toBe(false);
+      expect(periodProgressApplies(trip, "total")).toBe(false);
+    });
+
+    it("daily-only: period cues yes, total progress no", () => {
+      const trip = { totalBudget: "0", dailyBudget: "40" };
+      expect(periodProgressApplies(trip, "day")).toBe(true);
+      expect(periodProgressApplies(trip, "month")).toBe(true);
+      expect(periodProgressApplies(trip, "total")).toBe(false);
+    });
+
+    it("total-only: total progress yes, period/daily bars no", () => {
+      const trip = { totalBudget: "2000", dailyBudget: "0" };
+      expect(periodProgressApplies(trip, "total")).toBe(true);
+      expect(periodProgressApplies(trip, "month")).toBe(false);
+      expect(periodProgressApplies(trip, "day")).toBe(false);
+    });
+  });
+});

--- a/TravelCostApp/__tests__/util/trip-form.test.ts
+++ b/TravelCostApp/__tests__/util/trip-form.test.ts
@@ -1,0 +1,166 @@
+import {
+  buildTripFormSubmitData,
+  hasOptionalTripFormValues,
+  resolveTripFormMode,
+  shouldConfirmCurrencyChange,
+} from "../../util/trip-form";
+import { resolvePeriodStartDate } from "../../util/budget-free";
+
+describe("trip-form", () => {
+  describe("resolveTripFormMode", () => {
+    it("uses explicit promote / addAnother / edit modes", () => {
+      expect(resolveTripFormMode({ mode: "promote", tripId: "t1" })).toBe(
+        "promote"
+      );
+      expect(resolveTripFormMode({ mode: "addAnother" })).toBe("addAnother");
+      expect(resolveTripFormMode({ mode: "edit", tripId: "t1" })).toBe("edit");
+    });
+
+    it("promotes when editing an implicit default trip without mode", () => {
+      expect(
+        resolveTripFormMode({ tripId: "t1" }, { isImplicitDefault: true })
+      ).toBe("promote");
+    });
+
+    it("edits a named trip with tripId", () => {
+      expect(resolveTripFormMode({ tripId: "t1" })).toBe("edit");
+    });
+
+    it("defaults to addAnother with no tripId", () => {
+      expect(resolveTripFormMode({})).toBe("addAnother");
+      expect(resolveTripFormMode(undefined)).toBe("addAnother");
+    });
+  });
+
+  describe("buildTripFormSubmitData", () => {
+    it("promote updates same trip id and clears isImplicitDefault", () => {
+      const trip = buildTripFormSubmitData({
+        mode: "promote",
+        tripid: "implicit-1",
+        tripName: "Home",
+        tripCurrency: "EUR",
+        totalBudget: "",
+        dailyBudget: "",
+        isDynamicDailyBudget: false,
+      });
+
+      expect(trip.tripid).toBe("implicit-1");
+      expect(trip.isImplicitDefault).toBe(false);
+      expect(trip.tripName).toBe("Home");
+      expect(trip.startDate).toBeUndefined();
+      expect(trip.endDate).toBeUndefined();
+      expect(trip.totalBudget).toBe("0");
+      expect(trip.dailyBudget).toBe("0");
+    });
+
+    it("addAnother creates a named trip without inventing dates", () => {
+      const trip = buildTripFormSubmitData({
+        mode: "addAnother",
+        tripName: "Japan",
+        tripCurrency: "JPY",
+        totalBudget: "100000",
+        dailyBudget: "",
+        isDynamicDailyBudget: false,
+      });
+
+      expect(trip.isImplicitDefault).toBeUndefined();
+      expect(trip.startDate).toBeUndefined();
+      expect(trip.endDate).toBeUndefined();
+      expect(trip.dailyBudget).toBe("0");
+      expect(trip.totalBudget).toBe("100000");
+    });
+
+    it("does not invent daily from total when dates are unset", () => {
+      const trip = buildTripFormSubmitData({
+        mode: "edit",
+        tripid: "t1",
+        tripName: "Named",
+        tripCurrency: "EUR",
+        totalBudget: "700",
+        dailyBudget: "",
+        isDynamicDailyBudget: false,
+      });
+
+      expect(trip.dailyBudget).toBe("0");
+    });
+
+    it("derives daily from total only when both dates are set", () => {
+      const trip = buildTripFormSubmitData({
+        mode: "edit",
+        tripid: "t1",
+        tripName: "Named",
+        tripCurrency: "EUR",
+        totalBudget: "700",
+        dailyBudget: "",
+        isDynamicDailyBudget: false,
+        startDate: "2026-01-01",
+        endDate: "2026-01-07",
+      });
+
+      expect(trip.dailyBudget).toBe("100.00");
+    });
+  });
+
+  describe("hasOptionalTripFormValues", () => {
+    it("is false for budget-free with no dates", () => {
+      expect(
+        hasOptionalTripFormValues({
+          totalBudget: "0",
+          dailyBudget: "0",
+        })
+      ).toBe(false);
+    });
+
+    it("is true when any optional value is set", () => {
+      expect(
+        hasOptionalTripFormValues({ totalBudget: "100", dailyBudget: "0" })
+      ).toBe(true);
+      expect(
+        hasOptionalTripFormValues({
+          totalBudget: "0",
+          dailyBudget: "0",
+          startDate: "2026-01-01",
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("resolvePeriodStartDate", () => {
+    it("prefers trip startDate when set", () => {
+      expect(resolvePeriodStartDate("2026-01-01", ["2026-01-10"])).toBe(
+        "2026-01-01"
+      );
+    });
+
+    it("falls back to earliest expense date when trip dates unset", () => {
+      expect(
+        resolvePeriodStartDate(undefined, [
+          "2026-01-20",
+          "2026-01-05",
+          "2026-01-12",
+        ])
+      ).toBe("2026-01-05");
+    });
+
+    it("returns undefined when no trip start and no expenses (all-time)", () => {
+      expect(resolvePeriodStartDate("", [])).toBeUndefined();
+    });
+  });
+
+  describe("shouldConfirmCurrencyChange", () => {
+    it("always confirms on edit", () => {
+      expect(
+        shouldConfirmCurrencyChange({ isEditing: true, expenseCount: 0 })
+      ).toBe(true);
+    });
+
+    it("on create confirms only when expenses exist", () => {
+      expect(
+        shouldConfirmCurrencyChange({ isEditing: false, expenseCount: 0 })
+      ).toBe(false);
+      expect(
+        shouldConfirmCurrencyChange({ isEditing: false, expenseCount: 3 })
+      ).toBe(true);
+    });
+  });
+});

--- a/TravelCostApp/__tests__/util/trip-form.test.ts
+++ b/TravelCostApp/__tests__/util/trip-form.test.ts
@@ -4,7 +4,7 @@ import {
   resolveTripFormMode,
   shouldConfirmCurrencyChange,
 } from "../../util/trip-form";
-import { resolvePeriodStartDate } from "../../util/budget-free";
+import { resolvePeriodStartDate } from "../../util/budget";
 
 describe("trip-form", () => {
   describe("resolveTripFormMode", () => {
@@ -51,6 +51,21 @@ describe("trip-form", () => {
       expect(trip.endDate).toBeUndefined();
       expect(trip.totalBudget).toBe("0");
       expect(trip.dailyBudget).toBe("0");
+    });
+
+    it("clears isImplicitDefault on edit when the trip was an implicit default", () => {
+      const trip = buildTripFormSubmitData({
+        mode: "edit",
+        tripid: "implicit-1",
+        tripName: "Home",
+        tripCurrency: "EUR",
+        totalBudget: "",
+        dailyBudget: "",
+        isDynamicDailyBudget: false,
+        wasImplicitDefault: true,
+      });
+
+      expect(trip.isImplicitDefault).toBe(false);
     });
 
     it("addAnother creates a named trip without inventing dates", () => {

--- a/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
@@ -26,6 +26,10 @@ import {
   calculateDailyAverage,
   getBudgetColor,
 } from "../../util/budget";
+import {
+  periodProgressApplies,
+  resolvePeriodStartDate,
+} from "../../util/budget-free";
 import BudgetOverviewModal from "./BudgetOverviewModal";
 
 const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
@@ -58,6 +62,14 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
       </View>
     );
   }
+
+  const showProgress = periodProgressApplies(
+    {
+      dailyBudget: tripCtx.dailyBudget,
+      totalBudget: tripCtx.totalBudget,
+    },
+    periodName
+  );
 
   const expensesSum = getExpensesSumPeriod(safeExpenses, hideSpecial);
 
@@ -120,31 +132,46 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
     budgetNumber > 0 ? (expenseSumNum / budgetNumber) * 1 : 0;
 
   const today = new Date();
-  const averageDailySpending = settings.trafficLightBudgetColors
-    ? calculateDailyAverage(
-        periodName as "day" | "week" | "month" | "year" | "total",
-        today,
-        expCtx.expenses || [],
-        {
-          startDate: tripCtx.startDate,
-        },
-        hideSpecial,
-      )
-    : 0;
+  const periodStart =
+    resolvePeriodStartDate(
+      tripCtx.startDate,
+      (expCtx.expenses || []).map((e) => {
+        const d = e.date;
+        if (d instanceof Date) return d;
+        if (typeof d === "string") return d;
+        if (d && typeof (d as { toJSDate?: () => Date }).toJSDate === "function") {
+          return (d as { toJSDate: () => Date }).toJSDate();
+        }
+        return undefined;
+      })
+    ) ?? tripCtx.startDate;
+  const averageDailySpending =
+    settings.trafficLightBudgetColors && periodStart
+      ? calculateDailyAverage(
+          periodName as "day" | "week" | "month" | "year" | "total",
+          today,
+          expCtx.expenses || [],
+          {
+            startDate: periodStart,
+          },
+          hideSpecial,
+        )
+      : 0;
 
   const dailyBudget = Number(tripCtx.dailyBudget) || 0;
-  const budgetColor = noTotalBudget
-    ? GlobalStyles.colors.primary500
-    : getBudgetColor(
-        expenseSumNum,
-        budgetNumber,
-        averageDailySpending,
-        dailyBudget,
-        settings.trafficLightBudgetColors,
-      );
+  const budgetColor =
+    !showProgress || noTotalBudget
+      ? GlobalStyles.colors.primary500
+      : getBudgetColor(
+          expenseSumNum,
+          budgetNumber,
+          averageDailySpending,
+          dailyBudget,
+          settings.trafficLightBudgetColors,
+        );
 
   let unfilledColor = GlobalStyles.colors.gray600;
-  if (!noTotalBudget) {
+  if (!noTotalBudget && showProgress) {
     if (budgetColor === GlobalStyles.colors.error300) {
       unfilledColor = GlobalStyles.colors.errorGrayed;
     } else if (budgetColor === GlobalStyles.colors.accent500) {
@@ -157,16 +184,17 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
   }
 
   if (budgetProgress > 1) budgetProgress -= 1;
-  if (noTotalBudget) {
+  if (noTotalBudget || !showProgress) {
     budgetProgress = 0;
   }
-  if (Number.isNaN(budgetProgress)) {
+  if (showProgress && Number.isNaN(budgetProgress)) {
     return <></>;
   }
   const valid = tripCtx.tripid && travellerNames.length > 0;
   const closeOverview = () => setIsOverviewVisible(false);
 
   const pressBudgetHandler = () => {
+    if (!showProgress) return;
     if (isOverviewVisible) {
       closeOverview();
       return;
@@ -188,31 +216,33 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
 
   return (
     <>
-    <BudgetOverviewModal
-      isVisible={isOverviewVisible}
-      onClose={closeOverview}
-      travellerList={travellerNames}
-      travellerBudgets={
-        travellerNames.length > 0 ? budgetNumber / travellerNames.length : 0
-      }
-      travellerSplitExpenseSums={travellerSplitExpenseSums}
-      currency={tripCurrency}
-      noTotalBudget={noTotalBudget}
-      periodName={periodName}
-      trafficLightActive={settings.trafficLightBudgetColors}
-      currentBudgetColor={budgetColor}
-      averageDailySpending={averageDailySpending}
-      dailyBudget={dailyBudget}
-      expenseSumNum={expenseSumNum}
-      budgetNumber={budgetNumber}
-    />
+    {showProgress && (
+      <BudgetOverviewModal
+        isVisible={isOverviewVisible}
+        onClose={closeOverview}
+        travellerList={travellerNames}
+        travellerBudgets={
+          travellerNames.length > 0 ? budgetNumber / travellerNames.length : 0
+        }
+        travellerSplitExpenseSums={travellerSplitExpenseSums}
+        currency={tripCurrency}
+        noTotalBudget={noTotalBudget}
+        periodName={periodName}
+        trafficLightActive={settings.trafficLightBudgetColors}
+        currentBudgetColor={budgetColor}
+        averageDailySpending={averageDailySpending}
+        dailyBudget={dailyBudget}
+        expenseSumNum={expenseSumNum}
+        budgetNumber={budgetNumber}
+      />
+    )}
     <Pressable
       testID="expenses-summary-pressable"
       onPress={() => pressBudgetHandler()}
       style={({ pressed }) => [
         shadowRegressionStyles.expensesSummaryContainer,
         style,
-        pressed && GlobalStyles.pressedWithShadow,
+        pressed && showProgress && GlobalStyles.pressedWithShadow,
       ]}
     >
       <View style={styles.sumTextContainer}>
@@ -224,14 +254,17 @@ const ExpensesSummary = ({ expenses, periodName, style = {} }) => {
           disableAnimation={settings.disableNumberAnimations}
         />
       </View>
-      <Progress.Bar
-        color={budgetColor}
-        unfilledColor={unfilledColor}
-        borderWidth={0}
-        borderRadius={dynamicScale(6)}
-        progress={budgetProgress}
-        height={constantScale(6, 0.5)}
-      />
+      {showProgress && (
+        <Progress.Bar
+          testID="expenses-summary-progress"
+          color={budgetColor}
+          unfilledColor={unfilledColor}
+          borderWidth={0}
+          borderRadius={dynamicScale(6)}
+          progress={budgetProgress}
+          height={constantScale(6, 0.5)}
+        />
+      )}
     </Pressable>
     </>
   );

--- a/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesSummary.tsx
@@ -25,11 +25,9 @@ import { CurrencyTicker } from "../UI/AnimatedNumber";
 import {
   calculateDailyAverage,
   getBudgetColor,
-} from "../../util/budget";
-import {
-  periodProgressApplies,
   resolvePeriodStartDate,
-} from "../../util/budget-free";
+} from "../../util/budget";
+import { periodProgressApplies } from "../../util/budget-free";
 import BudgetOverviewModal from "./BudgetOverviewModal";
 
 const ExpensesSummary = ({ expenses, periodName, style = {} }) => {

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import { useState, useContext, useEffect, useLayoutEffect } from "react";
-import { View, Text, Alert, ScrollView, Platform } from "react-native";
+import {
+  View,
+  Text,
+  Alert,
+  ScrollView,
+  Platform,
+  Pressable,
+} from "react-native";
 import { StyleSheet } from "react-native";
 import { GlobalStyles } from "../../constants/styles";
 import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
@@ -63,6 +70,14 @@ import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 import { getTripData } from "../../util/trip";
 import { countableTripsTowardNonPremiumLimit } from "../../util/implicit-default-trip";
+import {
+  buildTripFormSubmitData,
+  hasOptionalTripFormValues,
+  resolveTripFormMode,
+  shouldConfirmCurrencyChange,
+  type TripFormMode,
+} from "../../util/trip-form";
+import { hasDailyBudget, hasTotalBudget } from "../../util/budget-free";
 
 const TripForm = ({ navigation, route }) => {
   const tripCtx = useContext(TripContext);
@@ -107,21 +122,15 @@ const TripForm = ({ navigation, route }) => {
     },
   });
 
-  // datepicker states
+  // datepicker states — unset by default (no invented today→+7 window)
   const [showDatePickerRange, setShowDatePickerRange] = useState(false);
-  const [startDate, setStartDate] = useState(
-    // defaultValues
-    // ? getFormattedDate(DateTime.fromJSDate(defaultValues.date).toJSDate())
-    // :
-    getFormattedDate(DateTime.now())
-  );
-  const [endDate, setEndDate] = useState(
-    // defaultValues
-    //   ? getFormattedDate(DateTime.fromJSDate(defaultValues.date).toJSDate())
-    //   :
-    getFormattedDate(DateTime.now().plus({ days: 7 }))
-  );
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
   const [travellers, setTravellers] = useState([]);
+  const [loadedIsImplicitDefault, setLoadedIsImplicitDefault] = useState(
+    false
+  );
+  const [optionalDetailsOpen, setOptionalDetailsOpen] = useState(false);
 
   const openDatePickerRange = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -151,25 +160,52 @@ const TripForm = ({ navigation, route }) => {
 
   const editedTripId = route.params?.tripId;
   const isEditing = !!editedTripId;
+  const formMode: TripFormMode = resolveTripFormMode(route.params, {
+    isImplicitDefault: loadedIsImplicitDefault,
+  });
+  const isPromote = formMode === "promote";
+  const isAddAnother = formMode === "addAnother";
 
   useLayoutEffect(() => {
+    const applyLoadedTrip = (selectedTrip: TripData) => {
+      const daily =
+        selectedTrip.dailyBudget !== undefined &&
+        selectedTrip.dailyBudget !== null
+          ? String(selectedTrip.dailyBudget)
+          : "";
+      const total =
+        selectedTrip.totalBudget !== undefined &&
+        selectedTrip.totalBudget !== null
+          ? String(selectedTrip.totalBudget)
+          : "";
+      inputChangedHandler("tripName", selectedTrip.tripName ?? "");
+      inputChangedHandler("tripCurrency", selectedTrip.tripCurrency);
+      inputChangedHandler("dailyBudget", daily === "0" ? "" : daily);
+      inputChangedHandler(
+        "totalBudget",
+        total === "0" || Number(total) >= MAX_JS_NUMBER ? "" : total
+      );
+      inputChangedHandler(
+        "isDynamicDailyBudget",
+        selectedTrip.isDynamicDailyBudget
+      );
+      setStartDate(selectedTrip.startDate ?? "");
+      setEndDate(selectedTrip.endDate ?? "");
+      setTravellers(selectedTrip.travellers ?? []);
+      setLoadedIsImplicitDefault(selectedTrip.isImplicitDefault === true);
+      setOptionalDetailsOpen(
+        hasOptionalTripFormValues({
+          ...selectedTrip,
+          dailyBudget: daily,
+          totalBudget: total,
+        })
+      );
+    };
+
     const fetchTripData = async () => {
       try {
         const selectedTrip = await fetchTrip(editedTripId);
-        inputChangedHandler("tripName", selectedTrip.tripName);
-        inputChangedHandler("tripCurrency", selectedTrip.tripCurrency);
-        inputChangedHandler("dailyBudget", selectedTrip.dailyBudget.toString());
-        inputChangedHandler(
-          "totalBudget",
-          selectedTrip.totalBudget?.toString()
-        );
-        inputChangedHandler(
-          "isDynamicDailyBudget",
-          selectedTrip.isDynamicDailyBudget
-        );
-        setStartDate(selectedTrip.startDate);
-        setEndDate(selectedTrip.endDate);
-        setTravellers(selectedTrip.travellers);
+        applyLoadedTrip(selectedTrip);
       } catch (error) {
         safeLogError(error);
       }
@@ -179,14 +215,18 @@ const TripForm = ({ navigation, route }) => {
       // if we are editing a trip, we load the data from the context
       // no need to fetch it from the server in that case
       if (tripCtx.tripid == editedTripId) {
-        inputChangedHandler("tripName", tripCtx.tripName);
-        inputChangedHandler("totalBudget", tripCtx.totalBudget);
-        inputChangedHandler("dailyBudget", tripCtx.dailyBudget);
-        inputChangedHandler("tripCurrency", tripCtx.tripCurrency);
-        inputChangedHandler(
-          "isDynamicDailyBudget",
-          tripCtx.isDynamicDailyBudget
-        );
+        applyLoadedTrip({
+          tripName: tripCtx.tripName,
+          totalBudget: tripCtx.totalBudget,
+          dailyBudget: tripCtx.dailyBudget,
+          tripCurrency: tripCtx.tripCurrency,
+          isDynamicDailyBudget: tripCtx.isDynamicDailyBudget,
+          startDate: tripCtx.startDate,
+          endDate: tripCtx.endDate,
+          travellers: tripCtx.travellers,
+          isImplicitDefault: (tripCtx as { isImplicitDefault?: boolean })
+            .isImplicitDefault,
+        });
         setIsLoading(false);
         return;
       } else {
@@ -197,16 +237,22 @@ const TripForm = ({ navigation, route }) => {
     if (isEditing && editedTripId) {
       loadTripDataFromContext();
       fetchTripData();
+    } else if (isAddAnother) {
+      setOptionalDetailsOpen(false);
     }
   }, [
     editedTripId,
     isEditing,
+    isAddAnother,
     tripCtx.dailyBudget,
     tripCtx.totalBudget,
     tripCtx.tripCurrency,
     tripCtx.tripName,
     tripCtx.tripid,
     tripCtx.isDynamicDailyBudget,
+    tripCtx.startDate,
+    tripCtx.endDate,
+    tripCtx.travellers,
   ]);
 
   const [countryValue, setCountryValue] = useState(
@@ -392,27 +438,27 @@ const TripForm = ({ navigation, route }) => {
     // tripCurrency should not be empty
     const tripCurrencyIsValid =
       tripData.tripCurrency && tripData.tripCurrency?.length > 0;
-    // Total budget should be a number between 0 and 3B
+    // Total budget optional; when both set, total must exceed daily
+    const hasTotal = hasTotalBudget(tripData);
+    const hasDaily = hasDailyBudget(tripData);
     const totalBudgetIsValid =
-      !tripData.totalBudget ||
-      tripData.totalBudget === "0" ||
-      (tripData.totalBudget &&
-        !isNaN(+tripData.totalBudget) &&
+      !hasTotal ||
+      (!isNaN(+tripData.totalBudget) &&
         +tripData.totalBudget >= 0 &&
         +tripData.totalBudget < MAX_JS_NUMBER &&
-        +tripData.totalBudget > +tripData.dailyBudget);
+        (!hasDaily || +tripData.totalBudget > +tripData.dailyBudget));
 
     const dynamicIsValid =
       !tripData.isDynamicDailyBudget ||
-      (tripData.isDynamicDailyBudget && totalBudgetIsValid);
+      (tripData.isDynamicDailyBudget && hasTotal);
 
+    // Daily optional (budget-free allowed); when set must be positive
     const dailyBudgetIsValid =
-      !isNaN(+tripData.dailyBudget) &&
-      +tripData.dailyBudget > 0 &&
-      +tripData.dailyBudget < MAX_JS_NUMBER &&
-      (!tripData.totalBudget ||
-        tripData.totalBudget === "0" ||
-        +tripData.dailyBudget < +tripData.totalBudget);
+      !hasDaily ||
+      (!isNaN(+tripData.dailyBudget) &&
+        +tripData.dailyBudget > 0 &&
+        +tripData.dailyBudget < MAX_JS_NUMBER &&
+        (!hasTotal || +tripData.dailyBudget < +tripData.totalBudget));
 
     if (!tripNameIsValid) {
       inputs.tripName.isValid = tripNameIsValid;
@@ -469,38 +515,24 @@ const TripForm = ({ navigation, route }) => {
       Toast.hide();
       return;
     }
-    const tripData: TripData = {
+    const tripData: TripData = buildTripFormSubmitData({
+      mode: formMode,
       tripName: inputs.tripName.value,
       totalBudget: inputs.totalBudget.value,
       tripCurrency: inputs.tripCurrency.value,
       dailyBudget: inputs.dailyBudget.value,
-      startDate: startDate,
-      endDate: endDate,
+      startDate,
+      endDate,
       tripid: editedTripId,
       travellers: travellers,
       isDynamicDailyBudget: inputs.isDynamicDailyBudget.value,
-    };
-
-    if (
-      !tripData.dailyBudget &&
-      tripData.totalBudget &&
-      tripData.startDate &&
-      tripData.endDate &&
-      !tripData.isDynamicDailyBudget
-    ) {
-      const diffDays = daysBetween(new Date(endDate), new Date(startDate)) + 1;
-      const calcDailyBudget = (
-        Number(inputs.totalBudget.value) / diffDays
-      ).toFixed(2);
-      tripData.dailyBudget = calcDailyBudget;
-    }
+    });
 
     const formIsValid = checkFormValidity(tripData);
     if (!formIsValid) return;
-    if (!tripData.totalBudget) tripData.totalBudget = "0";
     try {
-      if (isEditing) {
-        await editingTripData(tripData, setActive);
+      if (isEditing || isPromote) {
+        await editingTripData(tripData, setActive || isPromote);
       } else {
         await createTripData(tripData);
       }
@@ -529,6 +561,21 @@ const TripForm = ({ navigation, route }) => {
 
   function updateCurrency() {
     if (!countryValue || countryValue.length < 1) return;
+    const apply = () => {
+      inputChangedHandler("tripCurrency", countryValue?.split(" ")[0]);
+    };
+    const expenseCount = Array.isArray(expenseCtx.expenses)
+      ? expenseCtx.expenses.length
+      : 0;
+    if (
+      !shouldConfirmCurrencyChange({
+        isEditing,
+        expenseCount,
+      })
+    ) {
+      apply();
+      return;
+    }
     Alert.alert(
       i18n.t("alertChangeHomeCurrencyTitle"),
       i18n.t("alertChangeHomeCurrencyMessage"),
@@ -540,9 +587,7 @@ const TripForm = ({ navigation, route }) => {
         {
           text: i18n.t("yes"),
           style: "destructive",
-          onPress: () => {
-            inputChangedHandler("tripCurrency", countryValue?.split(" ")[0]);
-          },
+          onPress: apply,
         },
       ]
     );
@@ -605,12 +650,15 @@ const TripForm = ({ navigation, route }) => {
     setInfoIsVisible(true);
   }
 
-  const titleString = isEditing
-    ? i18n.t("tripFormTitleEdit")
-    : i18n.t("tripFormTitleNew");
-  const currencyView = isEditing ? (
-    <></>
-  ) : (
+  const titleString =
+    formMode === "promote"
+      ? i18n.t("tripFormTitlePromote")
+      : formMode === "addAnother"
+        ? i18n.t("tripFormTitleAddAnother")
+        : i18n.t("tripFormTitleEdit");
+  const subtitleString =
+    formMode === "addAnother" ? i18n.t("tripFormSubtitleAddAnother") : "";
+  const currencyView = (
     <View style={styles.currencyPickerContainer}>
       <CurrencyPicker
         placeholder={
@@ -742,7 +790,14 @@ const TripForm = ({ navigation, route }) => {
               isEditing && { minHeight: "70%" },
             ]}
           >
-            <Text style={styles.title}>{titleString}</Text>
+            <Text style={styles.title} testID="trip-form-title">
+              {titleString}
+            </Text>
+            {!!subtitleString && (
+              <Text style={styles.subtitle} testID="trip-form-subtitle">
+                {subtitleString}
+              </Text>
+            )}
 
             <Input
               label={i18n.t("tripNameLabel")}
@@ -756,166 +811,206 @@ const TripForm = ({ navigation, route }) => {
               autoFocus={false}
             />
 
-            {currencyView}
+            <Pressable
+              testID="trip-form-optional-toggle"
+              onPress={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                setOptionalDetailsOpen((open) => !open);
+              }}
+              style={styles.optionalToggle}
+            >
+              <Text style={styles.optionalToggleText}>
+                {i18n.t("tripFormOptionalDetails")}
+                {optionalDetailsOpen ? " ▲" : " ▼"}
+              </Text>
+            </Pressable>
 
-            <View style={styles.categoryRow}>
-              {/* TODO: add recalculate button */}
-              <Input
-                label={`${i18n.t("totalBudgetLabel")} ${
-                  inputs.tripCurrency.value
-                }`}
-                style={{ flex: 1, marginTop: "-2%" }}
-                inputStyle={{}}
-                autoFocus={false}
-                textInputConfig={{
-                  keyboardType: "decimal-pad",
-                  onChangeText: inputChangedHandler.bind(this, "totalBudget"),
-                  value: inputs.totalBudget.value,
-                }}
-                invalid={!inputs.totalBudget.isValid}
-              />
-              {validDailyBudgetEntry && !inputs.isDynamicDailyBudget.value && (
-                <Animated.View
-                  entering={ZoomIn}
-                  exiting={ZoomOut}
-                  style={styles.recalcButtonContainer}
-                >
-                  <IconButton
-                    icon="git-compare-outline"
-                    color={GlobalStyles.colors.primary500}
-                    size={dynamicScale(36, false, 0.5)}
-                    buttonStyle={styles.recalcButton}
-                    onPressStyle={GlobalStyles.pressedWithShadow}
-                    onPress={() => {
-                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                      const diffDays =
-                        daysBetween(new Date(endDate), new Date(startDate)) + 1;
-                      const calcTotalBudget =
-                        Number(inputs.dailyBudget.value) * diffDays;
-                      inputChangedHandler(
-                        "totalBudget",
-                        calcTotalBudget.toString()
-                      );
-                    }}
-                  />
-                </Animated.View>
-              )}
-              <InfoButton
-                onPress={showInfoHandler.bind(this, infoEnum.totalBudget)}
-                containerStyle={{ marginTop: "-3%" }}
-              ></InfoButton>
-            </View>
+            {optionalDetailsOpen && (
+              <View testID="trip-form-optional-section">
+                {currencyView}
 
-            {!inputs.isDynamicDailyBudget.value && (
-              <View>
                 <View style={styles.categoryRow}>
+                  {/* TODO: add recalculate button */}
                   <Input
-                    style={{ flex: 1 }}
-                    inputStyle={{}}
-                    autoFocus={false}
-                    label={`${i18n.t("dailyBudgetLabel")} ${
+                    label={`${i18n.t("totalBudgetLabel")} ${
                       inputs.tripCurrency.value
                     }`}
+                    style={{ flex: 1, marginTop: "-2%" }}
+                    inputStyle={{}}
+                    autoFocus={false}
                     textInputConfig={{
                       keyboardType: "decimal-pad",
                       onChangeText: inputChangedHandler.bind(
                         this,
-                        "dailyBudget"
+                        "totalBudget"
                       ),
-                      value: inputs.dailyBudget.value,
+                      value: inputs.totalBudget.value,
                     }}
-                    invalid={!inputs.dailyBudget.isValid}
+                    invalid={!inputs.totalBudget.isValid}
                   />
-                  {validTotalBudgetEntry && (
-                    <Animated.View
-                      entering={ZoomIn}
-                      exiting={ZoomOut}
-                      style={styles.recalcButtonContainer}
-                    >
-                      <IconButton
-                        icon="git-compare-outline"
-                        color={GlobalStyles.colors.primary500}
-                        size={dynamicScale(36, false, 0.5)}
-                        buttonStyle={styles.recalcButton}
-                        onPressStyle={GlobalStyles.pressedWithShadow}
-                        onPress={() => {
-                          Haptics.impactAsync(
-                            Haptics.ImpactFeedbackStyle.Light
-                          );
-                          const diffDays =
-                            daysBetween(
-                              new Date(endDate),
-                              new Date(startDate)
-                            ) + 1;
-                          const calcDailyBudget = (
-                            Number(inputs.totalBudget.value) / diffDays
-                          ).toFixed(2);
+                  {validDailyBudgetEntry &&
+                    !inputs.isDynamicDailyBudget.value &&
+                    !!startDate &&
+                    !!endDate && (
+                      <Animated.View
+                        entering={ZoomIn}
+                        exiting={ZoomOut}
+                        style={styles.recalcButtonContainer}
+                      >
+                        <IconButton
+                          icon="git-compare-outline"
+                          color={GlobalStyles.colors.primary500}
+                          size={dynamicScale(36, false, 0.5)}
+                          buttonStyle={styles.recalcButton}
+                          onPressStyle={GlobalStyles.pressedWithShadow}
+                          onPress={() => {
+                            Haptics.impactAsync(
+                              Haptics.ImpactFeedbackStyle.Light
+                            );
+                            const diffDays =
+                              daysBetween(
+                                new Date(endDate),
+                                new Date(startDate)
+                              ) + 1;
+                            const calcTotalBudget =
+                              Number(inputs.dailyBudget.value) * diffDays;
+                            inputChangedHandler(
+                              "totalBudget",
+                              calcTotalBudget.toString()
+                            );
+                          }}
+                        />
+                      </Animated.View>
+                    )}
+                  <InfoButton
+                    onPress={showInfoHandler.bind(this, infoEnum.totalBudget)}
+                    containerStyle={{ marginTop: "-3%" }}
+                  ></InfoButton>
+                </View>
+
+                {!inputs.isDynamicDailyBudget.value && (
+                  <View>
+                    <View style={styles.categoryRow}>
+                      <Input
+                        style={{ flex: 1 }}
+                        inputStyle={{}}
+                        autoFocus={false}
+                        label={`${i18n.t("dailyBudgetLabel")} ${
+                          inputs.tripCurrency.value
+                        }`}
+                        textInputConfig={{
+                          keyboardType: "decimal-pad",
+                          onChangeText: inputChangedHandler.bind(
+                            this,
+                            "dailyBudget"
+                          ),
+                          value: inputs.dailyBudget.value,
+                        }}
+                        invalid={!inputs.dailyBudget.isValid}
+                      />
+                      {validTotalBudgetEntry && !!startDate && !!endDate && (
+                        <Animated.View
+                          entering={ZoomIn}
+                          exiting={ZoomOut}
+                          style={styles.recalcButtonContainer}
+                        >
+                          <IconButton
+                            icon="git-compare-outline"
+                            color={GlobalStyles.colors.primary500}
+                            size={dynamicScale(36, false, 0.5)}
+                            buttonStyle={styles.recalcButton}
+                            onPressStyle={GlobalStyles.pressedWithShadow}
+                            onPress={() => {
+                              Haptics.impactAsync(
+                                Haptics.ImpactFeedbackStyle.Light
+                              );
+                              const diffDays =
+                                daysBetween(
+                                  new Date(endDate),
+                                  new Date(startDate)
+                                ) + 1;
+                              const calcDailyBudget = (
+                                Number(inputs.totalBudget.value) / diffDays
+                              ).toFixed(2);
+                              inputChangedHandler(
+                                "dailyBudget",
+                                calcDailyBudget.toString()
+                              );
+                            }}
+                          />
+                        </Animated.View>
+                      )}
+                      <InfoButton
+                        onPress={showInfoHandler.bind(
+                          this,
+                          infoEnum.dailyBudget
+                        )}
+                        containerStyle={{ marginTop: "-3%" }}
+                      ></InfoButton>
+                    </View>
+                  </View>
+                )}
+                <View style={styles.dynamicDailyContainer}>
+                  <Text style={styles.dynamicDailyLabel}>
+                    Calculate Daily Budget dynamically
+                  </Text>
+                  <Switch
+                    value={inputs.isDynamicDailyBudget.value}
+                    style={{ marginRight: "5%" }}
+                    color={GlobalStyles.colors.primary500}
+                    onValueChange={(value) => {
+                      if (startDate && endDate) {
+                        const calcNewDaily =
+                          +inputs.totalBudget.value /
+                          daysBetween(new Date(endDate), new Date(startDate));
+                        const isAPositiveInt =
+                          !isNaN(calcNewDaily) &&
+                          calcNewDaily > 0 &&
+                          calcNewDaily < MAX_JS_NUMBER;
+                        const newDailyBudget =
+                          isAPositiveInt && calcNewDaily.toFixed(2);
+                        if (
+                          !inputs.dailyBudget.value &&
+                          inputs.totalBudget.value
+                        )
                           inputChangedHandler(
                             "dailyBudget",
-                            calcDailyBudget.toString()
+                            newDailyBudget ?? ""
                           );
-                        }}
-                      />
-                    </Animated.View>
-                  )}
+                      }
+                      inputChangedHandler("isDynamicDailyBudget", value);
+                    }}
+                  ></Switch>
                   <InfoButton
-                    onPress={showInfoHandler.bind(this, infoEnum.dailyBudget)}
-                    containerStyle={{ marginTop: "-3%" }}
+                    onPress={showInfoHandler.bind(
+                      this,
+                      infoEnum.dynamicDailyBudget
+                    )}
+                    containerStyle={{ marginLeft: "-4%" }}
+                  ></InfoButton>
+                </View>
+                <Text
+                  style={[
+                    styles.label,
+                    { marginLeft: "5%", marginTop: "2%", marginBottom: "-4%" },
+                  ]}
+                >
+                  {i18n.t("datePickerLabel")}
+                </Text>
+                <View style={{ flexDirection: "row" }}>
+                  {DatePickerContainer({
+                    openDatePickerRange,
+                    startDate,
+                    endDate,
+                    dateIsRanged: true,
+                  })}
+                  <InfoButton
+                    onPress={showInfoHandler.bind(this, infoEnum.datePicker)}
+                    containerStyle={{ marginLeft: "-4%" }}
                   ></InfoButton>
                 </View>
               </View>
             )}
-            <View style={styles.dynamicDailyContainer}>
-              <Text style={styles.dynamicDailyLabel}>
-                Calculate Daily Budget dynamically
-              </Text>
-              <Switch
-                value={inputs.isDynamicDailyBudget.value}
-                style={{ marginRight: "5%" }}
-                color={GlobalStyles.colors.primary500}
-                onValueChange={(value) => {
-                  const calcNewDaily =
-                    +inputs.totalBudget.value /
-                    daysBetween(new Date(endDate), new Date(startDate));
-                  const isAPositiveInt =
-                    !isNaN(calcNewDaily) &&
-                    calcNewDaily > 0 &&
-                    calcNewDaily < MAX_JS_NUMBER;
-                  const newDailyBudget =
-                    isAPositiveInt && calcNewDaily.toFixed(2);
-                  if (!inputs.dailyBudget.value && inputs.totalBudget.value)
-                    inputChangedHandler("dailyBudget", newDailyBudget ?? "");
-                  inputChangedHandler("isDynamicDailyBudget", value);
-                }}
-              ></Switch>
-              <InfoButton
-                onPress={showInfoHandler.bind(
-                  this,
-                  infoEnum.dynamicDailyBudget
-                )}
-                containerStyle={{ marginLeft: "-4%" }}
-              ></InfoButton>
-            </View>
-            <Text
-              style={[
-                styles.label,
-                { marginLeft: "5%", marginTop: "2%", marginBottom: "-4%" },
-              ]}
-            >
-              {i18n.t("datePickerLabel")}
-            </Text>
-            <View style={{ flexDirection: "row" }}>
-              {DatePickerContainer({
-                openDatePickerRange,
-                startDate,
-                endDate,
-                dateIsRanged: true,
-              })}
-              <InfoButton
-                onPress={showInfoHandler.bind(this, infoEnum.datePicker)}
-                containerStyle={{ marginLeft: "-4%" }}
-              ></InfoButton>
-            </View>
           </View>
           {/* Add Currency Input field */}
           <View style={styles.buttonContainer}>
@@ -937,7 +1032,7 @@ const TripForm = ({ navigation, route }) => {
             )}
           </View>
           {/* Horizontal container */}
-          {isEditing && (
+          {isEditing && !isPromote && (
             <GradientButton
               buttonStyle={{}}
               style={[
@@ -1050,8 +1145,24 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
     color: GlobalStyles.colors.textColor,
     marginTop: dynamicScale(5, false, 0.5),
-    marginBottom: dynamicScale(24, false, 0.5),
+    marginBottom: dynamicScale(8, false, 0.5),
     textAlign: "center",
+  },
+  subtitle: {
+    fontSize: dynamicScale(14, false, 0.5),
+    color: GlobalStyles.colors.textColor,
+    marginBottom: dynamicScale(16, false, 0.5),
+    textAlign: "center",
+    opacity: 0.8,
+  },
+  optionalToggle: {
+    paddingVertical: dynamicScale(10, false, 0.5),
+    marginBottom: dynamicScale(4, false, 0.5),
+  },
+  optionalToggleText: {
+    fontSize: dynamicScale(14, false, 0.5),
+    fontWeight: "600",
+    color: GlobalStyles.colors.primary500,
   },
   categoryRow: {
     flex: 1,

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -161,7 +161,7 @@ const TripForm = ({ navigation, route }) => {
   const editedTripId = route.params?.tripId;
   const isEditing = !!editedTripId;
   const formMode: TripFormMode = resolveTripFormMode(route.params, {
-    isImplicitDefault: loadedIsImplicitDefault,
+    isImplicitDefault: loadedIsImplicitDefault || tripCtx.isImplicitDefault,
   });
   const isPromote = formMode === "promote";
   const isAddAnother = formMode === "addAnother";
@@ -224,8 +224,7 @@ const TripForm = ({ navigation, route }) => {
           startDate: tripCtx.startDate,
           endDate: tripCtx.endDate,
           travellers: tripCtx.travellers,
-          isImplicitDefault: (tripCtx as { isImplicitDefault?: boolean })
-            .isImplicitDefault,
+          isImplicitDefault: tripCtx.isImplicitDefault,
         });
         setIsLoading(false);
         return;
@@ -253,6 +252,7 @@ const TripForm = ({ navigation, route }) => {
     tripCtx.startDate,
     tripCtx.endDate,
     tripCtx.travellers,
+    tripCtx.isImplicitDefault,
   ]);
 
   const [countryValue, setCountryValue] = useState(
@@ -502,19 +502,15 @@ const TripForm = ({ navigation, route }) => {
         return;
       }
     }
-    navigation.pop();
-    Toast.show({
-      type: "loading",
-      text1: i18n.t("toastSaving1"),
-      text2: i18n.t("toastSaving2"),
-      autoHide: false,
-    });
     if (!isConnected) {
       Alert.alert(i18n.t("noConnection"), i18n.t("checkConnectionError"));
       setIsLoading(false);
-      Toast.hide();
       return;
     }
+    const wasImplicitDefault =
+      loadedIsImplicitDefault ||
+      tripCtx.isImplicitDefault === true ||
+      isPromote;
     const tripData: TripData = buildTripFormSubmitData({
       mode: formMode,
       tripName: inputs.tripName.value,
@@ -526,13 +522,22 @@ const TripForm = ({ navigation, route }) => {
       tripid: editedTripId,
       travellers: travellers,
       isDynamicDailyBudget: inputs.isDynamicDailyBudget.value,
+      wasImplicitDefault,
     });
 
     const formIsValid = checkFormValidity(tripData);
     if (!formIsValid) return;
+
+    navigation.pop();
+    Toast.show({
+      type: "loading",
+      text1: i18n.t("toastSaving1"),
+      text2: i18n.t("toastSaving2"),
+      autoHide: false,
+    });
     try {
-      if (isEditing || isPromote) {
-        await editingTripData(tripData, setActive || isPromote);
+      if (isEditing) {
+        await editingTripData(tripData, setActive || wasImplicitDefault);
       } else {
         await createTripData(tripData);
       }

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -171,6 +171,10 @@ const en = {
   // Trip Form Labels
   tripFormTitleNew: "New Trip Budget",
   tripFormTitleEdit: "Edit Trip Budget",
+  tripFormTitlePromote: "Name your budget",
+  tripFormTitleAddAnother: "Add another budget",
+  tripFormSubtitleAddAnother: "New budgets start empty",
+  tripFormOptionalDetails: "Optional details",
   tripNameLabel: "Trip Name",
   baseCurrencyLabel: "Home Currency",
   totalBudgetLabel: "Total Budget in",
@@ -762,6 +766,10 @@ const de = {
   // Trip Form Labels
   tripFormTitleNew: "Neue Reise erstellen",
   tripFormTitleEdit: "Reise bearbeiten",
+  tripFormTitlePromote: "Budget benennen",
+  tripFormTitleAddAnother: "Weiteres Budget hinzufügen",
+  tripFormSubtitleAddAnother: "Neue Budgets starten leer",
+  tripFormOptionalDetails: "Optionale Details",
   tripNameLabel: "Name der Reise",
   tripCurrencyLabel: "Deine Heimatwährung in",
   totalBudgetLabel: "Gesamtbudget in",
@@ -1382,6 +1390,10 @@ const fr = {
   // Trip Form Labels
   tripFormTitleNew: "Nouveau voyage",
   tripFormTitleEdit: "Modifier le voyage",
+  tripFormTitlePromote: "Nommer votre budget",
+  tripFormTitleAddAnother: "Ajouter un autre budget",
+  tripFormSubtitleAddAnother: "Les nouveaux budgets commencent vides",
+  tripFormOptionalDetails: "Détails optionnels",
   tripNameLabel: "Nom du voyage",
   baseCurrencyLabel: "Devise du domicile",
   totalBudgetLabel: "Budget total en",
@@ -1996,6 +2008,10 @@ const ru = {
   // Trip Form Labels
   tripFormTitleNew: "Новая поездка",
   tripFormTitleEdit: "Изменить поездку",
+  tripFormTitlePromote: "Назовите бюджет",
+  tripFormTitleAddAnother: "Добавить другой бюджет",
+  tripFormSubtitleAddAnother: "Новые бюджеты начинаются пустыми",
+  tripFormOptionalDetails: "Дополнительные детали",
   tripNameLabel: "Название поездки",
   baseCurrencyLabel: "Домашняя валюта",
   totalBudgetLabel: "Общий бюджет в",

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -52,6 +52,7 @@ export type TripContextType = {
   isLoading: boolean;
   setIsLoading: (isLoading: boolean) => void;
   isDynamicDailyBudget: boolean;
+  isImplicitDefault: boolean;
 };
 
 export const TripContext = createContext<TripContextType>({
@@ -95,6 +96,7 @@ export const TripContext = createContext<TripContextType>({
   isLoading: false,
   setIsLoading: (isLoading: boolean) => {},
   isDynamicDailyBudget: false,
+  isImplicitDefault: false,
 });
 
 function TripContextProvider({ children }: React.PropsWithChildren) {
@@ -115,6 +117,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   );
   const [isLoading, setIsLoading] = useState(false);
   const [isDynamicDailyBudget, setIsDynamicDailyBudget] = useState(false);
+  const [isImplicitDefault, setIsImplicitDefault] = useState(false);
 
   const tripTotalSpent = useTripTotalSpent();
 
@@ -234,6 +237,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       setIsPaidDate("");
       setIsPaidTimestamp(undefined);
       setIsLoading(false);
+      setIsImplicitDefault(false);
       return;
     }
 
@@ -251,6 +255,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     setIsPaidTimestamp(hydratedTrip.isPaidTimestamp);
     setIsLoading(false);
     setIsDynamicDailyBudget(hydratedTrip.isDynamicDailyBudget ?? false);
+    setIsImplicitDefault(hydratedTrip.isImplicitDefault === true);
     if (typeof trip.travellers[1] === "string") {
       setTravellers(trip.travellers);
     } else {
@@ -338,6 +343,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
       endDate: endDate,
       travellers: travellers,
       isDynamicDailyBudget: isDynamicDailyBudget,
+      isImplicitDefault: isImplicitDefault,
     };
     return curTripData;
   }
@@ -431,6 +437,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     isLoading: isLoading,
     setIsLoading: setIsLoading,
     isDynamicDailyBudget: isDynamicDailyBudget,
+    isImplicitDefault: isImplicitDefault,
   };
 
   return <TripContext.Provider value={value}>{children}</TripContext.Provider>;

--- a/TravelCostApp/util/budget-free.ts
+++ b/TravelCostApp/util/budget-free.ts
@@ -1,0 +1,77 @@
+import { MAX_JS_NUMBER } from "../confAppConstants";
+import type { TripData } from "../types/trip";
+
+type BudgetFields = Pick<TripData, "dailyBudget" | "totalBudget">;
+
+/** True when a total budget amount is set and usable as a spending cap. */
+export function hasTotalBudget(
+  trip: Pick<TripData, "totalBudget"> | null | undefined
+): boolean {
+  if (!trip) return false;
+  const raw = trip.totalBudget;
+  if (raw === undefined || raw === null || raw === "") return false;
+  const asString = String(raw);
+  if (asString === "0") return false;
+  const n = Number(asString);
+  if (Number.isNaN(n) || n <= 0) return false;
+  if (n >= MAX_JS_NUMBER) return false;
+  return true;
+}
+
+/** True when a daily budget amount is set and usable as a daily target. */
+export function hasDailyBudget(
+  trip: Pick<TripData, "dailyBudget"> | null | undefined
+): boolean {
+  if (!trip) return false;
+  const raw = trip.dailyBudget;
+  if (raw === undefined || raw === null || raw === "") return false;
+  const asString = String(raw);
+  if (asString === "0") return false;
+  const n = Number(asString);
+  if (Number.isNaN(n) || n <= 0) return false;
+  return true;
+}
+
+/**
+ * Budget-free: neither total nor daily budget is set.
+ * Progress / over-budget UI must stay hidden until at least one is set.
+ */
+export function isBudgetFree(trip: BudgetFields | null | undefined): boolean {
+  return !hasTotalBudget(trip) && !hasDailyBudget(trip);
+}
+
+/**
+ * Whether the ExpensesSummary progress bar applies for this period.
+ * Daily-only trips skip total progress; total-only trips skip period/daily bars.
+ */
+export function periodProgressApplies(
+  trip: BudgetFields | null | undefined,
+  periodName: string
+): boolean {
+  if (isBudgetFree(trip)) return false;
+  if (periodName === "total") return hasTotalBudget(trip);
+  return hasDailyBudget(trip);
+}
+
+/**
+ * Period average start: trip startDate, else earliest expense date, else undefined (all-time / skip).
+ */
+export function resolvePeriodStartDate(
+  tripStartDate: string | null | undefined,
+  expenseDates: Array<Date | string | null | undefined>
+): string | undefined {
+  if (tripStartDate && String(tripStartDate).trim().length > 0) {
+    const parsed = new Date(tripStartDate);
+    if (!Number.isNaN(parsed.getTime())) return String(tripStartDate).trim();
+  }
+
+  let earliest: Date | undefined;
+  for (const raw of expenseDates) {
+    if (!raw) continue;
+    const d = raw instanceof Date ? raw : new Date(raw);
+    if (Number.isNaN(d.getTime())) continue;
+    if (!earliest || d.getTime() < earliest.getTime()) earliest = d;
+  }
+  if (!earliest) return undefined;
+  return earliest.toISOString().slice(0, 10);
+}

--- a/TravelCostApp/util/budget-free.ts
+++ b/TravelCostApp/util/budget-free.ts
@@ -52,26 +52,3 @@ export function periodProgressApplies(
   if (periodName === "total") return hasTotalBudget(trip);
   return hasDailyBudget(trip);
 }
-
-/**
- * Period average start: trip startDate, else earliest expense date, else undefined (all-time / skip).
- */
-export function resolvePeriodStartDate(
-  tripStartDate: string | null | undefined,
-  expenseDates: Array<Date | string | null | undefined>
-): string | undefined {
-  if (tripStartDate && String(tripStartDate).trim().length > 0) {
-    const parsed = new Date(tripStartDate);
-    if (!Number.isNaN(parsed.getTime())) return String(tripStartDate).trim();
-  }
-
-  let earliest: Date | undefined;
-  for (const raw of expenseDates) {
-    if (!raw) continue;
-    const d = raw instanceof Date ? raw : new Date(raw);
-    if (Number.isNaN(d.getTime())) continue;
-    if (!earliest || d.getTime() < earliest.getTime()) earliest = d;
-  }
-  if (!earliest) return undefined;
-  return earliest.toISOString().slice(0, 10);
-}

--- a/TravelCostApp/util/budget.ts
+++ b/TravelCostApp/util/budget.ts
@@ -94,6 +94,29 @@ export function getBudgetColor(
 }
 
 /**
+ * Period average start: trip startDate, else earliest expense date, else undefined (all-time / skip).
+ */
+export function resolvePeriodStartDate(
+  tripStartDate: string | null | undefined,
+  expenseDates: Array<Date | string | null | undefined>
+): string | undefined {
+  if (tripStartDate && String(tripStartDate).trim().length > 0) {
+    const parsed = new Date(tripStartDate);
+    if (!Number.isNaN(parsed.getTime())) return String(tripStartDate).trim();
+  }
+
+  let earliest: Date | undefined;
+  for (const raw of expenseDates) {
+    if (!raw) continue;
+    const d = raw instanceof Date ? raw : new Date(raw);
+    if (Number.isNaN(d.getTime())) continue;
+    if (!earliest || d.getTime() < earliest.getTime()) earliest = d;
+  }
+  if (!earliest) return undefined;
+  return earliest.toISOString().slice(0, 10);
+}
+
+/**
  * Calculates the daily average spending for a given period.
  * The average is calculated from the current period + the previous period.
  */

--- a/TravelCostApp/util/trip-form.ts
+++ b/TravelCostApp/util/trip-form.ts
@@ -58,12 +58,14 @@ export type BuildTripFormSubmitInput = {
   endDate?: string | null;
   tripid?: string;
   travellers?: TripData["travellers"];
+  /** When true, naming graduates an implicit default trip even if mode resolved as edit. */
+  wasImplicitDefault?: boolean;
 };
 
 /**
  * Build trip payload for promote / add-another / edit.
  * Does not invent dates or daily-from-total without dates.
- * Promote clears isImplicitDefault.
+ * Promote (or naming a previously implicit trip) clears isImplicitDefault.
  */
 export function buildTripFormSubmitData(
   input: BuildTripFormSubmitInput
@@ -109,7 +111,7 @@ export function buildTripFormSubmitData(
   if (endDate) tripData.endDate = endDate;
   if (input.tripid) tripData.tripid = input.tripid;
 
-  if (input.mode === "promote") {
+  if (input.mode === "promote" || input.wasImplicitDefault === true) {
     tripData.isImplicitDefault = false;
   }
 

--- a/TravelCostApp/util/trip-form.ts
+++ b/TravelCostApp/util/trip-form.ts
@@ -1,0 +1,127 @@
+import type { TripData } from "../types/trip";
+import { daysBetween } from "./date";
+import { hasDailyBudget, hasTotalBudget } from "./budget-free";
+
+export type TripFormMode = "promote" | "addAnother" | "edit";
+
+export type TripFormRouteParams = {
+  tripId?: string;
+  mode?: TripFormMode | string;
+};
+
+/** Resolve Trip form mode from navigation params + loaded trip flags. */
+export function resolveTripFormMode(
+  params: TripFormRouteParams | null | undefined,
+  trip?: Pick<TripData, "isImplicitDefault"> | null
+): TripFormMode {
+  const mode = params?.mode;
+  if (mode === "promote") return "promote";
+  if (mode === "addAnother") return "addAnother";
+  if (mode === "edit") return "edit";
+
+  const tripId = params?.tripId;
+  if (tripId) {
+    if (trip?.isImplicitDefault === true) return "promote";
+    return "edit";
+  }
+  return "addAnother";
+}
+
+/** Optional accordion fields already set → auto-expand on edit. */
+export function hasOptionalTripFormValues(
+  trip: Pick<
+    TripData,
+    | "dailyBudget"
+    | "totalBudget"
+    | "startDate"
+    | "endDate"
+    | "isDynamicDailyBudget"
+  > | null
+  | undefined
+): boolean {
+  if (!trip) return false;
+  if (hasDailyBudget(trip) || hasTotalBudget(trip)) return true;
+  if (trip.isDynamicDailyBudget) return true;
+  if (trip.startDate && String(trip.startDate).trim().length > 0) return true;
+  if (trip.endDate && String(trip.endDate).trim().length > 0) return true;
+  return false;
+}
+
+export type BuildTripFormSubmitInput = {
+  mode: TripFormMode;
+  tripName: string;
+  tripCurrency: string;
+  totalBudget: string;
+  dailyBudget: string;
+  isDynamicDailyBudget: boolean;
+  startDate?: string | null;
+  endDate?: string | null;
+  tripid?: string;
+  travellers?: TripData["travellers"];
+};
+
+/**
+ * Build trip payload for promote / add-another / edit.
+ * Does not invent dates or daily-from-total without dates.
+ * Promote clears isImplicitDefault.
+ */
+export function buildTripFormSubmitData(
+  input: BuildTripFormSubmitInput
+): TripData {
+  const startDate =
+    input.startDate && String(input.startDate).trim().length > 0
+      ? String(input.startDate).trim()
+      : undefined;
+  const endDate =
+    input.endDate && String(input.endDate).trim().length > 0
+      ? String(input.endDate).trim()
+      : undefined;
+
+  let dailyBudget = input.dailyBudget?.trim() ?? "";
+  let totalBudget = input.totalBudget?.trim() ?? "";
+
+  if (
+    !dailyBudget &&
+    totalBudget &&
+    startDate &&
+    endDate &&
+    !input.isDynamicDailyBudget
+  ) {
+    const diffDays = daysBetween(new Date(endDate), new Date(startDate)) + 1;
+    if (diffDays > 0 && Number(totalBudget) > 0) {
+      dailyBudget = (Number(totalBudget) / diffDays).toFixed(2);
+    }
+  }
+
+  if (!totalBudget) totalBudget = "0";
+  if (!dailyBudget) dailyBudget = "0";
+
+  const tripData: TripData = {
+    tripName: input.tripName,
+    tripCurrency: input.tripCurrency,
+    totalBudget,
+    dailyBudget,
+    isDynamicDailyBudget: input.isDynamicDailyBudget,
+    travellers: input.travellers,
+  };
+
+  if (startDate) tripData.startDate = startDate;
+  if (endDate) tripData.endDate = endDate;
+  if (input.tripid) tripData.tripid = input.tripid;
+
+  if (input.mode === "promote") {
+    tripData.isImplicitDefault = false;
+  }
+
+  return tripData;
+}
+
+/** Whether changing trip currency requires a confirm step. */
+export function shouldConfirmCurrencyChange(options: {
+  isEditing: boolean;
+  expenseCount: number;
+}): boolean {
+  // Edit always confirms (expenseCtx may be Active trip only).
+  if (options.isEditing) return true;
+  return options.expenseCount > 0;
+}


### PR DESCRIPTION
## Summary
- One TripForm shell for Name your budget (promote in place), Add another budget, and Edit — name required; optional accordion for currency/budgets/dates/dynamic daily; no invented trip dates
- Promote updates the same trip id and clears `isImplicitDefault`; ExpensesSummary hides progress/over-budget when budget-free or when the period’s budget shape is unset (daily-only / total-only matrix)

## Test plan
- [ ] Open ManageTrip with no `tripId` — title “Add another budget”, subtitle “New budgets start empty”, optional details collapsed; save name-only creates an empty named trip with no default dates
- [ ] Open with `{ tripId, mode: "promote" }` on an implicit default — “Name your budget”; save keeps same id and clears `isImplicitDefault`
- [ ] Edit a trip that already has budgets/dates — optional accordion auto-expands; changing currency confirms
- [ ] Budget-free Active trip — Recent Expenses still shows spend, no progress bar; daily-only hides total progress; total-only hides period progress
- [ ] `pnpm test` in TravelCostApp

Closes #354