### PR TITLE
Leave trip — slice 3: Undo toast for plain leave

### DIFF
--- a/TravelCostApp/__tests__/util/leave-trip.test.ts
+++ b/TravelCostApp/__tests__/util/leave-trip.test.ts
@@ -1,16 +1,38 @@
+let mockLastToastOnHide: (() => void) | undefined;
+
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn((args) => {
+    mockLastToastOnHide = args.onHide;
+  }),
+  hide: jest.fn(() => {
+    mockLastToastOnHide?.();
+  }),
+}));
+
 jest.mock("../../util/http", () => ({
   removeTravelerFromTrip: jest.fn(async () => ({ status: 200 })),
   removeTripFromHistory: jest.fn(async () => undefined),
+  putTravelerInTrip: jest.fn(async () => ({})),
+  storeTripHistory: jest.fn(async () => undefined),
 }));
 
+import Toast from "react-native-toast-message";
+import { i18n } from "../../i18n/i18n";
 import type { ExpenseData } from "../../util/expense";
 import type { Traveller } from "../../util/traveler";
 import type { TripData } from "../../types/trip";
 import type { ActivateTripDeps } from "../../util/activate-trip";
-import { leaveTrip } from "../../util/leave-trip";
 import {
+  UNDO_LEAVE_WINDOW_MS,
+  clearPendingUndoLeave,
+  leaveTrip,
+  undoLeaveTrip,
+} from "../../util/leave-trip";
+import {
+  putTravelerInTrip,
   removeTravelerFromTrip,
   removeTripFromHistory,
+  storeTripHistory,
 } from "../../util/http";
 
 const removeTravelerFromTripMock = removeTravelerFromTrip as jest.MockedFunction<
@@ -18,6 +40,12 @@ const removeTravelerFromTripMock = removeTravelerFromTrip as jest.MockedFunction
 >;
 const removeTripFromHistoryMock = removeTripFromHistory as jest.MockedFunction<
   typeof removeTripFromHistory
