### PR TITLE
Active-trip refactor — slice 4: migrate join/login/boot to activateTrip

### DIFF
--- a/TravelCostApp/App.tsx
+++ b/TravelCostApp/App.tsx
@@ -36,6 +36,9 @@ import {
   touchMyTraveler,
   dataResponseTime,
   updateUser,
+  fetchTrip,
+  getAllExpenses,
+  getTravellers,
 } from "./util/http";
 import TripContextProvider, {
   TripContext,
@@ -79,7 +82,10 @@ import {
 } from "./components/Rating/firstStartUtil";
 import RatingModal from "./screens/RatingModal";
 import NetworkContextProvider from "./store/network-context";
-import { secureStoreGetItem } from "./store/secure-storage";
+import {
+  secureStoreGetItem,
+  secureStoreSetItem,
+} from "./store/secure-storage";
 import { isConnectionFastEnough } from "./util/connectionSpeed";
 import FinderScreen from "./screens/FinderScreen";
 import CustomerScreen from "./screens/CustomerScreen";
@@ -101,6 +107,12 @@ import {
   VexoUserContext,
 } from "./util/vexo-tracking";
 import { VexoEvents } from "./util/vexo-constants";
+import {
+  activateTrip,
+  activateTripFromLastKnown,
+} from "./util/activate-trip";
+import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "./store/mmkv";
+import { Traveller } from "./util/traveler";
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
 
@@ -523,24 +535,22 @@ function Root() {
           if (!onlineSetupDone) {
             const { isFastEnough } = await isConnectionFastEnough();
             if (isFastEnough) {
-              //prepare online setup
               const storedUid = await secureStoreGetItem("uid");
               if (!storedUid) return;
               const checkUser = await fetchUser(storedUid);
               if (!checkUser) return;
-              const tripid = checkUser.currentTrip;
               const locale = checkUser.locale;
               if (!locale) {
                 checkUser.locale = i18n.locale;
                 await updateUser(storedUid, checkUser);
               }
+              // Authoritative Active trip id is secure storage (not server guesswork).
+              const tripid = await secureStoreGetItem("currentTripId");
               if (!tripid) return;
-              const tripData: TripData =
-                await tripCtx.fetchAndSetCurrentTrip(tripid);
-              if (!tripData) return;
               try {
                 setOnlineSetupDone(true);
-                await onlineSetup(tripData, checkUser, tripid, storedUid);
+                await activateTrip(tripid, activateTripDeps(storedUid));
+                await onlineSetup(checkUser, tripid, storedUid);
               } catch (error) {
                 setOnlineSetupDone(false);
               }
@@ -561,23 +571,39 @@ function Root() {
     }
   };
 
+  function activateTripDeps(uid: string) {
+    return {
+      uid,
+      previousTripSnapshot: tripCtx.getcurrentTrip(),
+      previousExpensesSnapshot: expensesCtx.expenses,
+      fetchTrip,
+      getTravellers,
+      getAllExpenses,
+      updateUser,
+      secureStoreGetItem,
+      secureStoreSetItem,
+      setCurrentTrip: tripCtx.setCurrentTrip,
+      saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+      saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+      setExpenses: expensesCtx.setExpenses,
+      setExpensesCache: (nextExpenses: ExpenseData[]) =>
+        setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+      setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
+    };
+  }
+
   async function onlineSetup(
-    tripData: TripData,
     checkUser: UserData,
     storedTripId: string,
     storedUid: string
   ) {
-    const userData: UserData = checkUser;
-    const tripid = userData.currentTrip;
-    if (!tripid || tripid?.length < 2) {
+    if (!storedTripId || storedTripId.length < 2) {
       return;
     }
-    // save user Name in Ctx and async
     await loadKeys();
     try {
-      await userCtx.addUserName(userData);
-      await tripCtx.setCurrentTrip(tripid, tripData);
-      await userCtx.loadCatListFromAsyncInCtx(tripid);
+      await userCtx.addUserName(checkUser);
+      await userCtx.loadCatListFromAsyncInCtx(storedTripId);
       await touchMyTraveler(storedTripId, storedUid);
     } catch (error) {
       await tripCtx.loadTripDataFromStorage();
@@ -586,15 +612,33 @@ function Root() {
 
   async function setupOfflineMount(
     isOfflineMode: boolean,
-    storedToken: string
+    storedToken: string,
+    storedUid: string,
+    storedTripId: string
   ) {
     if (!isOfflineMode) {
       return null;
     }
     try {
       await userCtx.loadUserNameFromStorage();
-      await tripCtx.loadTripDataFromStorage();
-      await tripCtx.loadTravellersFromStorage();
+      const lastKnownTrip =
+        (getMMKVObject(MMKV_KEYS.CURRENT_TRIP) as TripData | null) ??
+        ({} as TripData);
+      const lastKnownRoster =
+        ((await asyncStoreGetObject("currentTravellers")) as Traveller[]) ??
+        [];
+      const lastKnownExpenses =
+        (getMMKVObject(MMKV_KEYS.EXPENSES) as ExpenseData[]) ?? [];
+      await activateTripFromLastKnown(
+        storedTripId,
+        {
+          tripData: { ...lastKnownTrip, tripid: lastKnownTrip.tripid ?? storedTripId },
+          roster: lastKnownRoster,
+          expenses: lastKnownExpenses,
+        },
+        // Omit server mirror — offline must not call updateUser.
+        (({ updateUser: _skip, ...rest }) => rest)(activateTripDeps(storedUid))
+      );
       await userCtx.loadCatListFromAsyncInCtx("async");
       await authCtx.authenticate(storedToken);
     } catch (error) {}
@@ -669,26 +713,7 @@ function Root() {
 
         // check if user is online
         if (!online) {
-          await setupOfflineMount(true, storedToken);
-          setAppIsReady(true);
-          return;
-        }
-
-        // set tripId in context
-        let tripData;
-        if (storedTripId) {
-          tripData = await tripCtx.fetchAndSetCurrentTrip(storedTripId);
-          await tripCtx.fetchAndSetTravellers(storedTripId);
-          tripCtx.setTripid(storedTripId);
-        } else {
-          Toast.show({
-            type: "error",
-            text1: i18n.t("toastLoginError1"),
-            text2: i18n.t("toastLoginError2"),
-            visibilityTime: 5000,
-          });
-          await asyncStoreSafeClear();
-          authCtx.logout(tripCtx.tripid);
+          await setupOfflineMount(true, storedToken, storedUid, storedTripId);
           setAppIsReady(true);
           return;
         }
@@ -715,9 +740,25 @@ function Root() {
           // Do not re-enable Profile-first gate from boot.
           await userCtx.setFreshlyCreatedTo(false);
         }
+        try {
+          await activateTrip(storedTripId, activateTripDeps(storedUid));
+          setOnlineSetupDone(true);
+        } catch (error) {
+          safeLogError(error);
+          Toast.show({
+            type: "error",
+            text1: i18n.t("toastLoginError1"),
+            text2: i18n.t("toastLoginError2"),
+            visibilityTime: 5000,
+          });
+          await asyncStoreSafeClear();
+          authCtx.logout(tripCtx.tripid);
+          setAppIsReady(true);
+          return;
+        }
         // setup context
         await authCtx.setUserID(storedUid);
-        await onlineSetup(tripData, checkUser, storedTripId, storedUid);
+        await onlineSetup(checkUser, storedTripId, storedUid);
         await authCtx.authenticate(storedToken);
         setAppIsReady(true);
       } else {

--- a/TravelCostApp/App.tsx
+++ b/TravelCostApp/App.tsx
@@ -621,24 +621,37 @@ function Root() {
     }
     try {
       await userCtx.loadUserNameFromStorage();
-      const lastKnownTrip =
-        (getMMKVObject(MMKV_KEYS.CURRENT_TRIP) as TripData | null) ??
-        ({} as TripData);
-      const lastKnownRoster =
-        ((await asyncStoreGetObject("currentTravellers")) as Traveller[]) ??
-        [];
-      const lastKnownExpenses =
-        (getMMKVObject(MMKV_KEYS.EXPENSES) as ExpenseData[]) ?? [];
-      await activateTripFromLastKnown(
-        storedTripId,
-        {
-          tripData: { ...lastKnownTrip, tripid: lastKnownTrip.tripid ?? storedTripId },
-          roster: lastKnownRoster,
-          expenses: lastKnownExpenses,
-        },
-        // Omit server mirror — offline must not call updateUser.
-        (({ updateUser: _skip, ...rest }) => rest)(activateTripDeps(storedUid))
-      );
+      const lastKnownTrip = getMMKVObject(MMKV_KEYS.CURRENT_TRIP) as
+        | TripData
+        | null;
+      if (!lastKnownTrip) {
+        // No cached trip payload — fall back to storage loaders rather than
+        // hydrating an empty shell through the activate seam.
+        await tripCtx.loadTripDataFromStorage();
+        await tripCtx.loadTravellersFromStorage();
+        await expensesCtx.loadExpensesFromStorage(true);
+      } else {
+        const lastKnownRoster =
+          ((await asyncStoreGetObject("currentTravellers")) as Traveller[]) ??
+          [];
+        const lastKnownExpenses =
+          (getMMKVObject(MMKV_KEYS.EXPENSES) as ExpenseData[]) ?? [];
+        await activateTripFromLastKnown(
+          storedTripId,
+          {
+            tripData: {
+              ...lastKnownTrip,
+              tripid: lastKnownTrip.tripid ?? storedTripId,
+            },
+            roster: lastKnownRoster,
+            expenses: lastKnownExpenses,
+          },
+          // Omit server mirror — offline must not call updateUser.
+          (({ updateUser: _skip, ...rest }) => rest)(
+            activateTripDeps(storedUid)
+          )
+        );
+      }
       await userCtx.loadCatListFromAsyncInCtx("async");
       await authCtx.authenticate(storedToken);
     } catch (error) {}

--- a/TravelCostApp/__tests__/util/activate-trip-entry-paths.test.ts
+++ b/TravelCostApp/__tests__/util/activate-trip-entry-paths.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "fs";
+import { join } from "path";
 import type { ExpenseData } from "../../util/expense";
 import type { Traveller } from "../../util/traveler";
 import type { TripData } from "../../types/trip";
@@ -5,6 +7,8 @@ import {
   activateTrip,
   activateTripFromLastKnown,
 } from "../../util/activate-trip";
+
+const appRoot = join(__dirname, "../..");
 
 function tripX(): TripData {
   return {
@@ -103,6 +107,34 @@ function depsFor(probe: StoreProbe, overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+describe("call-site wiring to activateTrip (#326)", () => {
+  it("JoinTrip awaits activateTrip and does not fire-and-forget currentTrip updates", () => {
+    const src = readFileSync(join(appRoot, "screens/JoinTrip.tsx"), "utf8");
+    expect(src).toMatch(/await activateTrip\(/);
+    expect(src).not.toMatch(/updateUser\(uid,\s*\{\s*currentTrip:/);
+    expect(src).not.toMatch(/tripCtx\.fetchAndSetTravellers/);
+    expect(src).not.toMatch(/secureStoreSetItem\("currentTripId"/);
+  });
+
+  it("LoginScreen activates an existing Active trip via activateTrip instead of emptying expenses", () => {
+    const src = readFileSync(join(appRoot, "screens/LoginScreen.tsx"), "utf8");
+    expect(src).toMatch(/await activateTrip\(/);
+    expect(src).not.toMatch(/fetchAndSetCurrentTrip/);
+    // Empty ledger only allowed on implicit-default creation, not on the activate path.
+    const activateBlock = src.slice(src.indexOf("await activateTrip("));
+    expect(activateBlock).not.toMatch(/setExpenses\(\[\]\)/);
+  });
+
+  it("App boot/poll activates via activateTrip and offline via activateTripFromLastKnown", () => {
+    const src = readFileSync(join(appRoot, "App.tsx"), "utf8");
+    expect(src).toMatch(/await activateTrip\(/);
+    expect(src).toMatch(/await activateTripFromLastKnown\(/);
+    expect(src).not.toMatch(/tripCtx\.setTripid\(/);
+    expect(src).not.toMatch(/fetchAndSetCurrentTrip/);
+    expect(src).not.toMatch(/fetchAndSetTravellers/);
+  });
+});
 
 describe("join entry path via activateTrip", () => {
   it("awaits server currentTrip and replaces stale expenses with the joined trip ledger", async () => {

--- a/TravelCostApp/__tests__/util/activate-trip-entry-paths.test.ts
+++ b/TravelCostApp/__tests__/util/activate-trip-entry-paths.test.ts
@@ -1,0 +1,229 @@
+import type { ExpenseData } from "../../util/expense";
+import type { Traveller } from "../../util/traveler";
+import type { TripData } from "../../types/trip";
+import {
+  activateTrip,
+  activateTripFromLastKnown,
+} from "../../util/activate-trip";
+
+function tripX(): TripData {
+  return {
+    tripid: "trip-x",
+    tripName: "Japan",
+    totalBudget: "1000",
+    dailyBudget: "50",
+    tripCurrency: "EUR",
+    travellers: [],
+    startDate: "2026-01-01",
+    endDate: "2026-01-10",
+    isDynamicDailyBudget: false,
+  };
+}
+
+function expense(id: string, description: string): ExpenseData {
+  return {
+    id,
+    description,
+    amount: 10,
+    date: new Date("2026-01-02"),
+    category: "food",
+    currency: "EUR",
+    uid: "u1",
+  } as ExpenseData;
+}
+
+type StoreProbe = {
+  secureCurrentTripId: string | null;
+  serverCurrentTrip: string | null;
+  contextTrip: TripData | null;
+  contextTravellers: Traveller[];
+  expensesState: ExpenseData[];
+  expensesCache: ExpenseData[];
+  updateUserCalls: Array<{ currentTrip: string }>;
+  setCurrentTripCalls: string[];
+};
+
+function emptyProbe(prior?: Partial<StoreProbe>): StoreProbe {
+  return {
+    secureCurrentTripId: prior?.secureCurrentTripId ?? "trip-a",
+    serverCurrentTrip: prior?.serverCurrentTrip ?? "trip-a",
+    contextTrip: prior?.contextTrip ?? {
+      tripid: "trip-a",
+      tripName: "Old",
+      tripCurrency: "EUR",
+    },
+    contextTravellers: prior?.contextTravellers ?? [
+      { uid: "u9", userName: "Oldie" },
+    ],
+    expensesState: prior?.expensesState ?? [expense("e-old", "stale")],
+    expensesCache: prior?.expensesCache ?? [expense("e-old", "stale")],
+    updateUserCalls: [],
+    setCurrentTripCalls: [],
+  };
+}
+
+function depsFor(probe: StoreProbe, overrides: Record<string, unknown> = {}) {
+  return {
+    uid: "u1",
+    fetchTrip: async () => tripX(),
+    getTravellers: async () => [
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ],
+    getAllExpenses: async () => [expense("e-x1", "ramen")],
+    updateUser: async (_uid: string, data: { currentTrip: string }) => {
+      probe.serverCurrentTrip = data.currentTrip;
+      probe.updateUserCalls.push(data);
+    },
+    secureStoreGetItem: async (key: string) =>
+      key === "currentTripId" ? probe.secureCurrentTripId : null,
+    secureStoreSetItem: async (key: string, value: string) => {
+      if (key === "currentTripId") probe.secureCurrentTripId = value;
+    },
+    setCurrentTrip: async (tripid: string, trip: TripData) => {
+      probe.setCurrentTripCalls.push(tripid);
+      probe.contextTrip = { ...trip, tripid };
+      if (trip.travellers) {
+        probe.contextTravellers = trip.travellers as Traveller[];
+      }
+    },
+    saveTripDataInStorage: async (trip: TripData) => {
+      probe.contextTrip = { ...(probe.contextTrip ?? {}), ...trip };
+    },
+    saveTravellersInStorage: async (travellers: Traveller[]) => {
+      probe.contextTravellers = travellers;
+    },
+    setExpenses: (expenses: ExpenseData[]) => {
+      probe.expensesState = expenses;
+    },
+    setExpensesCache: (expenses: ExpenseData[]) => {
+      probe.expensesCache = expenses;
+    },
+    setFreshlyCreatedTo: async () => {},
+    ...overrides,
+  };
+}
+
+describe("join entry path via activateTrip", () => {
+  it("awaits server currentTrip and replaces stale expenses with the joined trip ledger", async () => {
+    const probe = emptyProbe();
+    const joinedRoster: Traveller[] = [
+      { uid: "u1", userName: "Alice" },
+      { uid: "u3", userName: "Carol" },
+    ];
+    const joinedExpenses = [expense("e-join", "welcome dinner")];
+
+    await activateTrip(
+      "trip-x",
+      depsFor(probe, {
+        tripData: tripX(),
+        getTravellers: async () => joinedRoster,
+        getAllExpenses: async () => joinedExpenses,
+      })
+    );
+
+    expect(probe.updateUserCalls).toEqual([{ currentTrip: "trip-x" }]);
+    expect(probe.secureCurrentTripId).toBe("trip-x");
+    expect(probe.serverCurrentTrip).toBe("trip-x");
+    expect(probe.contextTrip?.tripid).toBe("trip-x");
+    expect(probe.contextTravellers).toEqual(joinedRoster);
+    expect(probe.expensesState).toEqual(joinedExpenses);
+    expect(probe.expensesState.some((e) => e.id === "e-old")).toBe(false);
+  });
+});
+
+describe("login entry path via activateTrip", () => {
+  it("shows the server Active trip with its expenses and roster, not an emptied ledger", async () => {
+    const probe = emptyProbe({
+      secureCurrentTripId: null,
+      serverCurrentTrip: null,
+      expensesState: [],
+      expensesCache: [],
+    });
+    const loginExpenses = [
+      expense("e-l1", "taxi"),
+      expense("e-l2", "hotel"),
+    ];
+    const loginRoster: Traveller[] = [{ uid: "u1", userName: "Alice" }];
+
+    await activateTrip(
+      "trip-x",
+      depsFor(probe, {
+        getTravellers: async () => loginRoster,
+        getAllExpenses: async () => loginExpenses,
+      })
+    );
+
+    expect(probe.secureCurrentTripId).toBe("trip-x");
+    expect(probe.serverCurrentTrip).toBe("trip-x");
+    expect(probe.contextTrip?.tripName).toBe("Japan");
+    expect(probe.contextTravellers).toEqual(loginRoster);
+    expect(probe.expensesState).toEqual(loginExpenses);
+    expect(probe.expensesState).toHaveLength(2);
+  });
+});
+
+describe("boot entry path via activateTrip", () => {
+  it("activates the secure-store Active trip id once without leaving prior-trip expenses", async () => {
+    const probe = emptyProbe({
+      secureCurrentTripId: "trip-x",
+      serverCurrentTrip: "trip-other",
+    });
+
+    await activateTrip("trip-x", depsFor(probe));
+
+    expect(probe.setCurrentTripCalls).toEqual(["trip-x"]);
+    expect(probe.secureCurrentTripId).toBe("trip-x");
+    expect(probe.serverCurrentTrip).toBe("trip-x");
+    expect(probe.expensesState.some((e) => e.id === "e-old")).toBe(false);
+    expect(probe.expensesState[0]?.id).toBe("e-x1");
+  });
+});
+
+describe("offline boot via activateTripFromLastKnown", () => {
+  it("loads last-known Active trip, roster, and expenses through the seam without server drift", async () => {
+    const probe = emptyProbe({
+      secureCurrentTripId: "trip-x",
+      serverCurrentTrip: "trip-x",
+    });
+    const lastKnownTrip = tripX();
+    const lastKnownRoster: Traveller[] = [
+      { uid: "u1", userName: "Alice" },
+    ];
+    const lastKnownExpenses = [expense("e-cached", "cached ramen")];
+    let fetchTripCalls = 0;
+
+    await activateTripFromLastKnown(
+      "trip-x",
+      {
+        tripData: lastKnownTrip,
+        roster: lastKnownRoster,
+        expenses: lastKnownExpenses,
+      },
+      depsFor(probe, {
+        fetchTrip: async () => {
+          fetchTripCalls += 1;
+          throw new Error("network unavailable");
+        },
+        getTravellers: async () => {
+          throw new Error("network unavailable");
+        },
+        getAllExpenses: async () => {
+          throw new Error("network unavailable");
+        },
+        // Intentionally omit updateUser — offline seam must no-op the server mirror.
+        updateUser: undefined,
+      })
+    );
+
+    expect(fetchTripCalls).toBe(0);
+    expect(probe.secureCurrentTripId).toBe("trip-x");
+    expect(probe.contextTrip?.tripid).toBe("trip-x");
+    expect(probe.contextTrip?.tripName).toBe("Japan");
+    expect(probe.contextTravellers).toEqual(lastKnownRoster);
+    expect(probe.expensesState).toEqual(lastKnownExpenses);
+    // Server mirror skipped offline; prior server value unchanged.
+    expect(probe.serverCurrentTrip).toBe("trip-x");
+    expect(probe.updateUserCalls).toEqual([]);
+  });
+});

--- a/TravelCostApp/screens/JoinTrip.tsx
+++ b/TravelCostApp/screens/JoinTrip.tsx
@@ -40,7 +40,10 @@ import { ActivityIndicator } from "react-native-paper";
 import BackButton from "../components/UI/BackButton";
 import { NetworkContext } from "../store/network-context";
 import uniqBy from "lodash.uniqby";
-import { secureStoreSetItem } from "../store/secure-storage";
+import {
+  secureStoreGetItem,
+  secureStoreSetItem,
+} from "../store/secure-storage";
 import { MMKV_KEYS, setMMKVObject } from "../store/mmkv";
 import safeLogError from "../util/error";
 import Animated, { FadeIn } from "react-native-reanimated";
@@ -52,6 +55,7 @@ import { sleep } from "../util/appState";
 import { dynamicScale } from "../util/scalingUtil";
 import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
+import { activateTrip } from "../util/activate-trip";
 
 const JoinTrip = ({ navigation, route }) => {
   // join Trips via route params (route.params.id -> tripid)
@@ -170,36 +174,42 @@ const JoinTrip = ({ navigation, route }) => {
       ]);
       userCtx.setTripHistory(historyWithJoined);
 
-      updateUser(uid, {
-        currentTrip: tripid,
-      });
+      const travellers = await getTravellers(tripid);
+      // only put traveller in trip if not already in trip
+      if (
+        !travellers?.some((traveller) => traveller.userName === userCtx.userName)
+      ) {
+        await putTravelerInTrip(tripid, {
+          uid: uid,
+          userName: userCtx.userName,
+        });
+      }
+
       try {
-        await tripCtx.setCurrentTrip(tripid, tripdata);
-        await tripCtx.fetchAndSetTravellers(tripid);
-        await userCtx.setFreshlyCreatedTo(false);
+        await activateTrip(tripid, {
+          uid,
+          tripData: tripdata,
+          previousTripSnapshot: tripCtx.getcurrentTrip(),
+          previousExpensesSnapshot: expenseCtx.expenses,
+          fetchTrip,
+          getTravellers,
+          getAllExpenses,
+          updateUser,
+          secureStoreGetItem,
+          secureStoreSetItem,
+          setCurrentTrip: tripCtx.setCurrentTrip,
+          saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+          saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+          setExpenses: expenseCtx.setExpenses,
+          setExpensesCache: (nextExpenses) =>
+            setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+          setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
+        });
         await userCtx.loadCatListFromAsyncInCtx(tripid);
       } catch (error) {
         safeLogError(error);
         throw new Error("Error while updating user in context");
       }
-
-      const expenses = await getAllExpenses(tripid, uid);
-      expenseCtx.setExpenses(expenses);
-      tripdata.expenses = [];
-      setMMKVObject(MMKV_KEYS.CURRENT_TRIP, tripdata);
-      await secureStoreSetItem("currentTripId", tripid);
-      // await asyncStoreSetObject("expenses", expenses);
-      setMMKVObject(MMKV_KEYS.EXPENSES, expenses);
-
-      const travellers = await getTravellers(tripid);
-      // only put traveller in trip if not already in trip
-      if (
-        !travellers?.some((traveller) => traveller.userName === userCtx.userName)
-      )
-        await putTravelerInTrip(tripid, {
-          uid: uid,
-          userName: userCtx.userName,
-        });
 
       const joinDecision = resolveJoinImplicitDefaultDecision({
         activeTripId: previousActiveTripId,
@@ -217,9 +227,6 @@ const JoinTrip = ({ navigation, route }) => {
         setTripHistory: userCtx.setTripHistory,
       });
 
-      // // Immediately reload the React Native Bundle
-      // const r = await reloadApp();
-      // if (r == -1)
       navigation.popToTop();
     } catch (error) {
       Alert.alert(

--- a/TravelCostApp/screens/LoginScreen.tsx
+++ b/TravelCostApp/screens/LoginScreen.tsx
@@ -8,7 +8,14 @@ import { i18n } from "../i18n/i18n";
 
 import { AuthContext } from "../store/auth-context";
 import { UserContext, UserData } from "../store/user-context";
-import { fetchUser, touchMyTraveler, updateUser } from "../util/http";
+import {
+  fetchTrip,
+  fetchUser,
+  getAllExpenses,
+  getTravellers,
+  touchMyTraveler,
+  updateUser,
+} from "../util/http";
 import { TripContext } from "../store/trip-context";
 import Toast from "react-native-toast-message";
 import Purchases from "react-native-purchases";
@@ -20,11 +27,15 @@ import {
 import { NetworkContext } from "../store/network-context";
 import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
-import { secureStoreSetItem } from "../store/secure-storage";
+import {
+  secureStoreGetItem,
+  secureStoreSetItem,
+} from "../store/secure-storage";
 import { ExpensesContext } from "../store/expenses-context";
 import { MMKV_KEYS, setMMKVObject } from "../store/mmkv";
 import safeLogError from "../util/error";
 import { createImplicitDefaultForUser } from "../util/create-implicit-default-for-user";
+import { activateTrip } from "../util/activate-trip";
 
 function LoginScreen() {
   const [isAuthenticating, setIsAuthenticating] = useState(false);
@@ -142,22 +153,34 @@ function LoginScreen() {
           ...userData,
           freshlyCreated: false,
         });
-        await secureStoreSetItem("currentTripId", tripid);
         await secureStoreSetItem("uid", uid);
 
         await touchMyTraveler(tripid, uid);
 
-        await tripCtx.fetchAndSetCurrentTrip(tripid);
+        await activateTrip(tripid, {
+          uid,
+          previousTripSnapshot: tripCtx.getcurrentTrip(),
+          previousExpensesSnapshot: expCtx.expenses,
+          fetchTrip,
+          getTravellers,
+          getAllExpenses,
+          updateUser,
+          secureStoreGetItem,
+          secureStoreSetItem,
+          setCurrentTrip: tripCtx.setCurrentTrip,
+          saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+          saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+          setExpenses: expCtx.setExpenses,
+          setExpensesCache: (nextExpenses) =>
+            setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+          setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
+        });
         await userCtx.loadCatListFromAsyncInCtx(tripid);
         await userCtx.updateTripHistory();
-        tripCtx.refresh();
-        expCtx.setExpenses([]);
-        setMMKVObject(MMKV_KEYS.EXPENSES, []);
       } catch (error) {
         safeLogError(error);
       }
     }
-    tripCtx.setTripid(tripid);
     await authCtx.authenticate(token);
   }
 

--- a/TravelCostApp/screens/LoginScreen.tsx
+++ b/TravelCostApp/screens/LoginScreen.tsx
@@ -135,6 +135,7 @@ function LoginScreen() {
           setTripHistory: userCtx.setTripHistory,
         });
         tripid = created.tripid;
+        // New implicit default has no ledger yet — not the activate-existing-trip path.
         expCtx.setExpenses([]);
         setMMKVObject(MMKV_KEYS.EXPENSES, []);
         await userCtx.loadCatListFromAsyncInCtx(tripid);

--- a/TravelCostApp/util/activate-trip.ts
+++ b/TravelCostApp/util/activate-trip.ts
@@ -88,6 +88,35 @@ export async function activateTrip(
   }
 }
 
+export type LastKnownActiveTrip = {
+  tripData: TripData;
+  roster: Traveller[];
+  expenses: ExpenseData[];
+};
+
+/**
+ * Offline / last-known boot: route through activateTrip with cached payloads
+ * and a no-op server mirror so stores stay aligned without network.
+ */
+export async function activateTripFromLastKnown(
+  tripid: string,
+  lastKnown: LastKnownActiveTrip,
+  deps: Omit<
+    ActivateTripDeps,
+    "tripData" | "fetchTrip" | "getTravellers" | "getAllExpenses" | "updateUser"
+  > &
+    Partial<Pick<ActivateTripDeps, "updateUser">>
+): Promise<{ tripid: string; tripData: TripData }> {
+  return activateTrip(tripid, {
+    ...deps,
+    tripData: lastKnown.tripData,
+    fetchTrip: async () => lastKnown.tripData,
+    getTravellers: async () => lastKnown.roster,
+    getAllExpenses: async () => lastKnown.expenses,
+    updateUser: deps.updateUser ?? (async () => {}),
+  });
+}
+
 async function rollbackActivateTrip(
   attemptedTripid: string,
   previousActiveTripId: string | null,


### PR DESCRIPTION
## Summary
- Point JoinTrip, LoginScreen, and App boot/foreground-poll at `activateTrip` so every Active-trip entry uses the same awaited seam.
- Add `activateTripFromLastKnown` for offline boot so last-known trip/roster/expenses align without server drift.
- Remove bespoke switch rituals (un-awaited join `updateUser`, multi `setTripid`, login emptying expenses).

## Test plan
- [x] `pnpm test -- __tests__/util/activate-trip-entry-paths.test.ts`
- [x] `pnpm test -- __tests__/util/activate-trip.test.ts`
- [x] `pnpm test` (full suite)
- [ ] Smoke: join a trip — lands on that Active trip with correct expenses/roster; server `currentTrip` matches
- [ ] Smoke: log in — Active trip expenses/roster load (not empty/stale)
- [ ] Smoke: cold start online + offline — secure Active trip id, matching ledger, no multi-set drift

Closes #326