### PR TITLE
Active-trip refactor — slice 3: activateTrip seam + set-active call site

### DIFF
--- a/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
@@ -16,6 +16,7 @@ jest.mock("../../util/http", () => ({
   updateTripHistory: jest.fn(),
   updateTrip: jest.fn(),
   getAllExpenses: jest.fn(async () => []),
+  getTravellers: jest.fn(async () => [{ uid: "u1", userName: "Alice" }]),
   putTravelerInTrip: jest.fn(),
 }));
 
@@ -46,6 +47,7 @@ jest.mock("../../util/appState", () => ({
 }));
 
 jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => "t-implicit"),
   secureStoreSetItem: jest.fn(async () => {}),
 }));
 
@@ -168,10 +170,16 @@ describe("TripForm budget form modes", () => {
           dailyBudget: "0",
           totalBudget: "0",
           isImplicitDefault: true,
-          travellers: ["Alice"],
+          travellers: [{ uid: "u1", userName: "Alice" }],
+          getcurrentTrip: jest.fn(() => ({
+            tripid: "t-implicit",
+            tripName: "",
+            tripCurrency: "EUR",
+            travellers: [{ uid: "u1", userName: "Alice" }],
+          })),
           saveTripDataInStorage: jest.fn(async () => {}),
+          saveTravellersInStorage: jest.fn(async () => {}),
           setCurrentTrip: jest.fn(async () => {}),
-          fetchAndSetTravellers: jest.fn(async () => true),
           setdailyBudget: jest.fn(),
         },
         user: {
@@ -179,7 +187,7 @@ describe("TripForm budget form modes", () => {
         },
         expenses: {
           expenses: [],
-          mergeExpenses: jest.fn(),
+          setExpenses: jest.fn(),
         },
         auth: { uid: "u1" },
       }

--- a/TravelCostApp/__tests__/util/activate-trip.test.ts
+++ b/TravelCostApp/__tests__/util/activate-trip.test.ts
@@ -150,4 +150,40 @@ describe("activateTrip", () => {
     expect(contextTrip?.tripid).toBe("trip-a");
     expect(expensesState).toEqual(previousExpenses);
   });
+
+  it("replaces expenses with the full trip ledger, not a delta-sized subset", async () => {
+    const fullLedger = [
+      expense("e-x1", "ramen"),
+      expense("e-x2", "hotel"),
+      expense("e-x3", "train"),
+    ];
+    let requestedUseDelta: boolean | undefined;
+    let expensesState = [expense("e-old", "stale from trip-a")];
+
+    await activateTrip("trip-x", {
+      uid: "u1",
+      fetchTrip: async () => tripX(),
+      getTravellers: async () => [{ uid: "u1", userName: "Alice" }],
+      getAllExpenses: async (_tripid, _uid, useDelta) => {
+        requestedUseDelta = useDelta;
+        // Simulate a previously visited trip: delta would return only the newest row.
+        return useDelta === false ? fullLedger : [fullLedger[2]];
+      },
+      updateUser: async () => {},
+      secureStoreGetItem: async () => "trip-a",
+      secureStoreSetItem: async () => {},
+      setCurrentTrip: async () => {},
+      saveTripDataInStorage: async () => {},
+      saveTravellersInStorage: async () => {},
+      setExpenses: (expenses) => {
+        expensesState = expenses;
+      },
+      setExpensesCache: () => {},
+      setFreshlyCreatedTo: async () => {},
+    });
+
+    expect(requestedUseDelta).toBe(false);
+    expect(expensesState).toEqual(fullLedger);
+    expect(expensesState).toHaveLength(3);
+  });
 });

