### PR TITLE
Active-trip refactor — slice 5: authoritative currentTripId + ADR

### DIFF
--- a/TravelCostApp/App.tsx
+++ b/TravelCostApp/App.tsx
@@ -111,6 +111,7 @@ import {
   activateTrip,
   activateTripFromLastKnown,
 } from "./util/activate-trip";
+import { getActiveTripId } from "./util/active-trip-id";
 import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "./store/mmkv";
 import { Traveller } from "./util/traveler";
 // Keep the splash screen visible while we fetch resources
@@ -545,7 +546,7 @@ function Root() {
                 await updateUser(storedUid, checkUser);
               }
               // Authoritative Active trip id is secure storage (not server guesswork).
-              const tripid = await secureStoreGetItem("currentTripId");
+              const tripid = await getActiveTripId();
               if (!tripid) return;
               try {
                 setOnlineSetupDone(true);
@@ -668,7 +669,7 @@ function Root() {
       // fetch token and trip
       const storedToken = await secureStoreGetItem("token");
       const storedUid = await secureStoreGetItem("uid");
-      const storedTripId = await secureStoreGetItem("currentTripId");
+      const storedTripId = await getActiveTripId();
       const freshlyCreated = await asyncStoreGetObject("freshlyCreated");
 
       let REVCAT_G, REVCAT_A, VEXO;

--- a/TravelCostApp/__tests__/util/active-trip-id.test.ts
+++ b/TravelCostApp/__tests__/util/active-trip-id.test.ts
@@ -1,0 +1,131 @@
+import type { ExpenseData } from "../../util/expense";
+import type { Traveller } from "../../util/traveler";
+import type { TripData } from "../../types/trip";
+import { activateTrip } from "../../util/activate-trip";
+import {
+  ACTIVE_TRIP_ID_KEY,
+  getActiveTripId,
+} from "../../util/active-trip-id";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+function tripX(): TripData {
+  return {
+    tripid: "trip-x",
+    tripName: "Japan",
+    totalBudget: "1000",
+    dailyBudget: "50",
+    tripCurrency: "EUR",
+    travellers: [],
+    startDate: "2026-01-01",
+    endDate: "2026-01-10",
+    isDynamicDailyBudget: false,
+  };
+}
+
+function expense(id: string, description: string): ExpenseData {
+  return {
+    id,
+    description,
+    amount: 10,
+    date: new Date("2026-01-02"),
+    category: "food",
+    currency: "EUR",
+    uid: "u1",
+  } as ExpenseData;
+}
+
+function src(relFromAppRoot: string): string {
+  return readFileSync(join(__dirname, "../..", relFromAppRoot), "utf8");
+}
+
+describe("getActiveTripId", () => {
+  it("returns the authoritative Active trip id from secure currentTripId", async () => {
+    const id = await getActiveTripId({
+      secureStoreGetItem: async (key) =>
+        key === ACTIVE_TRIP_ID_KEY ? "trip-secure" : null,
+    });
+
+    expect(id).toBe("trip-secure");
+  });
+
+  it("returns null when secure storage has no Active trip id", async () => {
+    await expect(
+      getActiveTripId({
+        secureStoreGetItem: async () => "",
+      })
+    ).resolves.toBeNull();
+
+    await expect(
+      getActiveTripId({
+        secureStoreGetItem: async () => null,
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("after activateTrip switch, accessor and mirrors all agree on the new Active trip", async () => {
+    let secureCurrentTripId: string | null = "trip-a";
+    let serverCurrentTrip: string | null = "trip-a";
+    let contextTripid: string | null = "trip-a";
+    const roster: Traveller[] = [{ uid: "u1", userName: "Alice" }];
+
+    const deps = {
+      secureStoreGetItem: async (key: string) =>
+        key === ACTIVE_TRIP_ID_KEY ? secureCurrentTripId : null,
+      secureStoreSetItem: async (key: string, value: string) => {
+        if (key === ACTIVE_TRIP_ID_KEY) secureCurrentTripId = value;
+      },
+    };
+
+    await activateTrip("trip-x", {
+      uid: "u1",
+      fetchTrip: async () => tripX(),
+      getTravellers: async () => roster,
+      getAllExpenses: async () => [expense("e-x1", "ramen")],
+      updateUser: async (_uid, data) => {
+        serverCurrentTrip = data.currentTrip ?? serverCurrentTrip;
+      },
+      ...deps,
+      setCurrentTrip: async (tripid) => {
+        contextTripid = tripid;
+      },
+      saveTripDataInStorage: async () => {},
+      saveTravellersInStorage: async () => {},
+      setExpenses: () => {},
+      setExpensesCache: () => {},
+      setFreshlyCreatedTo: async () => {},
+    });
+
+    await expect(getActiveTripId(deps)).resolves.toBe("trip-x");
+    expect(serverCurrentTrip).toBe("trip-x");
+    expect(contextTripid).toBe("trip-x");
+  });
+});
+
+describe("Active trip id reader wiring (#327)", () => {
+  it("offline queue, HTTP helpers, App boot, TripContext, and Login resolve via getActiveTripId", () => {
+    expect(src("util/offline-queue.ts")).toMatch(/getActiveTripId\(/);
+    expect(src("util/offline-queue.ts")).not.toMatch(
+      /secureStoreGetItem\(["']currentTripId["']\)/
+    );
+
+    expect(src("util/http.tsx")).toMatch(/getActiveTripId\(/);
+    expect(src("util/http.tsx")).not.toMatch(
+      /secureStoreGetItem\(["']currentTripId["']\)/
+    );
+
+    expect(src("App.tsx")).toMatch(/getActiveTripId\(/);
+    expect(src("App.tsx")).not.toMatch(
+      /secureStoreGetItem\(["']currentTripId["']\)/
+    );
+
+    expect(src("store/trip-context.tsx")).toMatch(/getActiveTripId\(/);
+    expect(src("store/trip-context.tsx")).not.toMatch(
+      /fetched_tripid \?\? stored_tripid/
+    );
+
+    expect(src("screens/LoginScreen.tsx")).toMatch(
+      /getActiveTripId\(\)\)\s*\?\?\s*userData\.currentTrip/
+    );
+  });
+});

--- a/TravelCostApp/__tests__/util/active-trip-id.test.ts
+++ b/TravelCostApp/__tests__/util/active-trip-id.test.ts
@@ -128,4 +128,18 @@ describe("Active trip id reader wiring (#327)", () => {
       /getActiveTripId\(\)\)\s*\?\?\s*userData\.currentTrip/
     );
   });
+
+  it("create-trip and implicit-default write mirrors only via activateTrip", () => {
+    const tripForm = src("components/ManageTrip/TripForm.tsx");
+    expect(tripForm).toMatch(/await activateTrip\(/);
+    expect(tripForm).not.toMatch(/secureStoreSetItem\(ACTIVE_TRIP_ID_KEY/);
+    expect(tripForm).not.toMatch(
+      /secureStoreSetItem\(["']currentTripId["']\)/
+    );
+
+    const implicit = src("util/implicit-default-trip.ts");
+    expect(implicit).toMatch(/await activateTrip\(/);
+    expect(implicit).not.toMatch(/await deps\.secureStoreSetItem\(/);
+    expect(implicit).not.toMatch(/await deps\.setCurrentTrip\(/);
+  });
 });

--- a/TravelCostApp/__tests__/util/create-implicit-default-for-user.test.ts
+++ b/TravelCostApp/__tests__/util/create-implicit-default-for-user.test.ts
@@ -16,6 +16,7 @@ jest.mock("../../util/http", () => ({
 }));
 
 jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => null),
   secureStoreSetItem: jest.fn(async () => undefined),
 }));
 
@@ -37,12 +38,18 @@ describe("createImplicitDefaultForUser", () => {
     const setCurrentTrip = jest.fn(async () => undefined);
     const setFreshlyCreatedTo = jest.fn(async () => undefined);
     const setTripHistory = jest.fn();
+    const setExpenses = jest.fn();
+    const setExpensesCache = jest.fn();
 
     await createImplicitDefaultForUser({
       uid: "u1",
       userName: "Alice",
       existingTripHistory: ["trip-old-1"],
       setCurrentTrip,
+      saveTripDataInStorage: jest.fn(async () => undefined),
+      saveTravellersInStorage: jest.fn(async () => undefined),
+      setExpenses,
+      setExpensesCache,
       setFreshlyCreatedTo,
       setTripHistory,
     });
@@ -60,6 +67,7 @@ describe("createImplicitDefaultForUser", () => {
       expect.objectContaining({ isImplicitDefault: true })
     );
     expect(setFreshlyCreatedTo).toHaveBeenCalledWith(false);
+    expect(setExpenses).toHaveBeenCalledWith([]);
     expect(putTravelerInTrip).toHaveBeenCalled();
     expect(updateUser).toHaveBeenCalled();
     expect(secureStoreSetItem).toHaveBeenCalledWith(

--- a/TravelCostApp/__tests__/util/implicit-default-trip.test.ts
+++ b/TravelCostApp/__tests__/util/implicit-default-trip.test.ts
@@ -80,6 +80,18 @@ describe("non-premium trip limit counting", () => {
 });
 
 describe("ensureImplicitDefaultActiveTrip", () => {
+  it("routes Active trip mirror writes through activateTrip", () => {
+    const { readFileSync } = require("fs");
+    const { join } = require("path");
+    const src = readFileSync(
+      join(__dirname, "../../util/implicit-default-trip.ts"),
+      "utf8"
+    );
+    expect(src).toMatch(/await activateTrip\(/);
+    expect(src).not.toMatch(/await deps\.secureStoreSetItem\(/);
+    expect(src).not.toMatch(/await deps\.setCurrentTrip\(/);
+  });
+
   it("appends the new trip to existing Trip history instead of overwriting", async () => {
     const storeTrip = jest.fn(async () => "trip-implicit-1");
     const putTravelerInTrip = jest.fn(async () => ({}));
@@ -89,6 +101,10 @@ describe("ensureImplicitDefaultActiveTrip", () => {
     const secureStoreSetItem = jest.fn(async () => undefined);
     const setFreshlyCreatedTo = jest.fn(async () => undefined);
     const setTripHistory = jest.fn();
+    const setExpenses = jest.fn();
+    const setExpensesCache = jest.fn();
+    const saveTripDataInStorage = jest.fn(async () => undefined);
+    const saveTravellersInStorage = jest.fn(async () => undefined);
 
     const result = await ensureImplicitDefaultActiveTrip({
       uid: "u1",
@@ -100,7 +116,12 @@ describe("ensureImplicitDefaultActiveTrip", () => {
       updateTripHistory,
       updateUser,
       setCurrentTrip,
+      secureStoreGetItem: jest.fn(async () => null),
       secureStoreSetItem,
+      saveTripDataInStorage,
+      saveTravellersInStorage,
+      setExpenses,
+      setExpensesCache,
       setFreshlyCreatedTo,
       setTripHistory,
     });
@@ -142,6 +163,7 @@ describe("ensureImplicitDefaultActiveTrip", () => {
       "trip-implicit-1",
     ]);
     expect(setFreshlyCreatedTo).toHaveBeenCalledWith(false);
+    expect(setExpenses).toHaveBeenCalledWith([]);
     expect(result.tripid).toBe("trip-implicit-1");
     expect(result.tripData.isImplicitDefault).toBe(true);
   });
@@ -160,7 +182,12 @@ describe("ensureImplicitDefaultActiveTrip", () => {
       updateTripHistory,
       updateUser: jest.fn(async () => undefined),
       setCurrentTrip: jest.fn(async () => undefined),
+      secureStoreGetItem: jest.fn(async () => null),
       secureStoreSetItem: jest.fn(async () => undefined),
+      saveTripDataInStorage: jest.fn(async () => undefined),
+      saveTravellersInStorage: jest.fn(async () => undefined),
+      setExpenses: jest.fn(),
+      setExpensesCache: jest.fn(),
       setFreshlyCreatedTo: jest.fn(async () => undefined),
       setTripHistory,
     });

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -59,7 +59,6 @@ import {
   secureStoreSetItem,
 } from "../../store/secure-storage";
 import { activateTrip } from "../../util/activate-trip";
-import { ACTIVE_TRIP_ID_KEY } from "../../util/active-trip-id";
 import BackButton from "../UI/BackButton";
 import { onShare } from "../ProfileOutput/ShareTrip";
 import { NetworkContext } from "../../store/network-context";
@@ -378,20 +377,6 @@ const TripForm = ({ navigation, route }) => {
     await putTravelerInTrip(tripid, { userName: userName, uid: uid });
     setLoadingProgress(4);
 
-    await secureStoreSetItem(ACTIVE_TRIP_ID_KEY, tripid);
-    // await asyncStoreSetObject("expenses", []);
-    setMMKVObject(MMKV_KEYS.EXPENSES, []);
-
-    // the following context state functions are unnecessary as long as we reload
-    try {
-      await tripCtx.setCurrentTrip(tripid, tripData);
-      setLoadingProgress(5);
-
-      expenseCtx.setExpenses([]);
-    } catch (error) {
-      safeLogError(error);
-    }
-
     try {
       if (userCtx.tripHistory?.length > 0)
         userCtx.setTripHistory([...userCtx.tripHistory, tripid]);
@@ -411,15 +396,34 @@ const TripForm = ({ navigation, route }) => {
       safeLogError(error);
     }
     setLoadingProgress(7);
-    await updateUser(uid, {
-      userName: userName,
-      currentTrip: tripid,
+
+    // Secure + server + context mirrors + empty ledger via activateTrip.
+    await activateTrip(tripid, {
+      uid,
+      tripData: { ...tripData, tripid },
+      previousTripSnapshot: tripCtx.getcurrentTrip(),
+      previousExpensesSnapshot: expenseCtx.expenses,
+      fetchTrip,
+      getTravellers,
+      getAllExpenses: async () => [],
+      updateUser: async (userId, data) => {
+        await updateUser(userId, {
+          userName: userName,
+          currentTrip: data.currentTrip,
+        });
+      },
+      secureStoreGetItem,
+      secureStoreSetItem,
+      setCurrentTrip: tripCtx.setCurrentTrip,
+      saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+      saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+      setExpenses: expenseCtx.setExpenses,
+      setExpensesCache: (nextExpenses) =>
+        setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+      setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
     });
     setLoadingProgress(9);
-    expenseCtx.setExpenses([]);
-    setMMKVObject(MMKV_KEYS.EXPENSES, []);
 
-    await userCtx.setFreshlyCreatedTo(false);
     navigation.navigate("RecentExpenses");
   }
 

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -59,6 +59,7 @@ import {
   secureStoreSetItem,
 } from "../../store/secure-storage";
 import { activateTrip } from "../../util/activate-trip";
+import { ACTIVE_TRIP_ID_KEY } from "../../util/active-trip-id";
 import BackButton from "../UI/BackButton";
 import { onShare } from "../ProfileOutput/ShareTrip";
 import { NetworkContext } from "../../store/network-context";
@@ -377,7 +378,7 @@ const TripForm = ({ navigation, route }) => {
     await putTravelerInTrip(tripid, { userName: userName, uid: uid });
     setLoadingProgress(4);
 
-    await secureStoreSetItem("currentTripId", tripid);
+    await secureStoreSetItem(ACTIVE_TRIP_ID_KEY, tripid);
     // await asyncStoreSetObject("expenses", []);
     setMMKVObject(MMKV_KEYS.EXPENSES, []);
 

--- a/TravelCostApp/docs/adr/0001-authoritative-active-trip-id.md
+++ b/TravelCostApp/docs/adr/0001-authoritative-active-trip-id.md
@@ -1,0 +1,14 @@
+# Secure `currentTripId` is the authoritative Active trip id
+
+Three stores held an Active trip id — secure `currentTripId`, server `users/{uid}.currentTrip`, and `TripContext.tripid` — and readers preferred different ones, so switches and relogin could disagree. We treat secure `currentTripId` as the single source of truth (survives restart, readable offline, already used by the offline queue). Server `currentTrip` and `TripContext.tripid` are mirrors updated only through `activateTrip`. All readers resolve the id via `getActiveTripId`.
+
+## Considered options
+
+- **Server `currentTrip` as authority** — rejected: unavailable offline; a stale or failed server write during switch made relogin override the device’s last successful selection.
+- **`TripContext.tripid` as authority** — rejected: in-memory only; lost on process death; not shared with the offline queue or HTTP helpers.
+- **Secure `currentTripId` as authority** — accepted: durable on device, readable offline, already the queue’s source.
+
+## Consequences
+
+- Call sites that need “which trip is active” use `getActiveTripId`; they must not prefer server or context over secure storage.
+- Mirror writes belong in `activateTrip` (switch/restore). Creation paths that mint a new Active trip may still set the secure key (and mirrors) when establishing the first id.

--- a/TravelCostApp/docs/adr/0001-authoritative-active-trip-id.md
+++ b/TravelCostApp/docs/adr/0001-authoritative-active-trip-id.md
@@ -11,4 +11,4 @@ Three stores held an Active trip id — secure `currentTripId`, server `users/{u
 ## Consequences
 
 - Call sites that need “which trip is active” use `getActiveTripId`; they must not prefer server or context over secure storage.
-- Mirror writes belong in `activateTrip` (switch/restore). Creation paths that mint a new Active trip may still set the secure key (and mirrors) when establishing the first id.
+- Mirror writes belong in `activateTrip` (including establish-Active-trip on create / implicit default). Do not write server `currentTrip` or `TripContext.tripid` ad hoc.

--- a/TravelCostApp/screens/LoginScreen.tsx
+++ b/TravelCostApp/screens/LoginScreen.tsx
@@ -36,6 +36,7 @@ import { MMKV_KEYS, setMMKVObject } from "../store/mmkv";
 import safeLogError from "../util/error";
 import { createImplicitDefaultForUser } from "../util/create-implicit-default-for-user";
 import { activateTrip } from "../util/activate-trip";
+import { getActiveTripId } from "../util/active-trip-id";
 
 function LoginScreen() {
   const [isAuthenticating, setIsAuthenticating] = useState(false);
@@ -123,7 +124,8 @@ function LoginScreen() {
       safeLogError(error);
     }
 
-    let tripid = userData.currentTrip;
+    // Secure currentTripId is authoritative; server currentTrip is a fallback mirror.
+    let tripid = (await getActiveTripId()) ?? userData.currentTrip;
     if (!tripid) {
       try {
         const created = await createImplicitDefaultForUser({

--- a/TravelCostApp/screens/LoginScreen.tsx
+++ b/TravelCostApp/screens/LoginScreen.tsx
@@ -133,13 +133,15 @@ function LoginScreen() {
           userName: userData.userName,
           existingTripHistory: userCtx.tripHistory,
           setCurrentTrip: tripCtx.setCurrentTrip,
+          saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+          saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+          setExpenses: expCtx.setExpenses,
+          setExpensesCache: (nextExpenses) =>
+            setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
           setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
           setTripHistory: userCtx.setTripHistory,
         });
         tripid = created.tripid;
-        // New implicit default has no ledger yet — not the activate-existing-trip path.
-        expCtx.setExpenses([]);
-        setMMKVObject(MMKV_KEYS.EXPENSES, []);
         await userCtx.loadCatListFromAsyncInCtx(tripid);
         tripCtx.refresh();
       } catch (error) {

--- a/TravelCostApp/screens/SignupScreen.tsx
+++ b/TravelCostApp/screens/SignupScreen.tsx
@@ -128,11 +128,14 @@ function SignupScreen() {
         userName: name,
         existingTripHistory: [],
         setCurrentTrip: tripCtx.setCurrentTrip,
+        saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+        saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+        setExpenses: expCtx.setExpenses,
+        setExpensesCache: (nextExpenses) =>
+          setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
         setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
         setTripHistory: userCtx.setTripHistory,
       });
-      expCtx.setExpenses([]);
-      setMMKVObject(MMKV_KEYS.EXPENSES, []);
       await secureStoreSetItem("uid", uid);
     } catch (error) {
       safeLogError(error);

--- a/TravelCostApp/store/async-storage.tsx
+++ b/TravelCostApp/store/async-storage.tsx
@@ -1,6 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
 import { secureStoreRemoveItem } from "./secure-storage";
+import { ACTIVE_TRIP_ID_KEY } from "../util/active-trip-id";
 import safeLogError from "../util/error";
 import { safelyParseJSON } from "../util/jsonParse";
 
@@ -101,7 +102,7 @@ export async function asyncStoreSafeClear() {
     await AsyncStorage.multiRemove(keys);
     await secureStoreRemoveItem("token");
     await secureStoreRemoveItem("uid");
-    await secureStoreRemoveItem("currentTripId");
+    await secureStoreRemoveItem(ACTIVE_TRIP_ID_KEY);
     await secureStoreRemoveItem("freshlyCreated");
     await secureStoreRemoveItem("lastCountry");
     await secureStoreRemoveItem("lastCurrency");

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useEffect, useState } from "react";
 import { fetchTrip, fetchUser, getTravellers, updateTrip } from "../util/http";
 import { asyncStoreGetObject, asyncStoreSetObject } from "./async-storage";
 import { secureStoreGetItem } from "./secure-storage";
+import { getActiveTripId } from "../util/active-trip-id";
 import { ExpenseData, isPaidString } from "../util/expense";
 import { Traveller } from "../util/traveler";
 import { isConnectionFastEnough } from "../util/connectionSpeed";
@@ -123,17 +124,27 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   const tripTotalSpent = useTripTotalSpent();
 
   async function loadTripidFetchTrip() {
-    const stored_tripid = await secureStoreGetItem("currentTripId");
+    const stored_tripid = await getActiveTripId();
     const stored_uid = await secureStoreGetItem("uid");
     if (!(stored_tripid || stored_uid)) return;
     setTripid(stored_tripid ?? "");
     const { isFastEnough } = await isConnectionFastEnough();
     if (isFastEnough) {
       try {
-        const checkUser = await fetchUser(stored_uid);
-        const fetched_tripid = checkUser.currentTrip;
-        await fetchAndSetCurrentTrip(fetched_tripid ?? stored_tripid);
-        await fetchAndSetTravellers(fetched_tripid ?? stored_tripid);
+        // Secure currentTripId is authoritative; server currentTrip is a mirror.
+        // Fall back to server only when secure storage has no Active trip id.
+        let activeTripId = stored_tripid;
+        if (!activeTripId && stored_uid) {
+          const checkUser = await fetchUser(stored_uid);
+          activeTripId = checkUser.currentTrip ?? null;
+        }
+        if (!activeTripId) {
+          setIsLoading(false);
+          return;
+        }
+        setTripid(activeTripId);
+        await fetchAndSetCurrentTrip(activeTripId);
+        await fetchAndSetTravellers(activeTripId);
       } catch (error) {
         setIsLoading(false);
       }

--- a/TravelCostApp/util/activate-trip.ts
+++ b/TravelCostApp/util/activate-trip.ts
@@ -1,6 +1,7 @@
 import type { TripData } from "../types/trip";
 import type { ExpenseData } from "./expense";
 import type { Traveller } from "./traveler";
+import { ACTIVE_TRIP_ID_KEY } from "./active-trip-id";
 import { hydrateTrip } from "./hydrate-trip";
 import { normalizeTravellers } from "./normalize-travellers";
 
@@ -47,7 +48,7 @@ export async function activateTrip(
     throw new Error("activateTrip requires a tripid");
   }
 
-  const previousActiveTripId = await deps.secureStoreGetItem("currentTripId");
+  const previousActiveTripId = await deps.secureStoreGetItem(ACTIVE_TRIP_ID_KEY);
 
   const rawTrip = deps.tripData ?? (await deps.fetchTrip(tripid));
   if (!rawTrip) {
@@ -69,7 +70,7 @@ export async function activateTrip(
 
   let committed = false;
   try {
-    await deps.secureStoreSetItem("currentTripId", tripid);
+    await deps.secureStoreSetItem(ACTIVE_TRIP_ID_KEY, tripid);
     await deps.updateUser(deps.uid, { currentTrip: tripid });
     await deps.setCurrentTrip(tripid, hydratedTrip);
     await deps.saveTripDataInStorage(hydratedTrip);
@@ -127,7 +128,7 @@ async function rollbackActivateTrip(
   }
 
   try {
-    await deps.secureStoreSetItem("currentTripId", previousActiveTripId);
+    await deps.secureStoreSetItem(ACTIVE_TRIP_ID_KEY, previousActiveTripId);
     await deps.updateUser(deps.uid, { currentTrip: previousActiveTripId });
 
     if (deps.previousTripSnapshot) {

--- a/TravelCostApp/util/active-trip-id.ts
+++ b/TravelCostApp/util/active-trip-id.ts
@@ -1,0 +1,24 @@
+import { secureStoreGetItem } from "../store/secure-storage";
+
+/** Secure-store key for the authoritative Active trip id. */
+export const ACTIVE_TRIP_ID_KEY = "currentTripId";
+
+export type GetActiveTripIdDeps = {
+  secureStoreGetItem: (
+    key: string
+  ) => Promise<string | null | undefined>;
+};
+
+/**
+ * Resolves the Active trip id from secure storage — the single source of truth.
+ * Server `currentTrip` and `TripContext.tripid` are mirrors updated through
+ * `activateTrip` (see docs/adr/0001-authoritative-active-trip-id.md).
+ */
+export async function getActiveTripId(
+  deps?: GetActiveTripIdDeps
+): Promise<string | null> {
+  const read = deps?.secureStoreGetItem ?? secureStoreGetItem;
+  const id = await read(ACTIVE_TRIP_ID_KEY);
+  if (!id || id.trim() === "") return null;
+  return id;
+}

--- a/TravelCostApp/util/create-implicit-default-for-user.ts
+++ b/TravelCostApp/util/create-implicit-default-for-user.ts
@@ -5,8 +5,13 @@ import {
   updateUser,
 } from "./http";
 import { getMMKVObject, MMKV_KEYS } from "../store/mmkv";
-import { secureStoreSetItem } from "../store/secure-storage";
+import {
+  secureStoreGetItem,
+  secureStoreSetItem,
+} from "../store/secure-storage";
 import type { TripData } from "../types/trip";
+import type { Traveller } from "./traveler";
+import type { ExpenseData } from "./expense";
 import {
   deviceLocaleTripCurrency,
   ensureImplicitDefaultActiveTrip,
@@ -17,6 +22,10 @@ type ImplicitDefaultAuthContexts = {
   userName: string;
   existingTripHistory?: string[] | null;
   setCurrentTrip: (tripid: string, trip: TripData) => Promise<unknown>;
+  saveTripDataInStorage: (tripData: TripData) => Promise<void>;
+  saveTravellersInStorage: (travellers: Traveller[]) => Promise<unknown>;
+  setExpenses: (expenses: ExpenseData[]) => void;
+  setExpensesCache: (expenses: ExpenseData[]) => void;
   setFreshlyCreatedTo: (value: boolean) => void | Promise<unknown>;
   setTripHistory: (tripHistory: string[]) => void;
 };
@@ -36,7 +45,12 @@ export async function createImplicitDefaultForUser(
     updateTripHistory,
     updateUser,
     setCurrentTrip: ctx.setCurrentTrip,
+    secureStoreGetItem,
     secureStoreSetItem,
+    saveTripDataInStorage: ctx.saveTripDataInStorage,
+    saveTravellersInStorage: ctx.saveTravellersInStorage,
+    setExpenses: ctx.setExpenses,
+    setExpensesCache: ctx.setExpensesCache,
     setFreshlyCreatedTo: ctx.setFreshlyCreatedTo,
     setTripHistory: ctx.setTripHistory,
   });

--- a/TravelCostApp/util/http.tsx
+++ b/TravelCostApp/util/http.tsx
@@ -19,8 +19,8 @@ import { i18n } from "../i18n/i18n";
 import { Traveller } from "./traveler";
 import { normalizeTravellers } from "./normalize-travellers";
 import { getMMKVString, setMMKVString } from "../store/mmkv";
-import { secureStoreGetItem } from "../store/secure-storage";
 import { ExpoPushToken } from "expo-notifications";
+import { getActiveTripId } from "./active-trip-id";
 import safeLogError from "./error";
 import { safelyParseJSON } from "./jsonParse";
 import { getValidIdToken } from "./firebase-auth";
@@ -985,7 +985,7 @@ export async function storeExpoPushTokenInTrip(
   if (!token) return;
   let usedTripID = tripid;
   if (!tripid || tripid.length < 1)
-    usedTripID = await secureStoreGetItem("currentTripId");
+    usedTripID = await getActiveTripId();
   if (!usedTripID) return;
 
   const authToken = await getValidIdToken();

--- a/TravelCostApp/util/implicit-default-trip.ts
+++ b/TravelCostApp/util/implicit-default-trip.ts
@@ -3,6 +3,7 @@ import * as Localization from "expo-localization";
 import type { TripData } from "../types/trip";
 import type { Category } from "./category";
 import type { Traveller } from "./traveler";
+import { ACTIVE_TRIP_ID_KEY } from "./active-trip-id";
 
 export function isImplicitDefaultTrip(
   trip: Pick<TripData, "isImplicitDefault"> | null | undefined
@@ -101,7 +102,7 @@ export async function ensureImplicitDefaultActiveTrip(
     uid: deps.uid,
     userName: deps.userName,
   });
-  await deps.secureStoreSetItem("currentTripId", tripid);
+  await deps.secureStoreSetItem(ACTIVE_TRIP_ID_KEY, tripid);
   await deps.updateTripHistory(deps.uid, tripid);
   await deps.updateUser(deps.uid, {
     userName: deps.userName,

--- a/TravelCostApp/util/implicit-default-trip.ts
+++ b/TravelCostApp/util/implicit-default-trip.ts
@@ -3,7 +3,8 @@ import * as Localization from "expo-localization";
 import type { TripData } from "../types/trip";
 import type { Category } from "./category";
 import type { Traveller } from "./traveler";
-import { ACTIVE_TRIP_ID_KEY } from "./active-trip-id";
+import type { ExpenseData } from "./expense";
+import { activateTrip } from "./activate-trip";
 
 export function isImplicitDefaultTrip(
   trip: Pick<TripData, "isImplicitDefault"> | null | undefined
@@ -79,7 +80,12 @@ export type EnsureImplicitDefaultActiveTripDeps = {
     }
   ) => Promise<unknown>;
   setCurrentTrip: (tripid: string, trip: TripData) => Promise<unknown>;
+  secureStoreGetItem: (key: string) => Promise<string | null>;
   secureStoreSetItem: (key: string, value: string) => Promise<unknown>;
+  saveTripDataInStorage: (tripData: TripData) => Promise<void>;
+  saveTravellersInStorage: (travellers: Traveller[]) => Promise<unknown>;
+  setExpenses: (expenses: ExpenseData[]) => void;
+  setExpensesCache: (expenses: ExpenseData[]) => void;
   setFreshlyCreatedTo: (value: boolean) => void | Promise<unknown>;
   setTripHistory: (tripHistory: string[]) => void;
 };
@@ -97,21 +103,37 @@ export async function ensureImplicitDefaultActiveTrip(
     deps.existingTripHistory,
     tripid
   );
+  const roster: Traveller[] = [
+    { uid: deps.uid, userName: deps.userName },
+  ];
 
-  await deps.putTravelerInTrip(tripid, {
-    uid: deps.uid,
-    userName: deps.userName,
-  });
-  await deps.secureStoreSetItem(ACTIVE_TRIP_ID_KEY, tripid);
+  await deps.putTravelerInTrip(tripid, roster[0]);
   await deps.updateTripHistory(deps.uid, tripid);
-  await deps.updateUser(deps.uid, {
-    userName: deps.userName,
-    currentTrip: tripid,
-    freshlyCreated: false,
-  });
-  await deps.setCurrentTrip(tripid, tripWithId);
   deps.setTripHistory(nextHistory);
-  await deps.setFreshlyCreatedTo(false);
 
-  return { tripid, tripData: tripWithId };
+  // Mirror writes (secure + server + context + empty ledger) go through activateTrip.
+  const activated = await activateTrip(tripid, {
+    uid: deps.uid,
+    tripData: tripWithId,
+    fetchTrip: async () => tripWithId,
+    getTravellers: async () => roster,
+    getAllExpenses: async () => [],
+    updateUser: async (uid, data) => {
+      await deps.updateUser(uid, {
+        userName: deps.userName,
+        currentTrip: data.currentTrip,
+        freshlyCreated: false,
+      });
+    },
+    secureStoreGetItem: deps.secureStoreGetItem,
+    secureStoreSetItem: deps.secureStoreSetItem,
+    setCurrentTrip: deps.setCurrentTrip,
+    saveTripDataInStorage: deps.saveTripDataInStorage,
+    saveTravellersInStorage: deps.saveTravellersInStorage,
+    setExpenses: deps.setExpenses,
+    setExpensesCache: deps.setExpensesCache,
+    setFreshlyCreatedTo: deps.setFreshlyCreatedTo,
+  });
+
+  return { tripid: activated.tripid, tripData: activated.tripData };
 }

--- a/TravelCostApp/util/offline-queue.ts
+++ b/TravelCostApp/util/offline-queue.ts
@@ -16,8 +16,8 @@ import { DEBUG_FORCE_OFFLINE } from "../confAppConstants";
 
 import NetInfo from "@react-native-community/netinfo";
 import { isConnectionFastEnough } from "./connectionSpeed";
-import { secureStoreGetItem } from "../store/secure-storage";
 import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "../store/mmkv";
+import { getActiveTripId } from "./active-trip-id";
 import safeLogError from "./error";
 import { withRetries } from "./sync-with-retries";
 
@@ -96,7 +96,7 @@ const resolveTripidOrThrow = async (
   errorMessage: string,
   toastKey: "toastErrorStoreExp" | "toastErrorUpdateExp" | "toastErrorDeleteExp",
 ) => {
-  const tripid = await secureStoreGetItem("currentTripId");
+  const tripid = await getActiveTripId();
   if (!tripid) {
     Toast.show({
       type: "error",
@@ -221,7 +221,7 @@ export const restoreExpenseOnlineOffline = async (
   item: OfflineQueueManageExpenseItem,
   online: boolean,
 ) => {
-  const tripid = await secureStoreGetItem("currentTripId");
+  const tripid = await getActiveTripId();
   if (!tripid) {
     Toast.show({
       type: "error",
@@ -360,7 +360,7 @@ export const storeExpenseOnlineOffline = async (
   online: boolean,
   forceTripid: string | null = null,
 ): Promise<string> => {
-  const tripid = forceTripid ?? (await secureStoreGetItem("currentTripId"));
+  const tripid = forceTripid ?? (await getActiveTripId());
   if (!tripid) {
     Toast.show({
       type: "error",


### PR DESCRIPTION
## Summary
- Add `getActiveTripId` so secure `currentTripId` is the single source of truth for the Active trip id.
- Route offline queue, HTTP helpers, App boot, TripContext, and Login through the accessor; prefer secure over server mirrors.
- Record the decision and rejected alternatives in `docs/adr/0001-authoritative-active-trip-id.md`.

## Test plan
- [x] `pnpm test -- __tests__/util/active-trip-id.test.ts`
- [x] `pnpm test -- __tests__/util/activate-trip.test.ts __tests__/util/activate-trip-entry-paths.test.ts`
- [x] `pnpm test` (full suite)
- [ ] Smoke: set Active trip, kill app, relaunch — same trip stays active from secure id
- [ ] Smoke: offline expense queue uses Active trip from accessor
- [ ] Smoke: login prefers local secure Active trip over stale server `currentTrip`

Closes #327