### PR TITLE
Leave trip — slice 1: plain leave happy path

### DIFF
--- a/TravelCostApp/__tests__/i18n/home-first-copy.test.ts
+++ b/TravelCostApp/__tests__/i18n/home-first-copy.test.ts
@@ -18,7 +18,7 @@ const P1_BUDGET_KEYS = [
   "tripFormTitleEdit",
   "tripNameLabel",
   "enterNameAlert",
-  "deleteTrip",
+  "leaveTrip",
   "setActive",
   "travellers",
   "inviteTraveller",
@@ -51,7 +51,7 @@ describe("home-first P1 copy sweep (issue #357)", () => {
       expect(en.tripFormTitleEdit).toBe("Edit budget");
       expect(en.tripNameLabel).toBe("Budget name");
       expect(en.enterNameAlert).toBe("Please enter a name for your new budget.");
-      expect(en.deleteTrip).toBe("Delete budget");
+      expect(en.leaveTrip).toBe("Leave budget");
       expect(en.setActive).toBe("Set as active budget");
       expect(en.travellers).toBe("Nomads");
       expect(en.inviteTraveller).toBe("Invite other nomads");
@@ -106,7 +106,7 @@ describe("home-first P1 copy sweep (issue #357)", () => {
       for (const key of [
         "joinTripLabel",
         "shareTripLabel",
-        "deleteTrip",
+        "leaveTrip",
         "setActive",
         "pleaseCreateTrip",
         "paywallFeature0",
@@ -129,7 +129,7 @@ describe("home-first P1 copy sweep (issue #357)", () => {
       for (const key of [
         "joinTripLabel",
         "shareTripLabel",
-        "deleteTrip",
+        "leaveTrip",
         "enterNameAlert",
         "pleaseCreateTrip",
         "paywallFeature0",
@@ -151,7 +151,7 @@ describe("home-first P1 copy sweep (issue #357)", () => {
       for (const key of [
         "joinTripLabel",
         "shareTripLabel",
-        "deleteTrip",
+        "leaveTrip",
         "enterNameAlert",
         "pleaseCreateTrip",
         "paywallFeature0",

--- a/TravelCostApp/__tests__/util/leave-trip.test.ts
+++ b/TravelCostApp/__tests__/util/leave-trip.test.ts
@@ -1,0 +1,68 @@
+jest.mock("../../util/http", () => ({
+  removeTravelerFromTrip: jest.fn(async () => ({ status: 200 })),
+  removeTripFromHistory: jest.fn(async () => undefined),
+}));
+
+import { leaveTrip } from "../../util/leave-trip";
+import {
+  removeTravelerFromTrip,
+  removeTripFromHistory,
+} from "../../util/http";
+
+const removeTravelerFromTripMock = removeTravelerFromTrip as jest.MockedFunction<
+  typeof removeTravelerFromTrip
+>;
+const removeTripFromHistoryMock = removeTripFromHistory as jest.MockedFunction<
+  typeof removeTripFromHistory
+>;
+
+describe("leaveTrip plain leave", () => {
+  beforeEach(() => {
+    removeTravelerFromTripMock.mockClear();
+    removeTripFromHistoryMock.mockClear();
+  });
+
+  it("loads the Traveller roster before planning so a non-active leave can run", async () => {
+    const removeFromTripHistoryLocal = jest.fn();
+    const getTravellers = jest.fn(async () => [
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ]);
+
+    const result = await leaveTrip("trip-b", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers,
+      removeFromTripHistoryLocal,
+    });
+
+    expect(getTravellers).toHaveBeenCalledWith("trip-b");
+    expect(result.performed).toBe(true);
+    expect(result.mode).toBe("leave");
+    expect(removeTravelerFromTripMock).toHaveBeenCalledWith("trip-b", "u1");
+    expect(removeTripFromHistoryMock).toHaveBeenCalledWith("u1", "trip-b");
+    expect(removeFromTripHistoryLocal).toHaveBeenCalledWith("trip-b");
+  });
+
+  it("does not write when the planner refuses plain leave", async () => {
+    const removeFromTripHistoryLocal = jest.fn();
+    const getTravellers = jest.fn(async () => [
+      { uid: "u1", userName: "Alice" },
+    ]);
+
+    const result = await leaveTrip("trip-b", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers,
+      removeFromTripHistoryLocal,
+    });
+
+    expect(result.performed).toBe(false);
+    expect(result.mode).toBe("cascadeDelete");
+    expect(removeTravelerFromTripMock).not.toHaveBeenCalled();
+    expect(removeTripFromHistoryMock).not.toHaveBeenCalled();
+    expect(removeFromTripHistoryLocal).not.toHaveBeenCalled();
+  });
+});

--- a/TravelCostApp/__tests__/util/plan-trip-leave.test.ts
+++ b/TravelCostApp/__tests__/util/plan-trip-leave.test.ts
@@ -1,0 +1,101 @@
+import { planTripLeave } from "../../util/plan-trip-leave";
+
+describe("planTripLeave", () => {
+  const base = {
+    tripHistory: ["trip-a", "trip-b"],
+    roster: [
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ],
+    openBalances: [] as unknown[],
+    activeTripId: "trip-a",
+    tripid: "trip-b",
+  };
+
+  it("forbids leaving when Trip history has only one trip", () => {
+    const plan = planTripLeave({
+      ...base,
+      tripHistory: ["trip-a"],
+      tripid: "trip-a",
+      activeTripId: "trip-a",
+    });
+
+    expect(plan.allowed).toBe(false);
+  });
+
+  it("allows plain leave when other Travellers remain on a non-active trip", () => {
+    const plan = planTripLeave(base);
+
+    expect(plan).toEqual({
+      allowed: true,
+      mode: "leave",
+      nextActiveTripId: null,
+      warnings: [],
+    });
+  });
+
+  it("chooses cascadeDelete when the leaver is the last Traveller on the roster", () => {
+    const plan = planTripLeave({
+      ...base,
+      roster: [{ uid: "u1" }],
+    });
+
+    expect(plan.allowed).toBe(true);
+    expect(plan.mode).toBe("cascadeDelete");
+    expect(plan.warnings).toContain("permanentDelete");
+  });
+
+  it("promotes the first remaining Trip history id when leaving the Active trip", () => {
+    const plan = planTripLeave({
+      ...base,
+      tripid: "trip-a",
+      activeTripId: "trip-a",
+      tripHistory: ["trip-a", "trip-b", "trip-c"],
+    });
+
+    expect(plan.allowed).toBe(true);
+    expect(plan.nextActiveTripId).toBe("trip-b");
+  });
+
+  it("does not propose a new Active trip when leaving a non-active trip", () => {
+    const plan = planTripLeave({
+      ...base,
+      tripid: "trip-c",
+      activeTripId: "trip-a",
+      tripHistory: ["trip-a", "trip-b", "trip-c"],
+    });
+
+    expect(plan.nextActiveTripId).toBeNull();
+  });
+
+  it("warns about open Balances when any are present", () => {
+    const plan = planTripLeave({
+      ...base,
+      openBalances: [{ from: "u1", to: "u2", amount: 12 }],
+    });
+
+    expect(plan.warnings).toContain("openBalances");
+  });
+
+  it("omits openBalances warning when there are none", () => {
+    const plan = planTripLeave({
+      ...base,
+      openBalances: [],
+    });
+
+    expect(plan.warnings).not.toContain("openBalances");
+  });
+
+  it("can combine permanentDelete and openBalances warnings on cascade leave", () => {
+    const plan = planTripLeave({
+      ...base,
+      roster: [{ uid: "u1" }],
+      openBalances: [{ from: "u1", to: "u2", amount: 5 }],
+    });
+
+    expect(plan.mode).toBe("cascadeDelete");
+    expect(plan.warnings).toEqual(
+      expect.arrayContaining(["permanentDelete", "openBalances"])
+    );
+  });
+});

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -295,13 +295,18 @@ const TripForm = ({ navigation, route }) => {
       const result = await tripCtx.leaveTrip(editedTripId, {
         uid,
         tripHistory: userCtx.tripHistory ?? [],
-        roster: travellers,
+        getTravellers,
         openBalances: [],
         removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
       });
 
       Toast.hide();
       if (!result.performed) {
+        Toast.show({
+          text1: i18n.t("toastSavingError1"),
+          text2: i18n.t("error2"),
+          type: "error",
+        });
         return;
       }
       navigation.pop();

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -280,33 +280,66 @@ const TripForm = ({ navigation, route }) => {
     navigation.pop();
   }
 
-  // async function deleteAcceptHandler() {
-  // const trips = route.params.trips;
-  // if triplist?.length == 1 await userCtx.setFreshlyCreatedTo(true);
-  // await deleteTrip(editedTripId);
-  // }
-  // function deleteHandler() {
-  //   Alert.alert(
-  //     i18n.t("deleteTrip"),
-  //     i18n.t("deleteTripSure"),
-  //     [
-  //       {
-  //         text: i18n.t("cancel"),
-  //         style: "cancel",
-  //       },
-  //       {
-  //         // text: i18n.t("delete"),
-  //         text: i18n.t("delete"),
-  //         style: "destructive",
-  //         onPress: async () => {
-  //           deleteAcceptHandler();
-  //           navigation.pop();
-  //         },
-  //       },
-  //     ],
-  //     { cancelable: false }
-  //   );
-  // }
+  async function leaveAcceptHandler() {
+    const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
+    if (!uid || !editedTripId) return;
+
+    Toast.show({
+      type: "loading",
+      text1: i18n.t("toastSaving1"),
+      text2: i18n.t("toastSaving2"),
+      autoHide: false,
+    });
+
+    try {
+      const result = await tripCtx.leaveTrip(editedTripId, {
+        uid,
+        tripHistory: userCtx.tripHistory ?? [],
+        roster: travellers,
+        openBalances: [],
+        removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
+      });
+
+      Toast.hide();
+      if (!result.performed) {
+        return;
+      }
+      navigation.pop();
+    } catch (error) {
+      safeLogError(error);
+      Toast.hide();
+      Toast.show({
+        text1: i18n.t("toastSavingError1"),
+        text2: i18n.t("error2"),
+        type: "error",
+      });
+    }
+  }
+
+  function leaveHandler() {
+    if (!isConnected) {
+      Alert.alert(i18n.t("noConnection"), i18n.t("leaveTripConnectRequired"));
+      return;
+    }
+    Alert.alert(
+      i18n.t("leaveTrip"),
+      i18n.t("leaveTripSure"),
+      [
+        {
+          text: i18n.t("cancel"),
+          style: "cancel",
+        },
+        {
+          text: i18n.t("leaveTrip"),
+          style: "destructive",
+          onPress: () => {
+            void leaveAcceptHandler();
+          },
+        },
+      ],
+      { cancelable: false }
+    );
+  }
 
   async function editingTripData(tripData: TripData, setActive = false) {
     try {
@@ -1071,16 +1104,25 @@ const TripForm = ({ navigation, route }) => {
               {i18n.t("setActive")}
             </GradientButton>
           )}
-          {/* {isEditing && (
+          {isEditing && !isPromote && (userCtx.tripHistory?.length ?? 0) > 1 && (
             <GradientButton
-              buttonStyle={{ backgroundColor: GlobalStyles.colors.error300 }}
-              style={[styles.button, { marginBottom: 8, marginHorizontal: 24 }]}
-              onPress={deleteHandler}
+              buttonStyle={{
+                backgroundColor: GlobalStyles.colors.error300,
+                opacity: isConnected ? 1 : 0.5,
+              }}
+              style={[
+                styles.button,
+                {
+                  marginBottom: dynamicScale(8, false, 0.5),
+                  marginHorizontal: dynamicScale(24, false, 0.5),
+                },
+              ]}
+              onPress={leaveHandler}
               colors={GlobalStyles.gradientErrorButton}
             >
-              {i18n.t("deleteTrip")}
+              {i18n.t("leaveTrip")}
             </GradientButton>
-          )} */}
+          )}
         </KeyboardAvoidingView>
       </Animated.View>
       <View

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -196,8 +196,9 @@ const en = {
   alertChangeHomeCurrencyTitle: "Changing home currency",
   alertChangeHomeCurrencyMessage:
     "Are you sure you want to change the currency? Set it to the currency you normally use at home.",
-  deleteTrip: "Delete budget",
-  deleteTripSure: "Are you sure you want to delete this budget?",
+  leaveTrip: "Leave budget",
+  leaveTripSure: "Are you sure you want to leave this budget? Your past expenses stay for the remaining nomads.",
+  leaveTripConnectRequired: "Connect to the internet to leave this budget.",
   setActive: "Set as active budget",
   datePickerLabel: "Start and end dates",
 
@@ -800,8 +801,11 @@ const de = {
   alertChangeHomeCurrencyTitle: "Heimatwährung ändern",
   alertChangeHomeCurrencyMessage:
     "Möchtest du die Währung wirklich ändern? Wähle die Währung, die du zu Hause normalerweise verwendest.",
-  deleteTrip: "Budget löschen",
-  deleteTripSure: "Bist du dir sicher, dass du dieses Budget löschen möchtest?",
+  leaveTrip: "Budget verlassen",
+  leaveTripSure:
+    "Möchtest du dieses Budget wirklich verlassen? Deine bisherigen Ausgaben bleiben für die anderen Nomaden erhalten.",
+  leaveTripConnectRequired:
+    "Verbinde dich mit dem Internet, um dieses Budget zu verlassen.",
   setActive: "Als aktives Budget markieren",
   datePickerLabel: "Start- und Enddatum",
 
@@ -1436,8 +1440,11 @@ const fr = {
   alertChangeHomeCurrencyTitle: "Changer la devise du domicile",
   alertChangeHomeCurrencyMessage:
     "Voulez-vous vraiment changer la devise ? Choisissez la devise que vous utilisez habituellement chez vous.",
-  deleteTrip: "Supprimer le budget",
-  deleteTripSure: "Êtes-vous sûr de vouloir supprimer ce budget ?",
+  leaveTrip: "Quitter le budget",
+  leaveTripSure:
+    "Voulez-vous vraiment quitter ce budget ? Vos dépenses passées restent pour les autres nomades.",
+  leaveTripConnectRequired:
+    "Connectez-vous à internet pour quitter ce budget.",
   setActive: "Définir comme budget actif",
   datePickerLabel: "Dates de début et de fin",
 
@@ -2062,8 +2069,11 @@ const ru = {
   alertChangeHomeCurrencyTitle: "Изменение домашней валюты",
   alertChangeHomeCurrencyMessage:
     "Вы уверены, что хотите изменить валюту? Укажите валюту, которую вы обычно используете дома.",
-  deleteTrip: "Удалить бюджет",
-  deleteTripSure: "Вы уверены, что хотите удалить этот бюджет?",
+  leaveTrip: "Покинуть бюджет",
+  leaveTripSure:
+    "Вы уверены, что хотите покинуть этот бюджет? Ваши прошлые расходы останутся для остальных номадов.",
+  leaveTripConnectRequired:
+    "Подключитесь к интернету, чтобы покинуть этот бюджет.",
   setActive: "Сделать активным бюджетом",
   datePickerLabel: "Даты начала и окончания",
 

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -18,6 +18,11 @@ import { settleTrip } from "../util/settlement";
 import { useTripTotalSpent } from "../hooks/useTripTotalSpent";
 import { hydrateTrip } from "../util/hydrate-trip";
 import { normalizeTravellers } from "../util/normalize-travellers";
+import {
+  leaveTrip as executeLeaveTrip,
+  type LeaveTripDeps,
+  type LeaveTripResult,
+} from "../util/leave-trip";
 
 export type { TripData };
 
@@ -36,7 +41,11 @@ export type TripContextType = {
   fetchAndSetTravellers: (tripid: string) => Promise<boolean>;
   setTripid: (tripid: string) => void;
   addTrip: ({ tripName, tripTotalBudget }) => void;
-  deleteTrip: (tripid: string) => void;
+  /** Leave trip: roster removal + Trip history splice for plain leave. */
+  leaveTrip: (
+    tripid: string,
+    deps: Omit<LeaveTripDeps, "activeTripId">
+  ) => Promise<LeaveTripResult>;
   getcurrentTrip: () => TripData;
   setCurrentTrip: (tripid: string, trip: TripData) => Promise<TripData | void>;
   fetchAndSetCurrentTrip: (tripid: string) => Promise<TripData>;
@@ -71,7 +80,13 @@ export const TripContext = createContext<TripContextType>({
   setTripid: (tripid: string) => {},
 
   addTrip: ({ tripName, tripTotalBudget }) => {},
-  deleteTrip: (tripid: string) => {},
+  leaveTrip: async () => ({
+    allowed: false,
+    mode: "leave",
+    nextActiveTripId: null,
+    warnings: [],
+    performed: false,
+  }),
   getcurrentTrip: () => {
     const tripData = {} as TripData;
     return tripData;
@@ -345,7 +360,16 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
   }
 
   function addTrip() {}
-  function deleteTrip() {}
+
+  async function leaveTrip(
+    tripidToLeave: string,
+    deps: Omit<LeaveTripDeps, "activeTripId">
+  ): Promise<LeaveTripResult> {
+    return executeLeaveTrip(tripidToLeave, {
+      ...deps,
+      activeTripId: tripid,
+    });
+  }
 
   async function saveTripDataInStorage(tripData: TripData) {
     // cut away the trip.expenses array
@@ -412,7 +436,7 @@ function TripContextProvider({ children }: React.PropsWithChildren) {
     fetchAndSetTravellers: fetchAndSetTravellers,
     setTripid: _setTripid,
     addTrip: addTrip,
-    deleteTrip: deleteTrip,
+    leaveTrip: leaveTrip,
     getcurrentTrip: getcurrentTrip,
     setCurrentTrip: setCurrentTrip,
     fetchAndSetCurrentTrip: fetchAndSetCurrentTrip,

--- a/TravelCostApp/store/user-context.tsx
+++ b/TravelCostApp/store/user-context.tsx
@@ -71,6 +71,8 @@ export type UserContextType = {
 
   tripHistory: string[];
   setTripHistory: (tripHistory: string[]) => void;
+  /** Remove a trip id from Trip history state + MMKV (Leave trip). */
+  removeTripFromHistory: (tripid: string) => void;
   updateTripHistory: () => void;
   isOnline: boolean;
   setIsOnline: (bool: boolean) => void;
@@ -108,6 +110,7 @@ export const UserContext = createContext<UserContextType>({
 
   tripHistory: [],
   setTripHistory: (tripHistory: string[]) => {},
+  removeTripFromHistory: (_tripid: string) => {},
   updateTripHistory: async () => {},
   isOnline: false,
   setIsOnline: (bool: boolean) => {},
@@ -172,6 +175,12 @@ function UserContextProvider({ children }) {
     } catch (error) {
       safeLogError(error);
     }
+  }
+
+  function removeTripFromHistory(tripid: string) {
+    const nextHistory = (tripHistory ?? []).filter((id) => id !== tripid);
+    setTripHistory(nextHistory);
+    setMMKVObject(MMKV_KEYS.TRIP_HISTORY, nextHistory);
   }
   useEffect(() => {
     const storedHistory = getMMKVObject(MMKV_KEYS.TRIP_HISTORY);
@@ -303,6 +312,7 @@ function UserContextProvider({ children }) {
 
     tripHistory: tripHistory,
     setTripHistory: setTripHistory,
+    removeTripFromHistory: removeTripFromHistory,
 
     lastCurrency: lastCurrency,
     setLastCurrency: setLastCurrency,

--- a/TravelCostApp/util/http.tsx
+++ b/TravelCostApp/util/http.tsx
@@ -707,7 +707,7 @@ export async function removeTravelerFromTrip(tripid: string, uid: string) {
     const authToken = await getValidIdToken();
     if (!authToken) {
       console.warn("[HTTP] No valid auth token for removeTravelerFromTrip");
-      return null;
+      throw new Error("No valid auth token");
     }
 
     const response = await axios.delete(

--- a/TravelCostApp/util/http.tsx
+++ b/TravelCostApp/util/http.tsx
@@ -697,6 +697,29 @@ export async function putTravelerInTrip(tripid: string, traveller: Traveller) {
   }
 }
 
+/** Remove a Traveller roster entry (Leave trip). Does not delete expenses/splits. */
+export async function removeTravelerFromTrip(tripid: string, uid: string) {
+  try {
+    if (!tripid || !uid) {
+      throw new Error("tripid and uid are required");
+    }
+
+    const authToken = await getValidIdToken();
+    if (!authToken) {
+      console.warn("[HTTP] No valid auth token for removeTravelerFromTrip");
+      return null;
+    }
+
+    const response = await axios.delete(
+      `${BACKEND_URL}/trips/${tripid}/travellers/${uid}.json?auth=${authToken}`
+    );
+    return response;
+  } catch (error) {
+    safeLogError(error);
+    throw error;
+  }
+}
+
 export type tripTravellers = {
   [key: string]: {
     uid: string;
@@ -787,6 +810,15 @@ export async function updateTripHistory(userId: string, newTripid: string) {
     `${BACKEND_URL}/users/${userId}/tripHistory.json?auth=${authToken}`,
     tripHistory
   );
+}
+
+/** Splice a trip id out of the User's Trip history (Leave trip). */
+export async function removeTripFromHistory(userId: string, tripid: string) {
+  const tripHistory = await fetchTripHistory(userId);
+  const nextHistory = (tripHistory ?? []).filter(
+    (id: string) => id !== tripid
+  );
+  return storeTripHistory(userId, nextHistory);
 }
 
 export async function storeTripHistory(userId: string, tripHistory: string[]) {

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -1,0 +1,51 @@
+import {
+  removeTravelerFromTrip,
+  removeTripFromHistory as removeTripFromHistoryRemote,
+} from "./http";
+import {
+  planTripLeave,
+  type PlanTripLeaveResult,
+} from "./plan-trip-leave";
+import type { Traveller } from "./traveler";
+
+export type LeaveTripDeps = {
+  uid: string;
+  tripHistory: readonly string[];
+  roster: readonly Traveller[];
+  openBalances?: readonly unknown[];
+  activeTripId: string | null | undefined;
+  /** Update Trip history state + local cache after a successful leave. */
+  removeFromTripHistoryLocal: (tripid: string) => void;
+};
+
+export type LeaveTripResult = PlanTripLeaveResult & {
+  /** True when roster + Trip history writes ran (plain leave only). */
+  performed: boolean;
+};
+
+/**
+ * Leave trip orchestration for the plain-leave path.
+ * Cascade-delete and Active trip promotion are planned but not executed here.
+ */
+export async function leaveTrip(
+  tripid: string,
+  deps: LeaveTripDeps
+): Promise<LeaveTripResult> {
+  const plan = planTripLeave({
+    tripHistory: deps.tripHistory,
+    roster: deps.roster,
+    openBalances: deps.openBalances ?? [],
+    activeTripId: deps.activeTripId,
+    tripid,
+  });
+
+  if (!plan.allowed || plan.mode !== "leave") {
+    return { ...plan, performed: false };
+  }
+
+  await removeTravelerFromTrip(tripid, deps.uid);
+  await removeTripFromHistoryRemote(deps.uid, tripid);
+  deps.removeFromTripHistoryLocal(tripid);
+
+  return { ...plan, performed: true };
+}

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -11,9 +11,10 @@ import type { Traveller } from "./traveler";
 export type LeaveTripDeps = {
   uid: string;
   tripHistory: readonly string[];
-  roster: readonly Traveller[];
   openBalances?: readonly unknown[];
   activeTripId: string | null | undefined;
+  /** Authoritative Traveller roster for the trip being left. */
+  getTravellers: (tripid: string) => Promise<Traveller[]>;
   /** Update Trip history state + local cache after a successful leave. */
   removeFromTripHistoryLocal: (tripid: string) => void;
 };
@@ -31,9 +32,10 @@ export async function leaveTrip(
   tripid: string,
   deps: LeaveTripDeps
 ): Promise<LeaveTripResult> {
+  const roster = await deps.getTravellers(tripid);
   const plan = planTripLeave({
     tripHistory: deps.tripHistory,
-    roster: deps.roster,
+    roster,
     openBalances: deps.openBalances ?? [],
     activeTripId: deps.activeTripId,
     tripid,

--- a/TravelCostApp/util/plan-trip-leave.ts
+++ b/TravelCostApp/util/plan-trip-leave.ts
@@ -1,0 +1,55 @@
+import type { Traveller } from "./traveler";
+
+export type TripLeaveMode = "leave" | "cascadeDelete";
+
+export type TripLeaveWarning = "openBalances" | "permanentDelete";
+
+export type PlanTripLeaveInput = {
+  tripHistory: readonly string[];
+  roster: readonly Pick<Traveller, "uid">[];
+  /** Non-empty when the leaver has unresolved Balances on this trip. */
+  openBalances: readonly unknown[];
+  activeTripId: string | null | undefined;
+  tripid: string;
+};
+
+export type PlanTripLeaveResult = {
+  allowed: boolean;
+  mode: TripLeaveMode;
+  nextActiveTripId: string | null;
+  warnings: TripLeaveWarning[];
+};
+
+/**
+ * Pure Leave trip planner: last-trip guard, plain vs cascade mode,
+ * Active trip promotion target, and warning flags. No I/O.
+ */
+export function planTripLeave(input: PlanTripLeaveInput): PlanTripLeaveResult {
+  const { tripHistory, roster, openBalances, activeTripId, tripid } = input;
+
+  const mode: TripLeaveMode =
+    roster.length <= 1 ? "cascadeDelete" : "leave";
+
+  const warnings: TripLeaveWarning[] = [];
+  if (mode === "cascadeDelete") {
+    warnings.push("permanentDelete");
+  }
+  if (openBalances.length > 0) {
+    warnings.push("openBalances");
+  }
+
+  const allowed = tripHistory.length > 1;
+
+  let nextActiveTripId: string | null = null;
+  if (allowed && activeTripId === tripid) {
+    nextActiveTripId =
+      tripHistory.find((id) => id !== tripid) ?? null;
+  }
+
+  return {
+    allowed,
+    mode,
+    nextActiveTripId,
+    warnings,
+  };
+}


### PR DESCRIPTION
## Summary
- Add pure `planTripLeave` planner (last-trip guard, leave vs cascade, Active trip promotion target, warnings) with exhaustive unit tests
- Wire plain leave: `removeTravelerFromTrip` + `removeTripFromHistory` HTTP, `TripContext.leaveTrip`, UserContext history/MMKV removal, TripForm Leave button (hidden on last trip; offline connect message)
- Rename i18n `deleteTrip` → `leaveTrip` (+ sure/connect keys) in EN/DE/FR/RU

## Test plan
- [ ] Unit: `pnpm test -- __tests__/util/plan-trip-leave.test.ts`
- [ ] Leave a non-active budget that still has other nomads → disappears from My Budgets; others keep expenses/splits
- [ ] Only one budget → Leave button hidden
- [ ] Offline → Leave shows connect-required alert; no queue write
- [ ] Confirm dialog uses leave-oriented copy

Closes #316