+>;
+const putTravelerInTripMock = putTravelerInTrip as jest.MockedFunction<
+  typeof putTravelerInTrip
+>;
+const storeTripHistoryMock = storeTripHistory as jest.MockedFunction<
+  typeof storeTripHistory
 >;
 
 function expense(id: string, description: string): ExpenseData {
@@ -111,12 +139,20 @@ function createActivateProbe(initialActiveId: string) {
 
 describe("leaveTrip plain leave", () => {
   beforeEach(() => {
-    removeTravelerFromTripMock.mockClear();
-    removeTripFromHistoryMock.mockClear();
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockLastToastOnHide = undefined;
+    clearPendingUndoLeave();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    clearPendingUndoLeave();
   });
 
   it("loads the Traveller roster before planning so a non-active leave can run", async () => {
     const removeFromTripHistoryLocal = jest.fn();
+    const restoreTripHistoryLocal = jest.fn();
     const getTravellers = jest.fn(async () => multiTravellerRoster());
 
     const result = await leaveTrip("trip-b", {
@@ -125,6 +161,7 @@ describe("leaveTrip plain leave", () => {
       activeTripId: "trip-a",
       getTravellers,
       removeFromTripHistoryLocal,
+      restoreTripHistoryLocal,
     });
 
     expect(getTravellers).toHaveBeenCalledWith("trip-b");
@@ -138,6 +175,7 @@ describe("leaveTrip plain leave", () => {
 
   it("does not write when the planner refuses plain leave", async () => {
     const removeFromTripHistoryLocal = jest.fn();
+    const restoreTripHistoryLocal = jest.fn();
     const getTravellers = jest.fn(async () => [
       { uid: "u1", userName: "Alice" },
     ]);
@@ -148,6 +186,7 @@ describe("leaveTrip plain leave", () => {
       activeTripId: "trip-a",
       getTravellers,
       removeFromTripHistoryLocal,
+      restoreTripHistoryLocal,
     });
 
     expect(result.performed).toBe(false);
@@ -156,12 +195,53 @@ describe("leaveTrip plain leave", () => {
     expect(removeTripFromHistoryMock).not.toHaveBeenCalled();
     expect(removeFromTripHistoryLocal).not.toHaveBeenCalled();
   });
+
+  it("shows a deletedExpense Undo toast after a plain leave", async () => {
+    await leaveTrip("trip-b", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers: async () => multiTravellerRoster(),
+      removeFromTripHistoryLocal: jest.fn(),
+      restoreTripHistoryLocal: jest.fn(),
+    });
+
+    const undoToast = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "deletedExpense"
+    );
+    expect(undoToast).toBeDefined();
+    expect(undoToast![0].visibilityTime).toBe(UNDO_LEAVE_WINDOW_MS);
+    expect(undoToast![0].props?.onUndo).toEqual(expect.any(Function));
+  });
+
+  it("does not show an Undo toast for cascade-delete planning", async () => {
+    await leaveTrip("trip-b", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers: async () => [{ uid: "u1", userName: "Alice" }],
+      removeFromTripHistoryLocal: jest.fn(),
+      restoreTripHistoryLocal: jest.fn(),
+    });
+
+    const undoToast = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "deletedExpense"
+    );
+    expect(undoToast).toBeUndefined();
+  });
 });
 
 describe("leaveTrip Active trip promotion", () => {
   beforeEach(() => {
-    removeTravelerFromTripMock.mockClear();
-    removeTripFromHistoryMock.mockClear();
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockLastToastOnHide = undefined;
+    clearPendingUndoLeave();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    clearPendingUndoLeave();
   });
 
   it("promotes the first remaining Trip history id via activateTrip when leaving the Active trip", async () => {
@@ -174,6 +254,7 @@ describe("leaveTrip Active trip promotion", () => {
       activeTripId: "trip-a",
       getTravellers: async () => multiTravellerRoster(),
       removeFromTripHistoryLocal,
+      restoreTripHistoryLocal: jest.fn(),
       activate: probe.activate,
     });
 
@@ -201,6 +282,7 @@ describe("leaveTrip Active trip promotion", () => {
       activeTripId: "trip-a",
       getTravellers: async () => multiTravellerRoster(),
       removeFromTripHistoryLocal,
+      restoreTripHistoryLocal: jest.fn(),
       activate: probe.activate,
     });
 
@@ -238,6 +320,7 @@ describe("leaveTrip Active trip promotion", () => {
         activeTripId: "trip-a",
         getTravellers: async () => multiTravellerRoster(),
         removeFromTripHistoryLocal,
+        restoreTripHistoryLocal: jest.fn(),
         activate: probe.activate,
       })
     ).rejects.toThrow("cache write failed");
@@ -254,7 +337,7 @@ describe("leaveTrip Active trip promotion", () => {
 });
 
 describe("leaveTrip Active trip promotion wiring", () => {
-  it("TripForm leave path promotes via leaveTrip activate deps (activateTrip seam)", () => {
+  it("TripForm leave path wires activate + Trip history restore for Undo", () => {
     const { readFileSync } = require("fs") as typeof import("fs");
     const { join } = require("path") as typeof import("path");
     const src = readFileSync(
@@ -262,7 +345,126 @@ describe("leaveTrip Active trip promotion wiring", () => {
       "utf8"
     );
     expect(src).toMatch(/activate:\s*\{/);
+    expect(src).toMatch(/restoreTripHistoryLocal/);
+    expect(src).toMatch(/removeFromTripHistoryLocal/);
+  });
+
+  it("leaveTrip owns Undo toast copy for plain leave and promotion", () => {
+    const { readFileSync } = require("fs") as typeof import("fs");
+    const { join } = require("path") as typeof import("path");
+    const src = readFileSync(
+      join(__dirname, "../../util/leave-trip.ts"),
+      "utf8"
+    );
+    expect(src).toMatch(/toastLeftTrip1/);
     expect(src).toMatch(/leaveTripNowShowing/);
-    expect(src).toMatch(/result\.nextActiveTripId/);
+    expect(src).toMatch(/type:\s*"deletedExpense"/);
+  });
+});
+
+describe("undoLeaveTrip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockLastToastOnHide = undefined;
+    clearPendingUndoLeave();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    clearPendingUndoLeave();
+  });
+
+  it("restores the Traveller roster entry and Trip history when Undo is pressed in time", async () => {
+    const restoreTripHistoryLocal = jest.fn();
+    const previousHistory = ["trip-a", "trip-b"];
+
+    await leaveTrip("trip-b", {
+      uid: "u1",
+      tripHistory: previousHistory,
+      activeTripId: "trip-a",
+      getTravellers: async () => multiTravellerRoster(),
+      removeFromTripHistoryLocal: jest.fn(),
+      restoreTripHistoryLocal,
+    });
+
+    const { onUndo } = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "deletedExpense"
+    )![0].props;
+
+    await onUndo();
+
+    expect(putTravelerInTripMock).toHaveBeenCalledWith("trip-b", {
+      uid: "u1",
+      userName: "Alice",
+    });
+    expect(storeTripHistoryMock).toHaveBeenCalledWith("u1", previousHistory);
+    expect(restoreTripHistoryLocal).toHaveBeenCalledWith(previousHistory);
+  });
+
+  it("restores the previously Active trip when leave had promoted another", async () => {
+    const probe = createActivateProbe("trip-a");
+    // After leave, Active trip is trip-b; Undo must re-activate trip-a.
+    probe.activate.fetchTrip = async (tripid) => {
+      if (tripid === "trip-b") return tripB();
+      if (tripid === "trip-a") {
+        return {
+          tripid: "trip-a",
+          tripName: "Old active",
+          tripCurrency: "EUR",
+        };
+      }
+      throw new Error(`unexpected trip ${tripid}`);
+    };
+
+    await leaveTrip("trip-a", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b", "trip-c"],
+      activeTripId: "trip-a",
+      getTravellers: async () => multiTravellerRoster(),
+      removeFromTripHistoryLocal: jest.fn(),
+      restoreTripHistoryLocal: jest.fn(),
+      activate: probe.activate,
+    });
+
+    expect(probe.mirrors().secureCurrentTripId).toBe("trip-b");
+
+    const { onUndo } = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "deletedExpense"
+    )![0].props;
+
+    await onUndo();
+
+    const mirrors = probe.mirrors();
+    expect(mirrors.secureCurrentTripId).toBe("trip-a");
+    expect(mirrors.serverCurrentTrip).toBe("trip-a");
+    expect(mirrors.contextTripid).toBe("trip-a");
+  });
+
+  it("shows expired copy when Undo is pressed after the window", async () => {
+    await leaveTrip("trip-b", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers: async () => multiTravellerRoster(),
+      removeFromTripHistoryLocal: jest.fn(),
+      restoreTripHistoryLocal: jest.fn(),
+    });
+
+    const { actionId } = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "deletedExpense"
+    )![0].props;
+
+    jest.advanceTimersByTime(UNDO_LEAVE_WINDOW_MS + 1);
+
+    await undoLeaveTrip({ actionId });
+
+    expect(putTravelerInTripMock).not.toHaveBeenCalled();
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        text2: i18n.t("toastUndoLeaveExpired"),
+      })
+    );
   });
 });

--- a/TravelCostApp/__tests__/util/leave-trip.test.ts
+++ b/TravelCostApp/__tests__/util/leave-trip.test.ts
@@ -210,8 +210,31 @@ describe("leaveTrip plain leave", () => {
       ([args]) => args.type === "deletedExpense"
     );
     expect(undoToast).toBeDefined();
+    expect(undoToast![0].text1).toBe(i18n.t("toastLeftTrip1"));
+    expect(undoToast![0].text2).toBe(i18n.t("toastLeftTrip2"));
     expect(undoToast![0].visibilityTime).toBe(UNDO_LEAVE_WINDOW_MS);
     expect(undoToast![0].props?.onUndo).toEqual(expect.any(Function));
+  });
+
+  it("Undo toast text1 names the promoted Active trip after leaving Active trip", async () => {
+    const probe = createActivateProbe("trip-a");
+
+    await leaveTrip("trip-a", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers: async () => multiTravellerRoster(),
+      removeFromTripHistoryLocal: jest.fn(),
+      restoreTripHistoryLocal: jest.fn(),
+      activate: probe.activate,
+    });
+
+    const undoToast = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "deletedExpense"
+    );
+    expect(undoToast![0].text1).toBe(
+      i18n.t("leaveTripNowShowing", { name: "Portugal" })
+    );
   });
 
   it("does not show an Undo toast for cascade-delete planning", async () => {
@@ -439,6 +462,36 @@ describe("undoLeaveTrip", () => {
     expect(mirrors.secureCurrentTripId).toBe("trip-a");
     expect(mirrors.serverCurrentTrip).toBe("trip-a");
     expect(mirrors.contextTripid).toBe("trip-a");
+  });
+
+  it("does not restore Trip history when roster restore fails", async () => {
+    const restoreTripHistoryLocal = jest.fn();
+    putTravelerInTripMock.mockResolvedValueOnce(null);
+
+    await leaveTrip("trip-b", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers: async () => multiTravellerRoster(),
+      removeFromTripHistoryLocal: jest.fn(),
+      restoreTripHistoryLocal,
+    });
+
+    const { onUndo } = (Toast.show as jest.Mock).mock.calls.find(
+      ([args]) => args.type === "deletedExpense"
+    )![0].props;
+
+    await onUndo();
+
+    expect(putTravelerInTripMock).toHaveBeenCalled();
+    expect(storeTripHistoryMock).not.toHaveBeenCalled();
+    expect(restoreTripHistoryLocal).not.toHaveBeenCalled();
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        text2: i18n.t("error2"),
+      })
+    );
   });
 
   it("shows expired copy when Undo is pressed after the window", async () => {

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -298,6 +298,7 @@ const TripForm = ({ navigation, route }) => {
         getTravellers,
         openBalances: [],
         removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
+        restoreTripHistoryLocal: userCtx.restoreTripHistory,
         activate: {
           previousTripSnapshot: tripCtx.getcurrentTrip(),
           previousExpensesSnapshot: expenseCtx.expenses,
@@ -317,8 +318,8 @@ const TripForm = ({ navigation, route }) => {
         },
       });
 
-      Toast.hide();
       if (!result.performed) {
+        Toast.hide();
         Toast.show({
           text1: i18n.t("toastSavingError1"),
           text2: i18n.t("error2"),
@@ -326,14 +327,7 @@ const TripForm = ({ navigation, route }) => {
         });
         return;
       }
-      if (result.nextActiveTripId) {
-        Toast.show({
-          type: "success",
-          text1: i18n.t("leaveTripNowShowing", {
-            name: result.promotedTripName || i18n.t("trip"),
-          }),
-        });
-      }
+      // leaveTrip shows the Undo toast (and hides the loading toast).
       navigation.pop();
     } catch (error) {
       safeLogError(error);

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -200,6 +200,9 @@ const en = {
   leaveTripSure: "Are you sure you want to leave this budget? Your past expenses stay for the remaining nomads.",
   leaveTripConnectRequired: "Connect to the internet to leave this budget.",
   leaveTripNowShowing: "Now showing %{name}",
+  toastLeftTrip1: "Left budget",
+  toastLeftTrip2: "You can undo this action",
+  toastUndoLeaveExpired: "Undo is no longer available for this leave.",
   setActive: "Set as active budget",
   datePickerLabel: "Start and end dates",
 
@@ -808,6 +811,10 @@ const de = {
   leaveTripConnectRequired:
     "Verbinde dich mit dem Internet, um dieses Budget zu verlassen.",
   leaveTripNowShowing: "Jetzt angezeigt: %{name}",
+  toastLeftTrip1: "Budget verlassen",
+  toastLeftTrip2: "Du kannst diese Aktion rückgängig machen",
+  toastUndoLeaveExpired:
+    "Rückgängig machen ist für dieses Verlassen nicht mehr möglich.",
   setActive: "Als aktives Budget markieren",
   datePickerLabel: "Start- und Enddatum",
 
@@ -1448,6 +1455,10 @@ const fr = {
   leaveTripConnectRequired:
     "Connectez-vous à internet pour quitter ce budget.",
   leaveTripNowShowing: "Affichage de %{name}",
+  toastLeftTrip1: "Budget quitté",
+  toastLeftTrip2: "Vous pouvez annuler cette action",
+  toastUndoLeaveExpired:
+    "L'annulation n'est plus disponible pour ce départ.",
   setActive: "Définir comme budget actif",
   datePickerLabel: "Dates de début et de fin",
 
@@ -2078,6 +2089,10 @@ const ru = {
   leaveTripConnectRequired:
     "Подключитесь к интернету, чтобы покинуть этот бюджет.",
   leaveTripNowShowing: "Сейчас показан: %{name}",
+  toastLeftTrip1: "Бюджет покинут",
+  toastLeftTrip2: "Вы можете отменить это действие",
+  toastUndoLeaveExpired:
+    "Отменить выход из бюджета уже нельзя.",
   setActive: "Сделать активным бюджетом",
   datePickerLabel: "Даты начала и окончания",
 

--- a/TravelCostApp/store/user-context.tsx
+++ b/TravelCostApp/store/user-context.tsx
@@ -73,6 +73,8 @@ export type UserContextType = {
   setTripHistory: (tripHistory: string[]) => void;
   /** Remove a trip id from Trip history state + MMKV (Leave trip). */
   removeTripFromHistory: (tripid: string) => void;
+  /** Restore Trip history state + MMKV (Undo leave). */
+  restoreTripHistory: (tripHistory: string[]) => void;
   updateTripHistory: () => void;
   isOnline: boolean;
   setIsOnline: (bool: boolean) => void;
@@ -111,6 +113,7 @@ export const UserContext = createContext<UserContextType>({
   tripHistory: [],
   setTripHistory: (tripHistory: string[]) => {},
   removeTripFromHistory: (_tripid: string) => {},
+  restoreTripHistory: (_tripHistory: string[]) => {},
   updateTripHistory: async () => {},
   isOnline: false,
   setIsOnline: (bool: boolean) => {},
@@ -181,6 +184,11 @@ function UserContextProvider({ children }) {
     const nextHistory = (tripHistory ?? []).filter((id) => id !== tripid);
     setTripHistory(nextHistory);
     setMMKVObject(MMKV_KEYS.TRIP_HISTORY, nextHistory);
+  }
+
+  function restoreTripHistory(history: string[]) {
+    setTripHistory(history);
+    setMMKVObject(MMKV_KEYS.TRIP_HISTORY, history);
   }
   useEffect(() => {
     const storedHistory = getMMKVObject(MMKV_KEYS.TRIP_HISTORY);
@@ -313,6 +321,7 @@ function UserContextProvider({ children }) {
     tripHistory: tripHistory,
     setTripHistory: setTripHistory,
     removeTripFromHistory: removeTripFromHistory,
+    restoreTripHistory: restoreTripHistory,
 
     lastCurrency: lastCurrency,
     setLastCurrency: setLastCurrency,

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -139,7 +139,12 @@ export async function leaveTrip(
   }
 
   const leaver = roster.find((t) => t.uid === deps.uid);
-  const userName = leaver?.userName ?? "";
+  if (!leaver?.userName) {
+    throw new Error(
+      "leaveTrip: Traveller roster entry with userName required for leave"
+    );
+  }
+  const userName = leaver.userName;
   const previousTripHistory = [...deps.tripHistory];
   const previousActiveTripId = plan.nextActiveTripId ? tripid : null;
 
@@ -219,10 +224,13 @@ export async function undoLeaveTrip({
   Toast.hide();
 
   try {
-    await putTravelerInTrip(pending.tripid, {
+    const restored = await putTravelerInTrip(pending.tripid, {
       uid: pending.uid,
       userName: pending.userName,
     });
+    if (restored == null) {
+      throw new Error("undoLeaveTrip: roster restore failed");
+    }
     await storeTripHistory(pending.uid, pending.previousTripHistory);
     pending.restoreTripHistoryLocal(pending.previousTripHistory);
 

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -1,6 +1,10 @@
+import Toast from "react-native-toast-message";
+import { i18n } from "../i18n/i18n";
 import {
+  putTravelerInTrip,
   removeTravelerFromTrip,
   removeTripFromHistory as removeTripFromHistoryRemote,
+  storeTripHistory,
 } from "./http";
 import {
   activateTrip,
@@ -12,6 +16,8 @@ import {
 } from "./plan-trip-leave";
 import type { Traveller } from "./traveler";
 
+export const UNDO_LEAVE_WINDOW_MS = 8000;
+
 export type LeaveTripDeps = {
   uid: string;
   tripHistory: readonly string[];
@@ -21,11 +27,16 @@ export type LeaveTripDeps = {
   getTravellers: (tripid: string) => Promise<Traveller[]>;
   /** Update Trip history state + local cache after a successful leave. */
   removeFromTripHistoryLocal: (tripid: string) => void;
+  /** Restore full Trip history state + local cache after Undo. */
+  restoreTripHistoryLocal: (tripHistory: readonly string[]) => void;
   /**
    * Active trip promotion deps (sans uid). Used when leaving the Active trip
-   * so `nextActiveTripId` is promoted through `activateTrip`.
+   * so `nextActiveTripId` is promoted through `activateTrip`, and again on Undo
+   * to restore the previously Active trip.
    */
   activate?: Omit<ActivateTripDeps, "uid">;
+  /** False to skip Undo toast (e.g. tests that only assert leave writes). Default true. */
+  showUndoToast?: boolean;
 };
 
 export type LeaveTripResult = PlanTripLeaveResult & {
@@ -35,10 +46,80 @@ export type LeaveTripResult = PlanTripLeaveResult & {
   promotedTripName: string | null;
 };
 
+type PendingUndoLeave = {
+  actionId: string;
+  expiresAt: number;
+  tripid: string;
+  uid: string;
+  userName: string;
+  previousTripHistory: string[];
+  /** Set when leave promoted a new Active trip — Undo re-activates this id. */
+  previousActiveTripId: string | null;
+  activate?: Omit<ActivateTripDeps, "uid">;
+  restoreTripHistoryLocal: (tripHistory: readonly string[]) => void;
+};
+
+let pendingUndoLeave: PendingUndoLeave | null = null;
+let undoExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+let dismissToastClearsUndo = true;
+
+export function clearPendingUndoLeave(): void {
+  pendingUndoLeave = null;
+  if (undoExpiryTimer) {
+    clearTimeout(undoExpiryTimer);
+    undoExpiryTimer = null;
+  }
+}
+
+export function isUndoLeaveAvailable(actionId: string): boolean {
+  if (!pendingUndoLeave || pendingUndoLeave.actionId !== actionId) {
+    return false;
+  }
+  return Date.now() < pendingUndoLeave.expiresAt;
+}
+
+function registerPendingUndoLeave(
+  pending: Omit<PendingUndoLeave, "actionId" | "expiresAt">
+): string {
+  clearPendingUndoLeave();
+  dismissToastClearsUndo = true;
+  const actionId = `${Date.now()}-${pending.tripid}-${pending.uid}`;
+  const expiresAt = Date.now() + UNDO_LEAVE_WINDOW_MS;
+  pendingUndoLeave = { ...pending, actionId, expiresAt };
+  undoExpiryTimer = setTimeout(() => {
+    clearPendingUndoLeave();
+  }, UNDO_LEAVE_WINDOW_MS);
+  return actionId;
+}
+
+function showLeftTripToast(
+  actionId: string,
+  text1: string,
+  onUndo: () => Promise<void>
+): void {
+  const dismissUndoScope = () => {
+    if (dismissToastClearsUndo && pendingUndoLeave?.actionId === actionId) {
+      clearPendingUndoLeave();
+    }
+  };
+
+  Toast.show({
+    type: "deletedExpense",
+    text1,
+    text2: i18n.t("toastLeftTrip2"),
+    visibilityTime: UNDO_LEAVE_WINDOW_MS,
+    autoHide: true,
+    onHide: () => {
+      // Undo scope is cleared explicitly via onDismissUndo or the expiry timer.
+    },
+    props: { actionId, onUndo, onDismissUndo: dismissUndoScope },
+  });
+}
+
 /**
  * Leave trip orchestration for the plain-leave path, including Active trip
- * promotion via `activateTrip` when the left trip was active.
- * Cascade-delete is planned but not executed here.
+ * promotion via `activateTrip` when the left trip was active, and an Undo toast
+ * mirroring delete-expense. Cascade-delete is planned but not executed here.
  */
 export async function leaveTrip(
   tripid: string,
@@ -56,6 +137,11 @@ export async function leaveTrip(
   if (!plan.allowed || plan.mode !== "leave") {
     return { ...plan, performed: false, promotedTripName: null };
   }
+
+  const leaver = roster.find((t) => t.uid === deps.uid);
+  const userName = leaver?.userName ?? "";
+  const previousTripHistory = [...deps.tripHistory];
+  const previousActiveTripId = plan.nextActiveTripId ? tripid : null;
 
   let promotedTripName: string | null = null;
 
@@ -78,5 +164,84 @@ export async function leaveTrip(
   await removeTripFromHistoryRemote(deps.uid, tripid);
   deps.removeFromTripHistoryLocal(tripid);
 
-  return { ...plan, performed: true, promotedTripName };
+  const result: LeaveTripResult = {
+    ...plan,
+    performed: true,
+    promotedTripName,
+  };
+
+  if (deps.showUndoToast === false) {
+    return result;
+  }
+
+  Toast.hide();
+
+  const actionId = registerPendingUndoLeave({
+    tripid,
+    uid: deps.uid,
+    userName,
+    previousTripHistory,
+    previousActiveTripId,
+    activate: deps.activate,
+    restoreTripHistoryLocal: deps.restoreTripHistoryLocal,
+  });
+
+  const toastText1 = plan.nextActiveTripId
+    ? i18n.t("leaveTripNowShowing", {
+        name: promotedTripName || i18n.t("trip"),
+      })
+    : i18n.t("toastLeftTrip1");
+
+  showLeftTripToast(actionId, toastText1, () => {
+    dismissToastClearsUndo = false;
+    return undoLeaveTrip({ actionId });
+  });
+
+  return result;
+}
+
+export async function undoLeaveTrip({
+  actionId,
+}: {
+  actionId: string;
+}): Promise<void> {
+  if (!isUndoLeaveAvailable(actionId)) {
+    Toast.show({
+      type: "error",
+      text1: i18n.t("error"),
+      text2: i18n.t("toastUndoLeaveExpired"),
+    });
+    return;
+  }
+
+  const pending = pendingUndoLeave!;
+  clearPendingUndoLeave();
+  Toast.hide();
+
+  try {
+    await putTravelerInTrip(pending.tripid, {
+      uid: pending.uid,
+      userName: pending.userName,
+    });
+    await storeTripHistory(pending.uid, pending.previousTripHistory);
+    pending.restoreTripHistoryLocal(pending.previousTripHistory);
+
+    if (pending.previousActiveTripId) {
+      if (!pending.activate) {
+        throw new Error(
+          "undoLeaveTrip: activate deps required to restore Active trip"
+        );
+      }
+      await activateTrip(pending.previousActiveTripId, {
+        uid: pending.uid,
+        ...pending.activate,
+      });
+    }
+  } catch {
+    Toast.show({
+      type: "error",
+      text1: i18n.t("error"),
+      text2: i18n.t("error2"),
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- After a plain leave (`mode: "leave"`), show an Undo toast styled like the delete-expense flow (`deletedExpense` type)
- Undo restores the Traveller roster entry and Trip history; if leave promoted a new Active trip, Undo re-activates the previously Active trip via `activateTrip`
- Cascade-delete planning still shows no Undo; EN/DE/FR/RU copy for leave Undo toast + expiry

## Test plan
- [ ] Unit: `pnpm test -- __tests__/util/leave-trip.test.ts`
- [ ] Leave a non-active budget (other nomads remain) → Undo toast → Undo restores budget in My Budgets and roster
- [ ] Leave the Active budget → Undo toast shows “Now showing …” → Undo restores the previous Active trip (server + secure storage + context)
- [ ] Dismiss / wait out Undo window → Undo no longer restores
- [ ] Cascade path (sole traveller) still no Undo toast (unchanged; not executed in this slice)

Closes #320