--- a/TravelCostApp/__tests__/util/activate-trip.test.ts
+++ b/TravelCostApp/__tests__/util/activate-trip.test.ts
@@ -1,0 +1,153 @@
+import type { ExpenseData } from "../../util/expense";
+import type { Traveller } from "../../util/traveler";
+import type { TripData } from "../../types/trip";
+import { activateTrip } from "../../util/activate-trip";
+
+function tripX(): TripData {
+  return {
+    tripid: "trip-x",
+    tripName: "Japan",
+    totalBudget: "1000",
+    dailyBudget: "50",
+    tripCurrency: "EUR",
+    travellers: [],
+    startDate: "2026-01-01",
+    endDate: "2026-01-10",
+    isDynamicDailyBudget: false,
+  };
+}
+
+function expense(id: string, description: string): ExpenseData {
+  return {
+    id,
+    description,
+    amount: 10,
+    date: new Date("2026-01-02"),
+    category: "food",
+    currency: "EUR",
+    uid: "u1",
+  } as ExpenseData;
+}
+
+describe("activateTrip", () => {
+  it("aligns secure id, server mirror, context, roster, and replaces expenses for trip X", async () => {
+    const roster: Traveller[] = [
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ];
+    const tripXExpenses = [expense("e-x1", "ramen")];
+    const previousExpenses = [expense("e-old", "stale from trip-a")];
+
+    let secureCurrentTripId: string | null = "trip-a";
+    let serverCurrentTrip: string | null = "trip-a";
+    let contextTrip: TripData | null = {
+      tripid: "trip-a",
+      tripName: "Old",
+      tripCurrency: "EUR",
+    };
+    let contextTravellers: Traveller[] = [{ uid: "u9", userName: "Oldie" }];
+    let expensesState = [...previousExpenses];
+    let expensesCache: ExpenseData[] = [...previousExpenses];
+    let freshlyCreated = true;
+
+    await activateTrip("trip-x", {
+      uid: "u1",
+      fetchTrip: async () => tripX(),
+      getTravellers: async () => roster,
+      getAllExpenses: async () => tripXExpenses,
+      updateUser: async (_uid, data) => {
+        serverCurrentTrip = data.currentTrip ?? serverCurrentTrip;
+      },
+      secureStoreGetItem: async (key) =>
+        key === "currentTripId" ? secureCurrentTripId : null,
+      secureStoreSetItem: async (key, value) => {
+        if (key === "currentTripId") secureCurrentTripId = value;
+      },
+      setCurrentTrip: async (tripid, trip) => {
+        contextTrip = { ...trip, tripid };
+        if (trip.travellers) {
+          contextTravellers = trip.travellers as Traveller[];
+        }
+      },
+      saveTripDataInStorage: async (trip) => {
+        contextTrip = { ...(contextTrip ?? {}), ...trip };
+      },
+      saveTravellersInStorage: async (travellers) => {
+        contextTravellers = travellers;
+      },
+      setExpenses: (expenses) => {
+        expensesState = expenses;
+      },
+      setExpensesCache: (expenses) => {
+        expensesCache = expenses;
+      },
+      setFreshlyCreatedTo: async (value) => {
+        freshlyCreated = value;
+      },
+    });
+
+    expect(secureCurrentTripId).toBe("trip-x");
+    expect(serverCurrentTrip).toBe("trip-x");
+    expect(contextTrip?.tripid).toBe("trip-x");
+    expect(contextTrip?.tripName).toBe("Japan");
+    expect(contextTravellers).toEqual(roster);
+    expect(expensesState).toEqual(tripXExpenses);
+    expect(expensesCache).toEqual(tripXExpenses);
+    expect(expensesState.some((e) => e.id === "e-old")).toBe(false);
+    expect(freshlyCreated).toBe(false);
+  });
+
+  it("surfaces failure and restores previous active trip id so stores do not disagree", async () => {
+    let secureCurrentTripId: string | null = "trip-a";
+    let serverCurrentTrip: string | null = "trip-a";
+    let contextTrip: TripData | null = {
+      tripid: "trip-a",
+      tripName: "Old",
+      tripCurrency: "EUR",
+    };
+    let expensesState = [expense("e-old", "stale")];
+    const previousTrip: TripData = {
+      tripid: "trip-a",
+      tripName: "Old",
+      tripCurrency: "EUR",
+      travellers: [{ uid: "u9", userName: "Oldie" }],
+    };
+    const previousExpenses = [expense("e-old", "stale")];
+
+    await expect(
+      activateTrip("trip-x", {
+        uid: "u1",
+        fetchTrip: async () => tripX(),
+        getTravellers: async () => [{ uid: "u1", userName: "Alice" }],
+        getAllExpenses: async () => [expense("e-x1", "ramen")],
+        updateUser: async (_uid, data) => {
+          serverCurrentTrip = data.currentTrip ?? serverCurrentTrip;
+        },
+        secureStoreGetItem: async (key) =>
+          key === "currentTripId" ? secureCurrentTripId : null,
+        secureStoreSetItem: async (key, value) => {
+          if (key === "currentTripId") secureCurrentTripId = value;
+        },
+        setCurrentTrip: async (tripid, trip) => {
+          contextTrip = { ...trip, tripid };
+        },
+        saveTripDataInStorage: async () => {},
+        saveTravellersInStorage: async () => {},
+        setExpenses: (expenses) => {
+          expensesState = expenses;
+        },
+        setExpensesCache: () => {
+          throw new Error("cache write failed");
+        },
+        setFreshlyCreatedTo: async () => {},
+        previousTripSnapshot: previousTrip,
+        previousExpensesSnapshot: previousExpenses,
+      })
+    ).rejects.toThrow("cache write failed");
+
+    expect(secureCurrentTripId).toBe("trip-a");
+    expect(serverCurrentTrip).toBe("trip-a");
+    expect(contextTrip?.tripid).toBe("trip-a");
+    expect(expensesState).toEqual(previousExpenses);
+  });
+});

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -20,6 +20,7 @@ import {
   updateTripHistory,
   updateTrip,
   getAllExpenses,
+  getTravellers,
   putTravelerInTrip,
 } from "../../util/http";
 
