### PR TITLE
Recent Expenses guidance: empty CTA + naming banner (#355)

### DIFF
--- a/TravelCostApp/__tests__/i18n/naming-banner-copy.test.ts
+++ b/TravelCostApp/__tests__/i18n/naming-banner-copy.test.ts
@@ -1,0 +1,19 @@
+import { de, en, fr, ru } from "../../i18n/supportedLanguages";
+
+describe("naming banner i18n (issue #355)", () => {
+  it("ships EN+DE+FR+RU copy for banner text and Name it", () => {
+    for (const locale of [en, de, fr, ru]) {
+      expect(locale.namingBannerText).toBeTruthy();
+      expect(locale.namingBannerNameIt).toBeTruthy();
+      expect(locale.later).toBeTruthy();
+      expect(locale.addExp).toBeTruthy();
+    }
+  });
+
+  it("English matches the PRD naming banner wording", () => {
+    expect(en.namingBannerText).toBe(
+      "Name your budget to keep things organized."
+    );
+    expect(en.namingBannerNameIt).toBe("Name it");
+  });
+});

--- a/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
@@ -56,8 +56,19 @@ const mmkvStore: Record<string, unknown> = {};
 
 jest.mock("../../store/mmkv", () => ({
   MMKV_KEYS: { OFFLINE_QUEUE: "offlineQueue" },
+  MMKV_KEY_PATTERNS: {
+    NAMING_BANNER_DISMISSED: (tripid: string) =>
+      `namingBannerDismissed_${tripid}`,
+  },
   getMMKVObject: jest.fn((key: string) => mmkvStore[key] ?? null),
   setMMKVObject: jest.fn((key: string, value: unknown) => {
+    mmkvStore[key] = value;
+  }),
+  getMMKVString: jest.fn((key: string) => {
+    const value = mmkvStore[key];
+    return typeof value === "string" ? value : "";
+  }),
+  setMMKVString: jest.fn((key: string, value: string) => {
     mmkvStore[key] = value;
   }),
 }));
@@ -83,7 +94,7 @@ jest.mock("react-native-toast-message/lib/src/Toast", () => ({
   Toast: { show: jest.fn(), hide: jest.fn() },
 }));
 
-import { waitFor } from "@testing-library/react-native";
+import { act, fireEvent, waitFor } from "@testing-library/react-native";
 import { StyleSheet } from "react-native";
 import RecentExpenses from "../../screens/RecentExpenses";
 import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
@@ -108,6 +119,10 @@ describe("RecentExpenses screen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it("fetches expenses after the offline queue flushes successfully", async () => {
@@ -282,5 +297,207 @@ describe("RecentExpenses screen", () => {
 
     expect(screen.getByTestId("add-expense-entry")).toBeTruthy();
     expect(navigation.navigate).not.toHaveBeenCalledWith("Profile");
+  });
+
+  it("shows a clear empty-state add-expense CTA for an implicit default Active trip", async () => {
+    jest.useFakeTimers();
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <RecentExpenses navigation={navigation as any} />,
+      {
+        expenses: expensesContextForList([]),
+        user: {
+          periodName: "month",
+          freshlyCreated: false,
+        },
+        trip: {
+          tripid: "t-implicit",
+          tripName: "",
+          tripCurrency: "EUR",
+          isImplicitDefault: true,
+          dailyBudget: "0",
+          totalBudget: "0",
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByTestId("empty-expenses-cta")).toBeTruthy();
+    fireEvent.press(screen.getByText("Add Expense"));
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      expect.stringMatching(/CategoryPick|ManageExpense/)
+    );
+    jest.useRealTimers();
+  });
+
+  it("shows the naming banner for an undismissed implicit default Active trip", async () => {
+    jest.useFakeTimers();
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <RecentExpenses navigation={navigation as any} />,
+      {
+        expenses: expensesContextForList([]),
+        user: {
+          periodName: "month",
+          freshlyCreated: false,
+        },
+        trip: {
+          tripid: "t-implicit",
+          tripName: "",
+          tripCurrency: "EUR",
+          isImplicitDefault: true,
+          dailyBudget: "0",
+          totalBudget: "0",
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByTestId("naming-banner")).toBeTruthy();
+    expect(
+      screen.getByText("Name your budget to keep things organized.")
+    ).toBeTruthy();
+    expect(screen.getByTestId("naming-banner-name-it")).toBeTruthy();
+    expect(screen.getByTestId("naming-banner-later")).toBeTruthy();
+    jest.useRealTimers();
+  });
+
+  it("Name it opens the promote Name your budget flow", async () => {
+    jest.useFakeTimers();
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <RecentExpenses navigation={navigation as any} />,
+      {
+        expenses: expensesContextForList([]),
+        user: {
+          periodName: "month",
+          freshlyCreated: false,
+        },
+        trip: {
+          tripid: "t-implicit",
+          tripName: "",
+          tripCurrency: "EUR",
+          isImplicitDefault: true,
+          dailyBudget: "0",
+          totalBudget: "0",
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    fireEvent.press(screen.getByText("Name it"));
+    expect(navigation.navigate).toHaveBeenCalledWith("ManageTrip", {
+      tripId: "t-implicit",
+      mode: "promote",
+    });
+    jest.useRealTimers();
+  });
+
+  it("Later permanently dismisses the naming banner", async () => {
+    jest.useFakeTimers();
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <RecentExpenses navigation={navigation as any} />,
+      {
+        expenses: expensesContextForList([]),
+        user: {
+          periodName: "month",
+          freshlyCreated: false,
+        },
+        trip: {
+          tripid: "t-implicit",
+          tripName: "",
+          tripCurrency: "EUR",
+          isImplicitDefault: true,
+          dailyBudget: "0",
+          totalBudget: "0",
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    fireEvent.press(screen.getByTestId("naming-banner-later"));
+    expect(screen.queryByTestId("naming-banner")).toBeNull();
+    expect(mmkvStore["namingBannerDismissed_t-implicit"]).toBe("1");
+    jest.useRealTimers();
+  });
+
+  it("first expense permanently dismisses the naming banner", async () => {
+    jest.useFakeTimers();
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <RecentExpenses navigation={navigation as any} />,
+      {
+        expenses: expensesContextForList([
+          makeExpense({ id: "e1", calcAmount: 12, amount: 12 }),
+        ]),
+        user: {
+          periodName: "month",
+          freshlyCreated: false,
+        },
+        trip: {
+          tripid: "t-implicit",
+          tripName: "",
+          tripCurrency: "EUR",
+          isImplicitDefault: true,
+          dailyBudget: "0",
+          totalBudget: "0",
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByTestId("naming-banner")).toBeNull();
+    expect(mmkvStore["namingBannerDismissed_t-implicit"]).toBe("1");
+    jest.useRealTimers();
+  });
+
+  it("does not show the naming banner on a named Active trip", async () => {
+    jest.useFakeTimers();
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <RecentExpenses navigation={navigation as any} />,
+      {
+        expenses: expensesContextForList([]),
+        user: {
+          periodName: "month",
+          freshlyCreated: false,
+        },
+        trip: {
+          tripid: "t-named",
+          tripName: "Japan 2026",
+          tripCurrency: "EUR",
+          isImplicitDefault: false,
+          travellers: ["Alice"],
+        },
+      }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByTestId("naming-banner")).toBeNull();
+    jest.useRealTimers();
   });
 });

--- a/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
@@ -104,15 +104,52 @@ import { renderWithAppProviders } from "../fixtures/app-providers";
 import { assertNoNestedVerticalFlatLists } from "../../test-utils/scroll-composition";
 
 function expensesContextForList(
-  listedExpenses: ReturnType<typeof makeExpense>[]
+  listedExpenses: ReturnType<typeof makeExpense>[],
+  options?: {
+    tripExpenses?: ReturnType<typeof makeExpense>[];
+  }
 ) {
+  const tripExpenses = options?.tripExpenses ?? listedExpenses;
   return {
-    expenses: listedExpenses,
+    expenses: tripExpenses,
     getRecentExpenses: () => listedExpenses,
     getDailyExpenses: jest.fn(() => []),
     loadExpensesFromStorage: jest.fn(async () => {}),
     deleteExpense: jest.fn(),
   };
+}
+
+const implicitDefaultTrip = {
+  tripid: "t-implicit",
+  tripName: "",
+  tripCurrency: "EUR",
+  isImplicitDefault: true,
+  dailyBudget: "0",
+  totalBudget: "0",
+  travellers: ["Alice"],
+};
+
+function renderImplicitRecent(
+  navigation: { navigate: jest.Mock },
+  expenses: ReturnType<typeof expensesContextForList>
+) {
+  return renderWithAppProviders(
+    <RecentExpenses navigation={navigation as any} />,
+    {
+      expenses,
+      user: {
+        periodName: "month",
+        freshlyCreated: false,
+      },
+      trip: implicitDefaultTrip,
+    }
+  );
+}
+
+async function flushExpensesLoadTimeout() {
+  await act(async () => {
+    jest.advanceTimersByTime(1000);
+  });
 }
 
 describe("RecentExpenses screen", () => {
@@ -249,24 +286,9 @@ describe("RecentExpenses screen", () => {
 
   it("hides period progress on a budget-free implicit default Active trip", () => {
     const navigation = { navigate: jest.fn() };
-    const screen = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: expensesContextForList([]),
-        user: {
-          periodName: "month",
-          freshlyCreated: false,
-        },
-        trip: {
-          tripid: "t-implicit",
-          tripName: "",
-          tripCurrency: "EUR",
-          isImplicitDefault: true,
-          dailyBudget: "0",
-          totalBudget: "0",
-          travellers: ["Alice"],
-        },
-      }
+    const screen = renderImplicitRecent(
+      navigation,
+      expensesContextForList([])
     );
 
     expect(screen.getByTestId("expenses-summary-pressable")).toBeTruthy();
@@ -275,24 +297,9 @@ describe("RecentExpenses screen", () => {
 
   it("keeps the add-expense entry point on Recent Expenses for an implicit default Active trip", () => {
     const navigation = { navigate: jest.fn() };
-    const screen = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: expensesContextForList([]),
-        user: {
-          periodName: "month",
-          freshlyCreated: false,
-        },
-        trip: {
-          tripid: "t-implicit",
-          tripName: "",
-          tripCurrency: "EUR",
-          isImplicitDefault: true,
-          dailyBudget: "0",
-          totalBudget: "0",
-          travellers: ["Alice"],
-        },
-      }
+    const screen = renderImplicitRecent(
+      navigation,
+      expensesContextForList([])
     );
 
     expect(screen.getByTestId("add-expense-entry")).toBeTruthy();
@@ -302,64 +309,45 @@ describe("RecentExpenses screen", () => {
   it("shows a clear empty-state add-expense CTA for an implicit default Active trip", async () => {
     jest.useFakeTimers();
     const navigation = { navigate: jest.fn() };
-    const screen = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: expensesContextForList([]),
-        user: {
-          periodName: "month",
-          freshlyCreated: false,
-        },
-        trip: {
-          tripid: "t-implicit",
-          tripName: "",
-          tripCurrency: "EUR",
-          isImplicitDefault: true,
-          dailyBudget: "0",
-          totalBudget: "0",
-          travellers: ["Alice"],
-        },
-      }
+    const screen = renderImplicitRecent(
+      navigation,
+      expensesContextForList([])
     );
 
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
-    });
+    await flushExpensesLoadTimeout();
 
     expect(screen.getByTestId("empty-expenses-cta")).toBeTruthy();
     fireEvent.press(screen.getByText("Add Expense"));
-    expect(navigation.navigate).toHaveBeenCalledWith(
-      expect.stringMatching(/CategoryPick|ManageExpense/)
+    expect(navigation.navigate).toHaveBeenCalledWith("CategoryPick");
+  });
+
+  it("does not show the empty-state CTA when the trip ledger already has expenses", async () => {
+    jest.useFakeTimers();
+    const historyExpense = makeExpense({
+      id: "e-history",
+      calcAmount: 40,
+      amount: 40,
+    });
+    const navigation = { navigate: jest.fn() };
+    const screen = renderImplicitRecent(
+      navigation,
+      expensesContextForList([], { tripExpenses: [historyExpense] })
     );
-    jest.useRealTimers();
+
+    await flushExpensesLoadTimeout();
+
+    expect(screen.queryByTestId("empty-expenses-cta")).toBeNull();
   });
 
   it("shows the naming banner for an undismissed implicit default Active trip", async () => {
     jest.useFakeTimers();
     const navigation = { navigate: jest.fn() };
-    const screen = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: expensesContextForList([]),
-        user: {
-          periodName: "month",
-          freshlyCreated: false,
-        },
-        trip: {
-          tripid: "t-implicit",
-          tripName: "",
-          tripCurrency: "EUR",
-          isImplicitDefault: true,
-          dailyBudget: "0",
-          totalBudget: "0",
-          travellers: ["Alice"],
-        },
-      }
+    const screen = renderImplicitRecent(
+      navigation,
+      expensesContextForList([])
     );
 
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
-    });
+    await flushExpensesLoadTimeout();
 
     expect(screen.getByTestId("naming-banner")).toBeTruthy();
     expect(
@@ -367,109 +355,73 @@ describe("RecentExpenses screen", () => {
     ).toBeTruthy();
     expect(screen.getByTestId("naming-banner-name-it")).toBeTruthy();
     expect(screen.getByTestId("naming-banner-later")).toBeTruthy();
-    jest.useRealTimers();
   });
 
   it("Name it opens the promote Name your budget flow", async () => {
     jest.useFakeTimers();
     const navigation = { navigate: jest.fn() };
-    const screen = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: expensesContextForList([]),
-        user: {
-          periodName: "month",
-          freshlyCreated: false,
-        },
-        trip: {
-          tripid: "t-implicit",
-          tripName: "",
-          tripCurrency: "EUR",
-          isImplicitDefault: true,
-          dailyBudget: "0",
-          totalBudget: "0",
-          travellers: ["Alice"],
-        },
-      }
+    const screen = renderImplicitRecent(
+      navigation,
+      expensesContextForList([])
     );
 
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
-    });
+    await flushExpensesLoadTimeout();
 
     fireEvent.press(screen.getByText("Name it"));
     expect(navigation.navigate).toHaveBeenCalledWith("ManageTrip", {
       tripId: "t-implicit",
       mode: "promote",
     });
-    jest.useRealTimers();
   });
 
-  it("Later permanently dismisses the naming banner", async () => {
+  it("Later permanently dismisses the naming banner across remount", async () => {
     jest.useFakeTimers();
     const navigation = { navigate: jest.fn() };
-    const screen = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: expensesContextForList([]),
-        user: {
-          periodName: "month",
-          freshlyCreated: false,
-        },
-        trip: {
-          tripid: "t-implicit",
-          tripName: "",
-          tripCurrency: "EUR",
-          isImplicitDefault: true,
-          dailyBudget: "0",
-          totalBudget: "0",
-          travellers: ["Alice"],
-        },
-      }
+    const screen = renderImplicitRecent(
+      navigation,
+      expensesContextForList([])
     );
 
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
-    });
+    await flushExpensesLoadTimeout();
 
     fireEvent.press(screen.getByTestId("naming-banner-later"));
     expect(screen.queryByTestId("naming-banner")).toBeNull();
     expect(mmkvStore["namingBannerDismissed_t-implicit"]).toBe("1");
-    jest.useRealTimers();
+
+    screen.unmount();
+    const remounted = renderImplicitRecent(
+      { navigate: jest.fn() },
+      expensesContextForList([])
+    );
+    await flushExpensesLoadTimeout();
+    expect(remounted.queryByTestId("naming-banner")).toBeNull();
   });
 
-  it("first expense permanently dismisses the naming banner", async () => {
-    jest.useFakeTimers();
+  it("never shows the naming banner when the Active trip already has expenses", () => {
     const navigation = { navigate: jest.fn() };
-    const screen = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: expensesContextForList([
-          makeExpense({ id: "e1", calcAmount: 12, amount: 12 }),
-        ]),
-        user: {
-          periodName: "month",
-          freshlyCreated: false,
-        },
-        trip: {
-          tripid: "t-implicit",
-          tripName: "",
-          tripCurrency: "EUR",
-          isImplicitDefault: true,
-          dailyBudget: "0",
-          totalBudget: "0",
-          travellers: ["Alice"],
-        },
-      }
+    const screen = renderImplicitRecent(
+      navigation,
+      expensesContextForList([
+        makeExpense({ id: "e1", calcAmount: 12, amount: 12 }),
+      ])
     );
 
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
-    });
-
     expect(screen.queryByTestId("naming-banner")).toBeNull();
+  });
+
+  it("first expense permanently dismisses the naming banner in MMKV", async () => {
+    jest.useFakeTimers();
+    const navigation = { navigate: jest.fn() };
+    renderImplicitRecent(
+      navigation,
+      expensesContextForList([
+        makeExpense({ id: "e1", calcAmount: 12, amount: 12 }),
+      ])
+    );
+
+    await act(async () => {});
+
     expect(mmkvStore["namingBannerDismissed_t-implicit"]).toBe("1");
-    jest.useRealTimers();
   });
 
   it("does not show the naming banner on a named Active trip", async () => {
@@ -493,11 +445,8 @@ describe("RecentExpenses screen", () => {
       }
     );
 
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
-    });
+    await flushExpensesLoadTimeout();
 
     expect(screen.queryByTestId("naming-banner")).toBeNull();
-    jest.useRealTimers();
   });
 });

--- a/TravelCostApp/__tests__/util/naming-banner.test.ts
+++ b/TravelCostApp/__tests__/util/naming-banner.test.ts
@@ -48,6 +48,16 @@ describe("naming banner (implicit default trip guidance)", () => {
         })
       ).toBe(false);
     });
