### PR TITLE
Active-trip refactor — slice 6: cleanup (dead refresh + logout cache)

### DIFF
--- a/TravelCostApp/__tests__/store/async-storage-safe-clear.test.ts
+++ b/TravelCostApp/__tests__/store/async-storage-safe-clear.test.ts
@@ -1,0 +1,53 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const mmkvStore: Record<string, unknown> = {};
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: {
+    CURRENT_TRIP: "currentTrip",
+    EXPENSES: "expenses",
+  },
+  getMMKVObject: jest.fn((key: string) => mmkvStore[key] ?? null),
+  setMMKVObject: jest.fn((key: string, value: unknown) => {
+    mmkvStore[key] = value;
+  }),
+  deleteMMKVObject: jest.fn((key: string) => {
+    delete mmkvStore[key];
+  }),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreRemoveItem: jest.fn(async () => {}),
+}));
+
+import { MMKV_KEYS, getMMKVObject, setMMKVObject } from "../../store/mmkv";
+import { asyncStoreSafeClear } from "../../store/async-storage";
+
+describe("asyncStoreSafeClear (logout cache)", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    Object.keys(mmkvStore).forEach((key) => delete mmkvStore[key]);
+    await AsyncStorage.clear();
+  });
+
+  it("clears MMKV Active trip and expenses so a fresh login cannot resurrect them", async () => {
+    setMMKVObject(MMKV_KEYS.CURRENT_TRIP, {
+      tripid: "prior-trip",
+      tripName: "Prior budget",
+    });
+    setMMKVObject(MMKV_KEYS.EXPENSES, [
+      { id: "e1", amount: 12, description: "stale" },
+    ]);
+
+    expect(getMMKVObject(MMKV_KEYS.CURRENT_TRIP)).toEqual({
+      tripid: "prior-trip",
+      tripName: "Prior budget",
+    });
+    expect(getMMKVObject(MMKV_KEYS.EXPENSES)).toHaveLength(1);
+
+    await asyncStoreSafeClear();
+
+    expect(getMMKVObject(MMKV_KEYS.CURRENT_TRIP)).toBeNull();
+    expect(getMMKVObject(MMKV_KEYS.EXPENSES)).toBeNull();
+  });
+});

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -343,7 +343,6 @@ const TripForm = ({ navigation, route }) => {
         setLoadingProgress(9);
         return;
       }
-      tripCtx.refresh();
       Toast.hide();
       return;
     } catch (error) {

--- a/TravelCostApp/screens/LoginScreen.tsx
+++ b/TravelCostApp/screens/LoginScreen.tsx
@@ -143,7 +143,6 @@ function LoginScreen() {
         });
         tripid = created.tripid;
         await userCtx.loadCatListFromAsyncInCtx(tripid);
-        tripCtx.refresh();
       } catch (error) {
         safeLogError(error);
         setIsAuthenticating(false);

--- a/TravelCostApp/store/async-storage.tsx
+++ b/TravelCostApp/store/async-storage.tsx
@@ -4,6 +4,7 @@ import { secureStoreRemoveItem } from "./secure-storage";
 import { ACTIVE_TRIP_ID_KEY } from "../util/active-trip-id";
 import safeLogError from "../util/error";
 import { safelyParseJSON } from "../util/jsonParse";
+import { deleteMMKVObject, MMKV_KEYS } from "./mmkv";
 
 /**
  * Store item in long-term Memory of the device.
@@ -108,6 +109,10 @@ export async function asyncStoreSafeClear() {
     await secureStoreRemoveItem("lastCurrency");
     await secureStoreRemoveItem("ENCM");
     await secureStoreRemoveItem("ENCP");
+    // MMKV survives AsyncStorage/secure clears; drop Active trip + expenses so
+    // the next login cannot resurrect the prior session's cache.
+    deleteMMKVObject(MMKV_KEYS.CURRENT_TRIP);
+    deleteMMKVObject(MMKV_KEYS.EXPENSES);
   } catch (error) {
     safeLogError(error);
   }

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -31,8 +31,6 @@ export type TripContextType = {
   tripProgress: number;
   startDate: string;
   endDate: string;
-  refreshState: boolean;
-  refresh: () => void;
   setTripProgress: (percent: number) => void;
   travellers: Traveller[];
   fetchAndSetTravellers: (tripid: string) => Promise<boolean>;
@@ -67,8 +65,6 @@ export const TripContext = createContext<TripContextType>({
   tripProgress: 0,
   startDate: "",
   endDate: "",
-  refreshState: false,
-  refresh: () => {},
   setTripProgress: (percent: number) => {},
   travellers: [],
   fetchAndSetTravellers: async (tripid: string) => false,
@@ -109,7 +105,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   const [tripCurrency, setTripCurrency] = useState("");
   const [dailyBudget, setdailyBudget] = useState("");
   const [progress, setProgress] = useState(0);
-  const [refreshState, setRefreshState] = useState(false);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [isPaid, setIsPaid] = useState(isPaidString.notPaid);
@@ -209,10 +204,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   function setTripProgress(percent: number) {
     if (percent < 0 || percent > 1) percent = 1;
     setProgress(percent);
-  }
-  //
-  function refresh() {
-    setRefreshState(!refreshState);
   }
 
   async function fetchAndSetTravellers(tripid: string): Promise<boolean> {
@@ -416,8 +407,6 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     tripProgress: progress,
     startDate: startDate,
     endDate: endDate,
-    refresh: refresh,
-    refreshState: refreshState,
     setTripProgress: setTripProgress,
     travellers: travellers,
     fetchAndSetTravellers: fetchAndSetTravellers,


### PR DESCRIPTION
## Summary
- Remove dead `TripContext.refresh()` / `refreshState` (no consumer read the signal) and their no-op call sites.
- Clear MMKV `CURRENT_TRIP` and `EXPENSES` in `asyncStoreSafeClear` so logout does not leave Active trip / expenses for the next login to resurrect.
- Add logout-cache test covering MMKV Active trip + expenses clearing.

## Test plan
- [x] `pnpm test -- __tests__/store/async-storage-safe-clear.test.ts`
- [x] Related store/profile tests
- [x] Full suite (`pnpm test` — 100 suites / 629 tests)
- [ ] Manual: log in with Active trip + expenses, log out, log in as another (or same) user — prior trip/expenses must not appear from cache

Closes #328