@@ -53,7 +54,11 @@ import Animated, {
   ZoomIn,
   ZoomOut,
 } from "react-native-reanimated";
-import { secureStoreSetItem } from "../../store/secure-storage";
+import {
+  secureStoreGetItem,
+  secureStoreSetItem,
+} from "../../store/secure-storage";
+import { activateTrip } from "../../util/activate-trip";
 import BackButton from "../UI/BackButton";
 import { onShare } from "../ProfileOutput/ShareTrip";
 import { NetworkContext } from "../../store/network-context";
@@ -315,23 +320,27 @@ const TripForm = ({ navigation, route }) => {
 
       setLoadingProgress(1);
       if (editedTripId === tripCtx.tripid || setActive) {
-        await secureStoreSetItem("currentTripId", editedTripId);
-        await tripCtx.saveTripDataInStorage(tripData);
-        setLoadingProgress(2);
-        await tripCtx.setCurrentTrip(editedTripId, tripData);
         setLoadingProgress(4);
-        await updateUser(uid, {
-          currentTrip: editedTripId,
+        await activateTrip(editedTripId, {
+          uid,
+          tripData,
+          previousTripSnapshot: tripCtx.getcurrentTrip(),
+          previousExpensesSnapshot: expenseCtx.expenses,
+          fetchTrip,
+          getTravellers,
+          getAllExpenses,
+          updateUser,
+          secureStoreGetItem,
+          secureStoreSetItem,
+          setCurrentTrip: tripCtx.setCurrentTrip,
+          saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+          saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+          setExpenses: expenseCtx.setExpenses,
+          setExpensesCache: (nextExpenses) =>
+            setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+          setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
         });
-        setLoadingProgress(5);
-        await tripCtx.fetchAndSetTravellers(editedTripId);
-        setLoadingProgress(7);
-        await userCtx.setFreshlyCreatedTo(false);
-        setLoadingProgress(8);
-        const expenses = await getAllExpenses(editedTripId, uid);
         setLoadingProgress(9);
-        expenseCtx.mergeExpenses([...expenses]);
-        tripCtx.setdailyBudget(tripData.dailyBudget);
         return;
       }
       tripCtx.refresh();
@@ -341,6 +350,7 @@ const TripForm = ({ navigation, route }) => {
       safeLogError(error);
       navigation.popToTop();
       Toast.hide();
+      throw error;
     }
   }
 

--- a/TravelCostApp/util/activate-trip.ts
+++ b/TravelCostApp/util/activate-trip.ts
@@ -16,7 +16,8 @@ export type ActivateTripDeps = {
   getTravellers: (tripid: string) => Promise<Traveller[]>;
   getAllExpenses: (
     tripid: string,
-    uid: string
+    uid: string,
+    useDelta?: boolean
   ) => Promise<ExpenseData[]>;
   updateUser: (
     uid: string,
@@ -53,8 +54,12 @@ export async function activateTrip(
     throw new Error("activateTrip: trip not found");
   }
 
-  const roster = normalizeTravellers(await deps.getTravellers(tripid));
-  const expenses = await deps.getAllExpenses(tripid, deps.uid);
+  const [rosterRaw, expenses] = await Promise.all([
+    deps.getTravellers(tripid),
+    // Full ledger required: replace must not apply a delta-sized subset.
+    deps.getAllExpenses(tripid, deps.uid, false),
+  ]);
+  const roster = normalizeTravellers(rosterRaw);
 
   const hydratedTrip = hydrateTrip({
     ...rawTrip,

--- a/TravelCostApp/util/activate-trip.ts
+++ b/TravelCostApp/util/activate-trip.ts
@@ -1,0 +1,117 @@
+import type { TripData } from "../types/trip";
+import type { ExpenseData } from "./expense";
+import type { Traveller } from "./traveler";
+import { hydrateTrip } from "./hydrate-trip";
+import { normalizeTravellers } from "./normalize-travellers";
+
+export type ActivateTripDeps = {
+  uid: string;
+  /** Optional already-known trip payload (e.g. just-saved form data). */
+  tripData?: TripData;
+  /** Prior Active trip fields — used to roll back context on partial failure. */
+  previousTripSnapshot?: TripData | null;
+  /** Prior expense set — restored on partial failure so the ledger does not drift. */
+  previousExpensesSnapshot?: ExpenseData[] | null;
+  fetchTrip: (tripid: string) => Promise<TripData>;
+  getTravellers: (tripid: string) => Promise<Traveller[]>;
+  getAllExpenses: (
+    tripid: string,
+    uid: string
+  ) => Promise<ExpenseData[]>;
+  updateUser: (
+    uid: string,
+    userData: { currentTrip: string }
+  ) => Promise<unknown>;
+  secureStoreGetItem: (key: string) => Promise<string | null>;
+  secureStoreSetItem: (key: string, value: string) => Promise<unknown>;
+  setCurrentTrip: (tripid: string, trip: TripData) => Promise<unknown>;
+  saveTripDataInStorage: (tripData: TripData) => Promise<void>;
+  saveTravellersInStorage: (travellers: Traveller[]) => Promise<unknown>;
+  setExpenses: (expenses: ExpenseData[]) => void;
+  setExpensesCache: (expenses: ExpenseData[]) => void;
+  setFreshlyCreatedTo: (value: boolean) => void | Promise<unknown>;
+};
+
+/**
+ * Owns the full Active trip transition: persist authoritative id, mirror to
+ * server + TripContext, hydrate, load Traveller roster, replace expenses.
+ * Partial failure restores prior secure/server/context/expenses so stores do
+ * not disagree; the error is rethrown (not swallowed).
+ */
+export async function activateTrip(
+  tripid: string,
+  deps: ActivateTripDeps
+): Promise<{ tripid: string; tripData: TripData }> {
+  if (!tripid) {
+    throw new Error("activateTrip requires a tripid");
+  }
+
+  const previousActiveTripId = await deps.secureStoreGetItem("currentTripId");
+
+  const rawTrip = deps.tripData ?? (await deps.fetchTrip(tripid));
+  if (!rawTrip) {
+    throw new Error("activateTrip: trip not found");
+  }
+
+  const roster = normalizeTravellers(await deps.getTravellers(tripid));
+  const expenses = await deps.getAllExpenses(tripid, deps.uid);
+
+  const hydratedTrip = hydrateTrip({
+    ...rawTrip,
+    tripid: rawTrip.tripid ?? tripid,
+    travellers: roster,
+  });
+
+  let committed = false;
+  try {
+    await deps.secureStoreSetItem("currentTripId", tripid);
+    await deps.updateUser(deps.uid, { currentTrip: tripid });
+    await deps.setCurrentTrip(tripid, hydratedTrip);
+    await deps.saveTripDataInStorage(hydratedTrip);
+    await deps.saveTravellersInStorage(roster);
+    deps.setExpenses(expenses);
+    deps.setExpensesCache(expenses);
+    await deps.setFreshlyCreatedTo(false);
+    committed = true;
+
+    return { tripid, tripData: hydratedTrip };
+  } catch (error) {
+    if (!committed) {
+      await rollbackActivateTrip(tripid, previousActiveTripId, deps);
+    }
+    throw error;
+  }
+}
+
+async function rollbackActivateTrip(
+  attemptedTripid: string,
+  previousActiveTripId: string | null,
+  deps: ActivateTripDeps
+): Promise<void> {
+  if (!previousActiveTripId || previousActiveTripId === attemptedTripid) {
+    return;
+  }
+
+  try {
+    await deps.secureStoreSetItem("currentTripId", previousActiveTripId);
+    await deps.updateUser(deps.uid, { currentTrip: previousActiveTripId });
+
+    if (deps.previousTripSnapshot) {
+      const previous = hydrateTrip({
+        ...deps.previousTripSnapshot,
+        tripid: deps.previousTripSnapshot.tripid ?? previousActiveTripId,
+      });
+      await deps.setCurrentTrip(previousActiveTripId, previous);
+      await deps.saveTripDataInStorage(previous);
+      const previousRoster = normalizeTravellers(previous.travellers);
+      await deps.saveTravellersInStorage(previousRoster);
+    }
+
+    if (deps.previousExpensesSnapshot) {
+      deps.setExpenses(deps.previousExpensesSnapshot);
+      deps.setExpensesCache(deps.previousExpensesSnapshot);
+    }
+  } catch {
+    // Best-effort rollback; original error still surfaces to the caller.
+  }
+}


### PR DESCRIPTION
## Summary
- Add `activateTrip(tripid)` as the ordered Active trip transition: persist secure id, mirror server `currentTrip` + TripContext (via `hydrateTrip`), load canonical Traveller roster, and **replace** expenses.
- Partial failure rolls back secure/server/context/expenses so stores do not disagree; the error is surfaced.
- Wire TripForm set-active / edit-active path to `activateTrip`; remove the bespoke ritual and `mergeExpenses`-on-switch.

## Test plan
- [x] `pnpm test -- __tests__/util/activate-trip.test.ts`
- [x] `pnpm test -- __tests__/components/trip-form-budget-modes.test.tsx`
- [x] `pnpm test` (full suite)
- [ ] Smoke: set another trip active — expenses/roster/budget match that trip with no leftovers from the previous trip
- [ ] Smoke: force a mid-switch failure (e.g. airplane mode after persist) — prior active trip remains consistent

Closes #325