+
+    it("hides synchronously when the trip already has expenses", () => {
+      expect(
+        shouldShowNamingBanner({
+          isImplicitDefault: true,
+          isDismissed: false,
+          expenseCount: 1,
+        })
+      ).toBe(false);
+    });
   });
 
   describe("dismiss persistence", () => {

--- a/TravelCostApp/__tests__/util/naming-banner.test.ts
+++ b/TravelCostApp/__tests__/util/naming-banner.test.ts
@@ -1,0 +1,86 @@
+import {
+  dismissNamingBanner,
+  dismissNamingBannerAfterFirstExpense,
+  isNamingBannerDismissed,
+  shouldShowNamingBanner,
+} from "../../util/naming-banner";
+import { MMKV_KEY_PATTERNS } from "../../store/mmkv-keys";
+
+const mmkvStore: Record<string, string> = {};
+
+jest.mock("../../store/mmkv", () => ({
+  getMMKVString: jest.fn((key: string) => mmkvStore[key] ?? ""),
+  setMMKVString: jest.fn((key: string, value: string) => {
+    mmkvStore[key] = value;
+  }),
+}));
+
+describe("naming banner (implicit default trip guidance)", () => {
+  beforeEach(() => {
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+    jest.clearAllMocks();
+  });
+
+  describe("shouldShowNamingBanner", () => {
+    it("shows for an undismissed implicit default trip", () => {
+      expect(
+        shouldShowNamingBanner({
+          isImplicitDefault: true,
+          isDismissed: false,
+        })
+      ).toBe(true);
+    });
+
+    it("hides when the Active trip is not an implicit default", () => {
+      expect(
+        shouldShowNamingBanner({
+          isImplicitDefault: false,
+          isDismissed: false,
+        })
+      ).toBe(false);
+    });
+
+    it("hides after permanent dismiss", () => {
+      expect(
+        shouldShowNamingBanner({
+          isImplicitDefault: true,
+          isDismissed: true,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("dismiss persistence", () => {
+    it("Later permanently dismisses the banner for that trip", () => {
+      const tripid = "t-implicit";
+      expect(isNamingBannerDismissed(tripid)).toBe(false);
+
+      dismissNamingBanner(tripid);
+
+      expect(isNamingBannerDismissed(tripid)).toBe(true);
+      expect(mmkvStore[MMKV_KEY_PATTERNS.NAMING_BANNER_DISMISSED(tripid)]).toBe(
+        "1"
+      );
+    });
+
+    it("does not treat another trip's dismiss as this trip's dismiss", () => {
+      dismissNamingBanner("other-trip");
+      expect(isNamingBannerDismissed("t-implicit")).toBe(false);
+    });
+
+    it("first expense on an implicit default trip dismisses permanently", () => {
+      dismissNamingBannerAfterFirstExpense("t-implicit", 1, true);
+      expect(isNamingBannerDismissed("t-implicit")).toBe(true);
+    });
+
+    it("zero expenses does not dismiss the naming banner", () => {
+      dismissNamingBannerAfterFirstExpense("t-implicit", 0, true);
+      expect(isNamingBannerDismissed("t-implicit")).toBe(false);
+    });
+
+    it("named trips do not auto-dismiss via expense count", () => {
+      dismissNamingBannerAfterFirstExpense("t-named", 3, false);
+      expect(isNamingBannerDismissed("t-named")).toBe(false);
+    });
+  });
+});

--- a/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
@@ -14,6 +14,7 @@ import { EXPENSES_LOAD_TIMEOUT } from "../../confAppConstants";
 import { memo } from "react";
 import { TripContext } from "../../store/trip-context";
 import FlatButton from "../UI/FlatButton";
+import GradientButton from "../UI/GradientButton";
 import { useNavigation } from "@react-navigation/native";
 import { ExpensesContext, RangeString } from "../../store/expenses-context";
 import { UserContext } from "../../store/user-context";
@@ -27,8 +28,10 @@ function ExpensesOutput({
   refreshing,
   showSumForTravellerName,
   isFiltered,
+  emptyCtaLabel,
+  onEmptyCtaPress,
 }) {
-  const { tripName } = useContext(TripContext);
+  const { tripName, tripid } = useContext(TripContext);
   const [showLoading, setShowLoading] = useState(true);
   const [fallback, setFallback] = useState(true);
   const navigation = useNavigation();
@@ -43,15 +46,16 @@ function ExpensesOutput({
   const tomorrowExpenses = expCtx.getDailyExpenses(-1);
   const showTomorrow =
     tomorrowExpenses && tomorrowExpenses.length > 0 && shouldShowExtraButtons;
+  const tripReady = Boolean(tripid || tripName);
   useEffect(() => {
     setTimeout(() => {
-      if (tripName) setShowLoading(false);
+      if (tripReady) setShowLoading(false);
     }, EXPENSES_LOAD_TIMEOUT);
-  }, [tripName]);
+  }, [tripReady]);
 
   useEffect(() => {
-    if (tripName && expenses.length > 1) setShowLoading(false);
-  }, [tripName, expenses.length]);
+    if (tripReady && expenses.length > 1) setShowLoading(false);
+  }, [tripReady, expenses.length]);
 
   const memoizedContent = useMemo(() => {
     if (expenses?.length > 0) {
@@ -78,6 +82,16 @@ function ExpensesOutput({
             {showLoading && <LoadingOverlay></LoadingOverlay>}
             {!showLoading && (
               <Text style={styles.infoText}>{fallbackText}</Text>
+            )}
+            {!showLoading && emptyCtaLabel && onEmptyCtaPress && (
+              <View testID="empty-expenses-cta" style={styles.emptyCta}>
+                <GradientButton
+                  onPress={onEmptyCtaPress}
+                  buttonStyle={styles.emptyCtaInner}
+                >
+                  {emptyCtaLabel}
+                </GradientButton>
+              </View>
             )}
             {showYesterday && (
               <FlatButton
@@ -110,14 +124,21 @@ function ExpensesOutput({
       </Animated.View>
     );
   }, [
+    emptyCtaLabel,
     expenses,
     fallback,
     fallbackText,
     isFiltered,
+    onEmptyCtaPress,
     refreshControl,
     refreshing,
     showLoading,
     showSumForTravellerName,
+    showTomorrow,
+    showYesterday,
+    tomorrowExpenses,
+    yesterdayExpenses,
+    navigation,
   ]);
 
   return (
@@ -138,6 +159,8 @@ ExpensesOutput.propTypes = {
   refreshing: PropTypes.bool,
   showSumForTravellerName: PropTypes.string,
   isFiltered: PropTypes.bool,
+  emptyCtaLabel: PropTypes.string,
+  onEmptyCtaPress: PropTypes.func,
 };
 
 const styles = StyleSheet.create({
@@ -173,5 +196,13 @@ const styles = StyleSheet.create({
     fontSize: dynamicScale(16, false, 0.5),
     textAlign: "center",
     marginVertical: dynamicScale(32, false, 0.5),
+  },
+  emptyCta: {
+    alignSelf: "center",
+    marginTop: dynamicScale(8, true),
+    minWidth: "70%",
+  },
+  emptyCtaInner: {
+    paddingVertical: dynamicScale(12, true),
   },
 });

--- a/TravelCostApp/components/UI/NamingBanner.tsx
+++ b/TravelCostApp/components/UI/NamingBanner.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import PropTypes from "prop-types";
+
+import GradientButton from "./GradientButton";
+import { GlobalStyles } from "../../constants/styles";
+import { dynamicScale } from "../../util/scalingUtil";
+import { i18n } from "../../i18n/i18n";
+
+type NamingBannerProps = {
+  onNameIt: () => void;
+  onLater: () => void;
+};
+
+function NamingBanner({ onNameIt, onLater }: NamingBannerProps) {
+  return (
+    <View testID="naming-banner" style={styles.container}>
+      <Text style={styles.message}>{i18n.t("namingBannerText")}</Text>
+      <View style={styles.actions}>
+        <Pressable
+          testID="naming-banner-later"
+          onPress={onLater}
+          style={({ pressed }) => [
+            styles.laterButton,
+            pressed && GlobalStyles.pressed,
+          ]}
+        >
+          <Text style={styles.laterText}>{i18n.t("later")}</Text>
+        </Pressable>
+        <View testID="naming-banner-name-it" style={styles.nameItWrap}>
+          <GradientButton
+            onPress={onNameIt}
+            style={styles.nameItButton}
+            buttonStyle={styles.nameItButtonInner}
+          >
+            {i18n.t("namingBannerNameIt")}
+          </GradientButton>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default NamingBanner;
+
+NamingBanner.propTypes = {
+  onNameIt: PropTypes.func.isRequired,
+  onLater: PropTypes.func.isRequired,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: dynamicScale(12),
+    marginBottom: dynamicScale(8, true),
+    paddingHorizontal: dynamicScale(12),
+    paddingVertical: dynamicScale(12, true),
+    borderRadius: 12,
+    backgroundColor: GlobalStyles.colors.primary50,
+  },
+  message: {
+    color: GlobalStyles.colors.textColor,
+    fontSize: dynamicScale(14, false, 0.5),
+    textAlign: "center",
+    marginBottom: dynamicScale(8, true),
+  },
+  actions: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  laterButton: {
+    padding: dynamicScale(12),
+  },
+  laterText: {
+    color: GlobalStyles.colors.gray700,
+    fontSize: dynamicScale(14, false, 0.5),
+    textAlign: "center",
+  },
+  nameItWrap: {
+    flex: 1,
+    marginLeft: dynamicScale(8),
+  },
+  nameItButton: {
+    alignSelf: "stretch",
+  },
+  nameItButtonInner: {
+    paddingVertical: dynamicScale(10, true),
+    paddingHorizontal: dynamicScale(12),
+  },
+});

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -468,6 +468,8 @@ const en = {
   rateModalButton: "Rate Now",
   never: "Never",
   later: "Later",
+  namingBannerText: "Name your budget to keep things organized.",
+  namingBannerNameIt: "Name it",
   // gpt
   gptInfoTitle: "GPT-4 Info",
   gptInfoText:
@@ -1088,6 +1090,8 @@ const de = {
   rateModalButton: "Jetzt bewerten",
   never: "Nie",
   later: "Später",
+  namingBannerText: "Benenne dein Budget, um den Überblick zu behalten.",
+  namingBannerNameIt: "Benenne es",
   // gpt
   gptInfoTitle: "ChatGPT Info",
   gptInfoText:
@@ -1707,6 +1711,8 @@ const fr = {
   rateModalButton: "Évaluer maintenant",
   never: "Jamais",
   later: "Plus tard",
+  namingBannerText: "Donnez un nom à votre budget pour rester organisé.",
+  namingBannerNameIt: "Nommer",
 
   // gpt
   gptInfoTitle: "Informations sur GPT-4",
@@ -2328,6 +2334,8 @@ const ru = {
   rateModalButton: "Оценить сейчас",
   never: "Никогда",
   later: "Позже",
+  namingBannerText: "Назовите бюджет, чтобы всё было организовано.",
+  namingBannerNameIt: "Назвать",
 
   // gpt
   gptInfoTitle: "Информация о GPT-4",

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -219,6 +219,7 @@ function RecentExpenses({ navigation }) {
   ]);
 
   const [loadedOnce, setLoadedOnce] = useState(false);
+  const tripExpenseCount = expensesCtx.expenses?.length ?? 0;
   const [namingBannerDismissed, setNamingBannerDismissed] = useState(() =>
     isNamingBannerDismissed(tripid)
   );
@@ -229,23 +230,19 @@ function RecentExpenses({ navigation }) {
 
   useEffect(() => {
     if (!tripCtx.isImplicitDefault) return;
-    const expenseCount = expensesCtx.expenses?.length ?? 0;
-    if (expenseCount < 1) return;
+    if (tripExpenseCount < 1) return;
     dismissNamingBannerAfterFirstExpense(
       tripid,
-      expenseCount,
+      tripExpenseCount,
       tripCtx.isImplicitDefault
     );
     setNamingBannerDismissed(true);
-  }, [
-    expensesCtx.expenses?.length,
-    tripCtx.isImplicitDefault,
-    tripid,
-  ]);
+  }, [tripExpenseCount, tripCtx.isImplicitDefault, tripid]);
 
   const showNamingBanner = shouldShowNamingBanner({
     isImplicitDefault: tripCtx.isImplicitDefault === true,
     isDismissed: namingBannerDismissed,
+    expenseCount: tripExpenseCount,
   });
 
   const handleNameIt = useCallback(() => {
@@ -270,6 +267,8 @@ function RecentExpenses({ navigation }) {
       navigation.navigate("CategoryPick");
     }
   }, [navigation, settings.skipCategoryScreen]);
+
+  const tripLedgerEmpty = tripExpenseCount === 0;
 
   useEffect(() => {
     const asyncLoading = async () => {
@@ -354,12 +353,8 @@ function RecentExpenses({ navigation }) {
     <MemoizedExpensesOutput
       expenses={recentExpenses}
       fallbackText={i18n.t("fallbackTextExpenses")}
-      emptyCtaLabel={
-        recentExpenses?.length === 0 ? i18n.t("addExp") : undefined
-      }
-      onEmptyCtaPress={
-        recentExpenses?.length === 0 ? handleEmptyCtaPress : undefined
-      }
+      emptyCtaLabel={tripLedgerEmpty ? i18n.t("addExp") : undefined}
+      onEmptyCtaPress={tripLedgerEmpty ? handleEmptyCtaPress : undefined}
       refreshing={refreshing}
       refreshControl={
         <RefreshControl

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -28,6 +28,7 @@ import {
   shadowRegressionStyles,
 } from "../styles/shadow-regression-styles";
 import AddExpenseButton from "../components/ManageExpense/AddExpenseButton";
+import NamingBanner from "../components/UI/NamingBanner";
 import { DateTime } from "luxon";
 
 import { i18n } from "../i18n/i18n";
@@ -51,6 +52,12 @@ import { getMMKVObject, MMKV_KEYS } from "../store/mmkv";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
 import { OrientationContext } from "../store/orientation-context";
 import { refreshWithToast } from "../util/refreshWithToast";
+import {
+  dismissNamingBanner,
+  dismissNamingBannerAfterFirstExpense,
+  isNamingBannerDismissed,
+  shouldShowNamingBanner,
+} from "../util/naming-banner";
 
 function RecentExpenses({ navigation }) {
   const expensesCtx = useContext(ExpensesContext);
@@ -212,6 +219,57 @@ function RecentExpenses({ navigation }) {
   ]);
 
   const [loadedOnce, setLoadedOnce] = useState(false);
+  const [namingBannerDismissed, setNamingBannerDismissed] = useState(() =>
+    isNamingBannerDismissed(tripid)
+  );
+
+  useEffect(() => {
+    setNamingBannerDismissed(isNamingBannerDismissed(tripid));
+  }, [tripid]);
+
+  useEffect(() => {
+    if (!tripCtx.isImplicitDefault) return;
+    const expenseCount = expensesCtx.expenses?.length ?? 0;
+    if (expenseCount < 1) return;
+    dismissNamingBannerAfterFirstExpense(
+      tripid,
+      expenseCount,
+      tripCtx.isImplicitDefault
+    );
+    setNamingBannerDismissed(true);
+  }, [
+    expensesCtx.expenses?.length,
+    tripCtx.isImplicitDefault,
+    tripid,
+  ]);
+
+  const showNamingBanner = shouldShowNamingBanner({
+    isImplicitDefault: tripCtx.isImplicitDefault === true,
+    isDismissed: namingBannerDismissed,
+  });
+
+  const handleNameIt = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    navigation.navigate("ManageTrip", {
+      tripId: tripid,
+      mode: "promote",
+    });
+  }, [navigation, tripid]);
+
+  const handleNamingLater = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    dismissNamingBanner(tripid);
+    setNamingBannerDismissed(true);
+  }, [tripid]);
+
+  const handleEmptyCtaPress = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    if (settings.skipCategoryScreen) {
+      navigation.navigate("ManageExpense", { pickedCat: "undefined" });
+    } else {
+      navigation.navigate("CategoryPick");
+    }
+  }, [navigation, settings.skipCategoryScreen]);
 
   useEffect(() => {
     const asyncLoading = async () => {
@@ -296,6 +354,12 @@ function RecentExpenses({ navigation }) {
     <MemoizedExpensesOutput
       expenses={recentExpenses}
       fallbackText={i18n.t("fallbackTextExpenses")}
+      emptyCtaLabel={
+        recentExpenses?.length === 0 ? i18n.t("addExp") : undefined
+      }
+      onEmptyCtaPress={
+        recentExpenses?.length === 0 ? handleEmptyCtaPress : undefined
+      }
       refreshing={refreshing}
       refreshControl={
         <RefreshControl
@@ -390,6 +454,9 @@ function RecentExpenses({ navigation }) {
           !isPortrait && styles.landscapeBar,
         ]}
       ></View>
+      {showNamingBanner && (
+        <NamingBanner onNameIt={handleNameIt} onLater={handleNamingLater} />
+      )}
       {ExpensesOutputJSX}
 
       <AddExpenseButton navigation={navigation} />

--- a/TravelCostApp/store/mmkv-keys.ts
+++ b/TravelCostApp/store/mmkv-keys.ts
@@ -45,6 +45,7 @@ export type LastFetchKey = `lastFetch_${string}`;
 export type LastUpdateAllExpensesTripKey = `lastUpdate_allExpenses_tripid_${string}`;
 export type LastUpdateIsoAllExpensesTripKey =
   `lastUpdateISO_allExpenses_tripid${string}`;
+export type NamingBannerDismissedKey = `namingBannerDismissed_${string}`;
 
 // Dynamic key patterns - keys that require parameters
 export const MMKV_KEY_PATTERNS = {
@@ -68,6 +69,8 @@ export const MMKV_KEY_PATTERNS = {
     tripid: string
   ): LastUpdateIsoAllExpensesTripKey =>
     `lastUpdateISO_allExpenses_tripid${tripid}`,
+  NAMING_BANNER_DISMISSED: (tripid: string): NamingBannerDismissedKey =>
+    `namingBannerDismissed_${tripid}`,
 } as const;
 
 // Type for all static keys
@@ -81,7 +84,8 @@ export type MMKVDynamicKey =
   | TripLastUpdateIsoKey
   | LastFetchKey
   | LastUpdateAllExpensesTripKey
-  | LastUpdateIsoAllExpensesTripKey;
+  | LastUpdateIsoAllExpensesTripKey
+  | NamingBannerDismissedKey;
 export type MMKVKey = MMKVStaticKey | MMKVDynamicKey;
 
 // Type guard to ensure a string is a valid MMKV key
@@ -99,6 +103,7 @@ export function isValidMMKVKey(key: string): key is MMKVKey {
     key.startsWith("lastUpdateISO_trip_") ||
     key.startsWith("lastFetch_") ||
     key.startsWith("lastUpdate_allExpenses_tripid_") ||
-    key.startsWith("lastUpdateISO_allExpenses_tripid")
+    key.startsWith("lastUpdateISO_allExpenses_tripid") ||
+    key.startsWith("namingBannerDismissed_")
   );
 }

--- a/TravelCostApp/util/naming-banner.ts
+++ b/TravelCostApp/util/naming-banner.ts
@@ -4,13 +4,18 @@ import { MMKV_KEY_PATTERNS } from "../store/mmkv-keys";
 export type NamingBannerVisibilityInput = {
   isImplicitDefault: boolean;
   isDismissed: boolean;
+  /** Trip ledger expense count — first expense hides the banner without waiting for effects. */
+  expenseCount?: number;
 };
 
-/** Naming banner only for undismissed implicit default Active trips. */
+/** Naming banner only for undismissed implicit default Active trips with no expenses yet. */
 export function shouldShowNamingBanner(
   input: NamingBannerVisibilityInput
 ): boolean {
-  return input.isImplicitDefault === true && input.isDismissed !== true;
+  if (input.isImplicitDefault !== true) return false;
+  if (input.isDismissed === true) return false;
+  if ((input.expenseCount ?? 0) > 0) return false;
+  return true;
 }
 
 export function isNamingBannerDismissed(tripid: string): boolean {

--- a/TravelCostApp/util/naming-banner.ts
+++ b/TravelCostApp/util/naming-banner.ts
@@ -1,0 +1,39 @@
+import { getMMKVString, setMMKVString } from "../store/mmkv";
+import { MMKV_KEY_PATTERNS } from "../store/mmkv-keys";
+
+export type NamingBannerVisibilityInput = {
+  isImplicitDefault: boolean;
+  isDismissed: boolean;
+};
+
+/** Naming banner only for undismissed implicit default Active trips. */
+export function shouldShowNamingBanner(
+  input: NamingBannerVisibilityInput
+): boolean {
+  return input.isImplicitDefault === true && input.isDismissed !== true;
+}
+
+export function isNamingBannerDismissed(tripid: string): boolean {
+  if (!tripid) return false;
+  return getMMKVString(MMKV_KEY_PATTERNS.NAMING_BANNER_DISMISSED(tripid)) === "1";
+}
+
+/** Permanent dismiss (Later or after first expense). */
+export function dismissNamingBanner(tripid: string): void {
+  if (!tripid) return;
+  setMMKVString(MMKV_KEY_PATTERNS.NAMING_BANNER_DISMISSED(tripid), "1");
+}
+
+/**
+ * First expense on an implicit default trip permanently dismisses the naming banner.
+ * Safe to call repeatedly.
+ */
+export function dismissNamingBannerAfterFirstExpense(
+  tripid: string,
+  expenseCount: number,
+  isImplicitDefault: boolean
+): void {
+  if (!isImplicitDefault || !tripid) return;
+  if (expenseCount < 1) return;
+  dismissNamingBanner(tripid);
+}


### PR DESCRIPTION
## Summary
- Empty Recent Expenses shows an add-expense CTA (not tour spotlight), including for unnamed implicit default trips
- Naming banner (“Name your budget to keep things organized.”) with Name it → promote and Later → permanent dismiss
- First expense also permanently dismisses the banner (per-trip MMKV); screen tests cover CTA + dismiss rules via AppProviders

## Test plan
- [ ] Fresh implicit default: empty CTA visible; tapping opens CategoryPick / ManageExpense
- [ ] Naming banner copy + Name it opens ManageTrip promote
- [ ] Later hides banner across remount/session
- [ ] Adding first expense hides banner permanently
- [ ] Named Active trip: no naming banner
- [ ] `pnpm test` in TravelCostApp

Closes #355