### PR TITLE
Leave trip — slice 2: active-trip promotion on leave

### DIFF
--- a/TravelCostApp/__tests__/util/leave-trip.test.ts
+++ b/TravelCostApp/__tests__/util/leave-trip.test.ts
@@ -215,6 +215,42 @@ describe("leaveTrip Active trip promotion", () => {
     expect(after.expensesState).toEqual(before.expensesState);
     expect(after.expensesCache).toEqual(before.expensesCache);
   });
+
+  it("promotes before leave writes so a failed activate does not orphan Active trip", async () => {
+    const removeFromTripHistoryLocal = jest.fn();
+    const probe = createActivateProbe("trip-a");
+    const previousTrip: TripData = {
+      tripid: "trip-a",
+      tripName: "Old active",
+      tripCurrency: "EUR",
+    };
+    const previousExpenses = [expense("e-old", "from old active")];
+    probe.activate.previousTripSnapshot = previousTrip;
+    probe.activate.previousExpensesSnapshot = previousExpenses;
+    probe.activate.setExpensesCache = () => {
+      throw new Error("cache write failed");
+    };
+
+    await expect(
+      leaveTrip("trip-a", {
+        uid: "u1",
+        tripHistory: ["trip-a", "trip-b"],
+        activeTripId: "trip-a",
+        getTravellers: async () => multiTravellerRoster(),
+        removeFromTripHistoryLocal,
+        activate: probe.activate,
+      })
+    ).rejects.toThrow("cache write failed");
+
+    expect(removeTravelerFromTripMock).not.toHaveBeenCalled();
+    expect(removeTripFromHistoryMock).not.toHaveBeenCalled();
+    expect(removeFromTripHistoryLocal).not.toHaveBeenCalled();
+
+    const mirrors = probe.mirrors();
+    expect(mirrors.secureCurrentTripId).toBe("trip-a");
+    expect(mirrors.serverCurrentTrip).toBe("trip-a");
+    expect(mirrors.contextTripid).toBe("trip-a");
+  });
 });
 
 describe("leaveTrip Active trip promotion wiring", () => {

--- a/TravelCostApp/__tests__/util/leave-trip.test.ts
+++ b/TravelCostApp/__tests__/util/leave-trip.test.ts
@@ -3,6 +3,10 @@ jest.mock("../../util/http", () => ({
   removeTripFromHistory: jest.fn(async () => undefined),
 }));
 
+import type { ExpenseData } from "../../util/expense";
+import type { Traveller } from "../../util/traveler";
+import type { TripData } from "../../types/trip";
+import type { ActivateTripDeps } from "../../util/activate-trip";
 import { leaveTrip } from "../../util/leave-trip";
 import {
   removeTravelerFromTrip,
@@ -16,6 +20,95 @@ const removeTripFromHistoryMock = removeTripFromHistory as jest.MockedFunction<
   typeof removeTripFromHistory
 >;
 
+function expense(id: string, description: string): ExpenseData {
+  return {
+    id,
+    description,
+    amount: 10,
+    date: new Date("2026-01-02"),
+    category: "food",
+    currency: "EUR",
+    uid: "u1",
+  } as ExpenseData;
+}
+
+function tripB(): TripData {
+  return {
+    tripid: "trip-b",
+    tripName: "Portugal",
+    totalBudget: "800",
+    dailyBudget: "40",
+    tripCurrency: "EUR",
+    travellers: [],
+    startDate: "2026-02-01",
+    endDate: "2026-02-10",
+    isDynamicDailyBudget: false,
+  };
+}
+
+function multiTravellerRoster(): Traveller[] {
+  return [
+    { uid: "u1", userName: "Alice" },
+    { uid: "u2", userName: "Bob" },
+  ];
+}
+
+/** In-memory Active trip mirrors for asserting promotion consistency. */
+function createActivateProbe(initialActiveId: string) {
+  let secureCurrentTripId: string | null = initialActiveId;
+  let serverCurrentTrip: string | null = initialActiveId;
+  let contextTrip: TripData | null = {
+    tripid: initialActiveId,
+    tripName: "Old active",
+    tripCurrency: "EUR",
+  };
+  let expensesState: ExpenseData[] = [expense("e-old", "from old active")];
+  let expensesCache: ExpenseData[] = [...expensesState];
+  const promotedExpenses = [expense("e-b1", "pastel de nata")];
+
+  const activate: Omit<ActivateTripDeps, "uid"> = {
+    fetchTrip: async (tripid) => {
+      if (tripid === "trip-b") return tripB();
+      throw new Error(`unexpected trip ${tripid}`);
+    },
+    getTravellers: async () => multiTravellerRoster(),
+    getAllExpenses: async () => promotedExpenses,
+    updateUser: async (_uid, data) => {
+      serverCurrentTrip = data.currentTrip ?? serverCurrentTrip;
+    },
+    secureStoreGetItem: async (key) =>
+      key === "currentTripId" ? secureCurrentTripId : null,
+    secureStoreSetItem: async (key, value) => {
+      if (key === "currentTripId") secureCurrentTripId = value;
+    },
+    setCurrentTrip: async (tripid, trip) => {
+      contextTrip = { ...trip, tripid };
+    },
+    saveTripDataInStorage: async () => {},
+    saveTravellersInStorage: async () => {},
+    setExpenses: (expenses) => {
+      expensesState = expenses;
+    },
+    setExpensesCache: (expenses) => {
+      expensesCache = expenses;
+    },
+    setFreshlyCreatedTo: async () => {},
+  };
+
+  return {
+    activate,
+    mirrors: () => ({
+      secureCurrentTripId,
+      serverCurrentTrip,
+      contextTripid: contextTrip?.tripid ?? null,
+      contextTripName: contextTrip?.tripName ?? null,
+      expensesState,
+      expensesCache,
+    }),
+    promotedExpenses,
+  };
+}
+
 describe("leaveTrip plain leave", () => {
   beforeEach(() => {
     removeTravelerFromTripMock.mockClear();
@@ -24,10 +117,7 @@ describe("leaveTrip plain leave", () => {
 
   it("loads the Traveller roster before planning so a non-active leave can run", async () => {
     const removeFromTripHistoryLocal = jest.fn();
-    const getTravellers = jest.fn(async () => [
-      { uid: "u1", userName: "Alice" },
-      { uid: "u2", userName: "Bob" },
-    ]);
+    const getTravellers = jest.fn(async () => multiTravellerRoster());
 
     const result = await leaveTrip("trip-b", {
       uid: "u1",
@@ -40,6 +130,7 @@ describe("leaveTrip plain leave", () => {
     expect(getTravellers).toHaveBeenCalledWith("trip-b");
     expect(result.performed).toBe(true);
     expect(result.mode).toBe("leave");
+    expect(result.nextActiveTripId).toBeNull();
     expect(removeTravelerFromTripMock).toHaveBeenCalledWith("trip-b", "u1");
     expect(removeTripFromHistoryMock).toHaveBeenCalledWith("u1", "trip-b");
     expect(removeFromTripHistoryLocal).toHaveBeenCalledWith("trip-b");
@@ -64,5 +155,78 @@ describe("leaveTrip plain leave", () => {
     expect(removeTravelerFromTripMock).not.toHaveBeenCalled();
     expect(removeTripFromHistoryMock).not.toHaveBeenCalled();
     expect(removeFromTripHistoryLocal).not.toHaveBeenCalled();
+  });
+});
+
+describe("leaveTrip Active trip promotion", () => {
+  beforeEach(() => {
+    removeTravelerFromTripMock.mockClear();
+    removeTripFromHistoryMock.mockClear();
+  });
+
+  it("promotes the first remaining Trip history id via activateTrip when leaving the Active trip", async () => {
+    const removeFromTripHistoryLocal = jest.fn();
+    const probe = createActivateProbe("trip-a");
+
+    const result = await leaveTrip("trip-a", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b", "trip-c"],
+      activeTripId: "trip-a",
+      getTravellers: async () => multiTravellerRoster(),
+      removeFromTripHistoryLocal,
+      activate: probe.activate,
+    });
+
+    expect(result.performed).toBe(true);
+    expect(result.nextActiveTripId).toBe("trip-b");
+    expect(result.promotedTripName).toBe("Portugal");
+
+    const mirrors = probe.mirrors();
+    expect(mirrors.secureCurrentTripId).toBe("trip-b");
+    expect(mirrors.serverCurrentTrip).toBe("trip-b");
+    expect(mirrors.contextTripid).toBe("trip-b");
+    expect(mirrors.contextTripName).toBe("Portugal");
+    expect(mirrors.expensesState).toEqual(probe.promotedExpenses);
+    expect(mirrors.expensesCache).toEqual(probe.promotedExpenses);
+  });
+
+  it("does not change the Active trip or its expenses when leaving a non-active trip", async () => {
+    const removeFromTripHistoryLocal = jest.fn();
+    const probe = createActivateProbe("trip-a");
+    const before = probe.mirrors();
+
+    const result = await leaveTrip("trip-c", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b", "trip-c"],
+      activeTripId: "trip-a",
+      getTravellers: async () => multiTravellerRoster(),
+      removeFromTripHistoryLocal,
+      activate: probe.activate,
+    });
+
+    expect(result.performed).toBe(true);
+    expect(result.nextActiveTripId).toBeNull();
+    expect(result.promotedTripName).toBeNull();
+
+    const after = probe.mirrors();
+    expect(after.secureCurrentTripId).toBe(before.secureCurrentTripId);
+    expect(after.serverCurrentTrip).toBe(before.serverCurrentTrip);
+    expect(after.contextTripid).toBe(before.contextTripid);
+    expect(after.expensesState).toEqual(before.expensesState);
+    expect(after.expensesCache).toEqual(before.expensesCache);
+  });
+});
+
+describe("leaveTrip Active trip promotion wiring", () => {
+  it("TripForm leave path promotes via leaveTrip activate deps (activateTrip seam)", () => {
+    const { readFileSync } = require("fs") as typeof import("fs");
+    const { join } = require("path") as typeof import("path");
+    const src = readFileSync(
+      join(__dirname, "../../components/ManageTrip/TripForm.tsx"),
+      "utf8"
+    );
+    expect(src).toMatch(/activate:\s*\{/);
+    expect(src).toMatch(/leaveTripNowShowing/);
+    expect(src).toMatch(/result\.nextActiveTripId/);
   });
 });

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -298,6 +298,23 @@ const TripForm = ({ navigation, route }) => {
         getTravellers,
         openBalances: [],
         removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
+        activate: {
+          previousTripSnapshot: tripCtx.getcurrentTrip(),
+          previousExpensesSnapshot: expenseCtx.expenses,
+          fetchTrip,
+          getTravellers,
+          getAllExpenses,
+          updateUser,
+          secureStoreGetItem,
+          secureStoreSetItem,
+          setCurrentTrip: tripCtx.setCurrentTrip,
+          saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+          saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+          setExpenses: expenseCtx.setExpenses,
+          setExpensesCache: (nextExpenses) =>
+            setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+          setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
+        },
       });
 
       Toast.hide();
@@ -308,6 +325,14 @@ const TripForm = ({ navigation, route }) => {
           type: "error",
         });
         return;
+      }
+      if (result.nextActiveTripId) {
+        Toast.show({
+          type: "success",
+          text1: i18n.t("leaveTripNowShowing", {
+            name: result.promotedTripName || i18n.t("trip"),
+          }),
+        });
       }
       navigation.pop();
     } catch (error) {

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -199,6 +199,7 @@ const en = {
   leaveTrip: "Leave budget",
   leaveTripSure: "Are you sure you want to leave this budget? Your past expenses stay for the remaining nomads.",
   leaveTripConnectRequired: "Connect to the internet to leave this budget.",
+  leaveTripNowShowing: "Now showing %{name}",
   setActive: "Set as active budget",
   datePickerLabel: "Start and end dates",
 
@@ -806,6 +807,7 @@ const de = {
     "Möchtest du dieses Budget wirklich verlassen? Deine bisherigen Ausgaben bleiben für die anderen Nomaden erhalten.",
   leaveTripConnectRequired:
     "Verbinde dich mit dem Internet, um dieses Budget zu verlassen.",
+  leaveTripNowShowing: "Jetzt angezeigt: %{name}",
   setActive: "Als aktives Budget markieren",
   datePickerLabel: "Start- und Enddatum",
 
@@ -1445,6 +1447,7 @@ const fr = {
     "Voulez-vous vraiment quitter ce budget ? Vos dépenses passées restent pour les autres nomades.",
   leaveTripConnectRequired:
     "Connectez-vous à internet pour quitter ce budget.",
+  leaveTripNowShowing: "Affichage de %{name}",
   setActive: "Définir comme budget actif",
   datePickerLabel: "Dates de début et de fin",
 
@@ -2074,6 +2077,7 @@ const ru = {
     "Вы уверены, что хотите покинуть этот бюджет? Ваши прошлые расходы останутся для остальных номадов.",
   leaveTripConnectRequired:
     "Подключитесь к интернету, чтобы покинуть этот бюджет.",
+  leaveTripNowShowing: "Сейчас показан: %{name}",
   setActive: "Сделать активным бюджетом",
   datePickerLabel: "Даты начала и окончания",
 

--- a/TravelCostApp/store/trip-context.tsx
+++ b/TravelCostApp/store/trip-context.tsx
@@ -86,6 +86,7 @@ export const TripContext = createContext<TripContextType>({
     nextActiveTripId: null,
     warnings: [],
     performed: false,
+    promotedTripName: null,
   }),
   getcurrentTrip: () => {
     const tripData = {} as TripData;

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -57,28 +57,26 @@ export async function leaveTrip(
     return { ...plan, performed: false, promotedTripName: null };
   }
 
+  let promotedTripName: string | null = null;
+
+  // Promote first when leaving the Active trip so a failed activateTrip does
+  // not leave the User without a valid Active trip after roster/history writes.
+  if (plan.nextActiveTripId) {
+    if (!deps.activate) {
+      throw new Error(
+        "leaveTrip: activate deps required to promote Active trip"
+      );
+    }
+    const { tripData } = await activateTrip(plan.nextActiveTripId, {
+      uid: deps.uid,
+      ...deps.activate,
+    });
+    promotedTripName = tripData.tripName ?? null;
+  }
+
   await removeTravelerFromTrip(tripid, deps.uid);
   await removeTripFromHistoryRemote(deps.uid, tripid);
   deps.removeFromTripHistoryLocal(tripid);
 
-  if (!plan.nextActiveTripId) {
-    return { ...plan, performed: true, promotedTripName: null };
-  }
-
-  if (!deps.activate) {
-    throw new Error(
-      "leaveTrip: activate deps required to promote Active trip"
-    );
-  }
-
-  const { tripData } = await activateTrip(plan.nextActiveTripId, {
-    uid: deps.uid,
-    ...deps.activate,
-  });
-
-  return {
-    ...plan,
-    performed: true,
-    promotedTripName: tripData.tripName ?? null,
-  };
+  return { ...plan, performed: true, promotedTripName };
 }

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -3,6 +3,10 @@ import {
   removeTripFromHistory as removeTripFromHistoryRemote,
 } from "./http";
 import {
+  activateTrip,
+  type ActivateTripDeps,
+} from "./activate-trip";
+import {
   planTripLeave,
   type PlanTripLeaveResult,
 } from "./plan-trip-leave";
@@ -17,16 +21,24 @@ export type LeaveTripDeps = {
   getTravellers: (tripid: string) => Promise<Traveller[]>;
   /** Update Trip history state + local cache after a successful leave. */
   removeFromTripHistoryLocal: (tripid: string) => void;
+  /**
+   * Active trip promotion deps (sans uid). Used when leaving the Active trip
+   * so `nextActiveTripId` is promoted through `activateTrip`.
+   */
+  activate?: Omit<ActivateTripDeps, "uid">;
 };
 
 export type LeaveTripResult = PlanTripLeaveResult & {
   /** True when roster + Trip history writes ran (plain leave only). */
   performed: boolean;
+  /** Trip name after Active trip promotion; null when no promotion ran. */
+  promotedTripName: string | null;
 };
 
 /**
- * Leave trip orchestration for the plain-leave path.
- * Cascade-delete and Active trip promotion are planned but not executed here.
+ * Leave trip orchestration for the plain-leave path, including Active trip
+ * promotion via `activateTrip` when the left trip was active.
+ * Cascade-delete is planned but not executed here.
  */
 export async function leaveTrip(
   tripid: string,
@@ -42,12 +54,31 @@ export async function leaveTrip(
   });
 
   if (!plan.allowed || plan.mode !== "leave") {
-    return { ...plan, performed: false };
+    return { ...plan, performed: false, promotedTripName: null };
   }
 
   await removeTravelerFromTrip(tripid, deps.uid);
   await removeTripFromHistoryRemote(deps.uid, tripid);
   deps.removeFromTripHistoryLocal(tripid);
 
-  return { ...plan, performed: true };
+  if (!plan.nextActiveTripId) {
+    return { ...plan, performed: true, promotedTripName: null };
+  }
+
+  if (!deps.activate) {
+    throw new Error(
+      "leaveTrip: activate deps required to promote Active trip"
+    );
+  }
+
+  const { tripData } = await activateTrip(plan.nextActiveTripId, {
+    uid: deps.uid,
+    ...deps.activate,
+  });
+
+  return {
+    ...plan,
+    performed: true,
+    promotedTripName: tripData.tripName ?? null,
+  };
 }


### PR DESCRIPTION
## Summary
- After a plain leave of the **Active trip**, promote `planTripLeave`'s `nextActiveTripId` through `activateTrip` so secure `currentTripId`, server `currentTrip`, and `TripContext` stay aligned and the new trip's expenses load
- Leaving a non-active trip leaves the Active trip and its expenses untouched
- Toast notifies the user which budget is now showing (`leaveTripNowShowing` EN/DE/FR/RU)

## Test plan
- [ ] Unit: `pnpm test -- __tests__/util/leave-trip.test.ts`
- [ ] Leave the Active budget (with ≥2 budgets, other nomads remain) → another budget becomes active; toast shows its name; ledger matches the promoted budget
- [ ] Leave a non-active budget → Active budget and its expenses unchanged
- [ ] Offline leave still blocked (unchanged from #316)

Closes #317