### PR TITLE
Leave trip — slice 4: cascade-delete on empty roster

### DIFF
--- a/TravelCostApp/__tests__/components/trip-form-leave-confirm.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-leave-confirm.test.tsx
@@ -155,10 +155,27 @@ describe("TripForm Leave trip confirm dialog", () => {
     });
   });
 
+  it("surfaces an error alert when roster fetch fails before confirm", async () => {
+    getTravellersMock.mockRejectedValue(new Error("network"));
+
+    const screen = renderEditForm();
+    fireEvent.press(await screen.findByText(i18n.t("leaveTrip")));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("error"),
+        i18n.t("error2")
+      );
+    });
+  });
+
   it("has permanent-delete warning copy in EN/DE/FR/RU", () => {
+    for (const locale of [en, de, fr, ru]) {
+      expect(locale.leaveTripPermanentDeleteSure.length).toBeGreaterThan(10);
+      expect(locale.leaveTripPermanentDeleteSure).not.toBe(
+        locale.leaveTripSure
+      );
+    }
     expect(en.leaveTripPermanentDeleteSure).toMatch(/permanent/i);
-    expect(de.leaveTripPermanentDeleteSure.length).toBeGreaterThan(10);
-    expect(fr.leaveTripPermanentDeleteSure.length).toBeGreaterThan(10);
-    expect(ru.leaveTripPermanentDeleteSure.length).toBeGreaterThan(10);
   });
 });

--- a/TravelCostApp/__tests__/components/trip-form-leave-confirm.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-leave-confirm.test.tsx
@@ -1,0 +1,164 @@
+import * as React from "react";
+import { Alert } from "react-native";
+
+jest.mock("../../util/http", () => ({
+  storeTrip: jest.fn(),
+  storeTripHistory: jest.fn(),
+  updateUser: jest.fn(),
+  fetchTrip: jest.fn(async () => ({
+    tripName: "Japan",
+    tripCurrency: "EUR",
+    dailyBudget: "50",
+    totalBudget: "2000",
+    startDate: "2026-01-01",
+    endDate: "2026-01-10",
+    isDynamicDailyBudget: false,
+    travellers: [],
+  })),
+  updateTripHistory: jest.fn(),
+  updateTrip: jest.fn(),
+  getAllExpenses: jest.fn(async () => []),
+  getTravellers: jest.fn(),
+  putTravelerInTrip: jest.fn(),
+  deleteTrip: jest.fn(),
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+jest.mock("@react-navigation/elements", () => ({
+  useHeaderHeight: () => 0,
+}));
+
+jest.mock("../../components/Currency/CurrencyPicker", () => () => null);
+jest.mock("../../components/UI/DatePickerModal", () => () => null);
+jest.mock("../../components/UI/DatePickerContainer", () => () => null);
+
+jest.mock("../../util/appState", () => ({
+  sleep: jest.fn(async () => {}),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => "u1"),
+  secureStoreSetItem: jest.fn(async () => {}),
+}));
+
+import { fireEvent, waitFor } from "@testing-library/react-native";
+
+import TripForm from "../../components/ManageTrip/TripForm";
+import { i18n } from "../../i18n/i18n";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { getTravellers } from "../../util/http";
+import {
+  de,
+  en,
+  fr,
+  ru,
+} from "../../i18n/supportedLanguages";
+
+const navigation = {
+  navigate: jest.fn(),
+  pop: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+const getTravellersMock = getTravellers as jest.MockedFunction<
+  typeof getTravellers
+>;
+
+describe("TripForm Leave trip confirm dialog", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  function renderEditForm() {
+    return renderWithAppProviders(
+      <TripForm
+        navigation={navigation}
+        route={{ params: { tripId: "trip-b" } }}
+      />,
+      {
+        network: { isConnected: true, strongConnection: true },
+        auth: { uid: "u1" },
+        trip: {
+          tripid: "trip-a",
+          tripName: "Active",
+          leaveTrip: jest.fn(async () => ({
+            allowed: true,
+            mode: "leave",
+            nextActiveTripId: null,
+            warnings: [],
+            performed: true,
+            promotedTripName: null,
+          })),
+        },
+        user: {
+          tripHistory: ["trip-a", "trip-b"],
+          removeTripFromHistory: jest.fn(),
+          restoreTripHistory: jest.fn(),
+        },
+        expenses: { expenses: [] },
+      }
+    );
+  }
+
+  it("shows the escalated permanent-delete warning when the leaver is the last Traveller", async () => {
+    getTravellersMock.mockResolvedValue([{ uid: "u1", userName: "Alice" }]);
+
+    const screen = renderEditForm();
+    fireEvent.press(await screen.findByText(i18n.t("leaveTrip")));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        i18n.t("leaveTripPermanentDeleteSure"),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("shows the plain leave warning when other Travellers remain", async () => {
+    getTravellersMock.mockResolvedValue([
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ]);
+
+    const screen = renderEditForm();
+    fireEvent.press(await screen.findByText(i18n.t("leaveTrip")));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        i18n.t("leaveTripSure"),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("has permanent-delete warning copy in EN/DE/FR/RU", () => {
+    expect(en.leaveTripPermanentDeleteSure).toMatch(/permanent/i);
+    expect(de.leaveTripPermanentDeleteSure.length).toBeGreaterThan(10);
+    expect(fr.leaveTripPermanentDeleteSure.length).toBeGreaterThan(10);
+    expect(ru.leaveTripPermanentDeleteSure.length).toBeGreaterThan(10);
+  });
+});

--- a/TravelCostApp/__tests__/util/leave-trip.test.ts
+++ b/TravelCostApp/__tests__/util/leave-trip.test.ts
@@ -14,6 +14,7 @@ jest.mock("../../util/http", () => ({
   removeTripFromHistory: jest.fn(async () => undefined),
   putTravelerInTrip: jest.fn(async () => ({})),
   storeTripHistory: jest.fn(async () => undefined),
+  deleteTrip: jest.fn(async () => ({ status: 200 })),
 }));
 
 import Toast from "react-native-toast-message";
@@ -29,6 +30,7 @@ import {
   undoLeaveTrip,
 } from "../../util/leave-trip";
 import {
+  deleteTrip,
   putTravelerInTrip,
   removeTravelerFromTrip,
   removeTripFromHistory,
@@ -47,6 +49,7 @@ const putTravelerInTripMock = putTravelerInTrip as jest.MockedFunction<
 const storeTripHistoryMock = storeTripHistory as jest.MockedFunction<
   typeof storeTripHistory
 >;
+const deleteTripMock = deleteTrip as jest.MockedFunction<typeof deleteTrip>;
 
 function expense(id: string, description: string): ExpenseData {
   return {
@@ -173,16 +176,14 @@ describe("leaveTrip plain leave", () => {
     expect(removeFromTripHistoryLocal).toHaveBeenCalledWith("trip-b");
   });
 
-  it("does not write when the planner refuses plain leave", async () => {
+  it("does not write when the last-trip guard forbids leaving", async () => {
     const removeFromTripHistoryLocal = jest.fn();
     const restoreTripHistoryLocal = jest.fn();
-    const getTravellers = jest.fn(async () => [
-      { uid: "u1", userName: "Alice" },
-    ]);
+    const getTravellers = jest.fn(async () => multiTravellerRoster());
 
-    const result = await leaveTrip("trip-b", {
+    const result = await leaveTrip("trip-a", {
       uid: "u1",
-      tripHistory: ["trip-a", "trip-b"],
+      tripHistory: ["trip-a"],
       activeTripId: "trip-a",
       getTravellers,
       removeFromTripHistoryLocal,
@@ -190,8 +191,9 @@ describe("leaveTrip plain leave", () => {
     });
 
     expect(result.performed).toBe(false);
-    expect(result.mode).toBe("cascadeDelete");
+    expect(result.allowed).toBe(false);
     expect(removeTravelerFromTripMock).not.toHaveBeenCalled();
+    expect(deleteTripMock).not.toHaveBeenCalled();
     expect(removeTripFromHistoryMock).not.toHaveBeenCalled();
     expect(removeFromTripHistoryLocal).not.toHaveBeenCalled();
   });
@@ -237,7 +239,43 @@ describe("leaveTrip plain leave", () => {
     );
   });
 
-  it("does not show an Undo toast for cascade-delete planning", async () => {
+});
+
+describe("leaveTrip cascade-delete", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockLastToastOnHide = undefined;
+    clearPendingUndoLeave();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    clearPendingUndoLeave();
+  });
+
+  it("cascade-deletes the trip via deleteTrip when the leaver is the last Traveller", async () => {
+    const removeFromTripHistoryLocal = jest.fn();
+
+    const result = await leaveTrip("trip-b", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers: async () => [{ uid: "u1", userName: "Alice" }],
+      removeFromTripHistoryLocal,
+      restoreTripHistoryLocal: jest.fn(),
+    });
+
+    expect(result.performed).toBe(true);
+    expect(result.mode).toBe("cascadeDelete");
+    expect(result.warnings).toContain("permanentDelete");
+    expect(deleteTripMock).toHaveBeenCalledWith("trip-b");
+    expect(removeTripFromHistoryMock).toHaveBeenCalledWith("u1", "trip-b");
+    expect(removeFromTripHistoryLocal).toHaveBeenCalledWith("trip-b");
+    expect(removeTravelerFromTripMock).not.toHaveBeenCalled();
+  });
+
+  it("does not show an Undo toast for the cascade-delete path", async () => {
     await leaveTrip("trip-b", {
       uid: "u1",
       tripHistory: ["trip-a", "trip-b"],
@@ -251,6 +289,28 @@ describe("leaveTrip plain leave", () => {
       ([args]) => args.type === "deletedExpense"
     );
     expect(undoToast).toBeUndefined();
+  });
+
+  it("promotes Active trip before cascade-delete when leaving the Active trip", async () => {
+    const removeFromTripHistoryLocal = jest.fn();
+    const probe = createActivateProbe("trip-a");
+
+    const result = await leaveTrip("trip-a", {
+      uid: "u1",
+      tripHistory: ["trip-a", "trip-b"],
+      activeTripId: "trip-a",
+      getTravellers: async () => [{ uid: "u1", userName: "Alice" }],
+      removeFromTripHistoryLocal,
+      restoreTripHistoryLocal: jest.fn(),
+      activate: probe.activate,
+    });
+
+    expect(result.performed).toBe(true);
+    expect(result.mode).toBe("cascadeDelete");
+    expect(result.nextActiveTripId).toBe("trip-b");
+    expect(result.promotedTripName).toBe("Portugal");
+    expect(deleteTripMock).toHaveBeenCalledWith("trip-a");
+    expect(probe.mirrors().secureCurrentTripId).toBe("trip-b");
   });
 });
 

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -59,6 +59,7 @@ import {
   secureStoreSetItem,
 } from "../../store/secure-storage";
 import { activateTrip } from "../../util/activate-trip";
+import { planTripLeave } from "../../util/plan-trip-leave";
 import BackButton from "../UI/BackButton";
 import { onShare } from "../ProfileOutput/ShareTrip";
 import { NetworkContext } from "../../store/network-context";
@@ -327,7 +328,7 @@ const TripForm = ({ navigation, route }) => {
         });
         return;
       }
-      // leaveTrip shows the Undo toast (and hides the loading toast).
+      // Plain leave: leaveTrip shows Undo toast. Cascade-delete: no Undo.
       navigation.pop();
     } catch (error) {
       safeLogError(error);
@@ -340,14 +341,26 @@ const TripForm = ({ navigation, route }) => {
     }
   }
 
-  function leaveHandler() {
+  async function leaveHandler() {
     if (!isConnected) {
       Alert.alert(i18n.t("noConnection"), i18n.t("leaveTripConnectRequired"));
       return;
     }
+    if (!editedTripId) return;
+    const roster = await getTravellers(editedTripId);
+    const plan = planTripLeave({
+      tripHistory: userCtx.tripHistory ?? [],
+      roster,
+      openBalances: [],
+      activeTripId: tripCtx.tripid,
+      tripid: editedTripId,
+    });
+    const message = plan.warnings.includes("permanentDelete")
+      ? i18n.t("leaveTripPermanentDeleteSure")
+      : i18n.t("leaveTripSure");
     Alert.alert(
       i18n.t("leaveTrip"),
-      i18n.t("leaveTripSure"),
+      message,
       [
         {
           text: i18n.t("cancel"),

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -347,35 +347,40 @@ const TripForm = ({ navigation, route }) => {
       return;
     }
     if (!editedTripId) return;
-    const roster = await getTravellers(editedTripId);
-    const plan = planTripLeave({
-      tripHistory: userCtx.tripHistory ?? [],
-      roster,
-      openBalances: [],
-      activeTripId: tripCtx.tripid,
-      tripid: editedTripId,
-    });
-    const message = plan.warnings.includes("permanentDelete")
-      ? i18n.t("leaveTripPermanentDeleteSure")
-      : i18n.t("leaveTripSure");
-    Alert.alert(
-      i18n.t("leaveTrip"),
-      message,
-      [
-        {
-          text: i18n.t("cancel"),
-          style: "cancel",
-        },
-        {
-          text: i18n.t("leaveTrip"),
-          style: "destructive",
-          onPress: () => {
-            void leaveAcceptHandler();
+    try {
+      const roster = await getTravellers(editedTripId);
+      const plan = planTripLeave({
+        tripHistory: userCtx.tripHistory ?? [],
+        roster,
+        openBalances: [],
+        activeTripId: tripCtx.tripid,
+        tripid: editedTripId,
+      });
+      const message = plan.warnings.includes("permanentDelete")
+        ? i18n.t("leaveTripPermanentDeleteSure")
+        : i18n.t("leaveTripSure");
+      Alert.alert(
+        i18n.t("leaveTrip"),
+        message,
+        [
+          {
+            text: i18n.t("cancel"),
+            style: "cancel",
           },
-        },
-      ],
-      { cancelable: false }
-    );
+          {
+            text: i18n.t("leaveTrip"),
+            style: "destructive",
+            onPress: () => {
+              void leaveAcceptHandler();
+            },
+          },
+        ],
+        { cancelable: false }
+      );
+    } catch (error) {
+      safeLogError(error);
+      Alert.alert(i18n.t("error"), i18n.t("error2"));
+    }
   }
 
   async function editingTripData(tripData: TripData, setActive = false) {

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -198,6 +198,8 @@ const en = {
     "Are you sure you want to change the currency? Set it to the currency you normally use at home.",
   leaveTrip: "Leave budget",
   leaveTripSure: "Are you sure you want to leave this budget? Your past expenses stay for the remaining nomads.",
+  leaveTripPermanentDeleteSure:
+    "You are the last nomad on this budget. Leaving permanently deletes it and all its expenses. This cannot be undone.",
   leaveTripConnectRequired: "Connect to the internet to leave this budget.",
   leaveTripNowShowing: "Now showing %{name}",
   toastLeftTrip1: "Left budget",
@@ -808,6 +810,8 @@ const de = {
   leaveTrip: "Budget verlassen",
   leaveTripSure:
     "Möchtest du dieses Budget wirklich verlassen? Deine bisherigen Ausgaben bleiben für die anderen Nomaden erhalten.",
+  leaveTripPermanentDeleteSure:
+    "Du bist der letzte Nomade in diesem Budget. Verlassen löscht es und alle Ausgaben endgültig. Das kann nicht rückgängig gemacht werden.",
   leaveTripConnectRequired:
     "Verbinde dich mit dem Internet, um dieses Budget zu verlassen.",
   leaveTripNowShowing: "Jetzt angezeigt: %{name}",
@@ -1452,6 +1456,8 @@ const fr = {
   leaveTrip: "Quitter le budget",
   leaveTripSure:
     "Voulez-vous vraiment quitter ce budget ? Vos dépenses passées restent pour les autres nomades.",
+  leaveTripPermanentDeleteSure:
+    "Vous êtes le dernier nomade sur ce budget. Quitter le supprime définitivement avec toutes ses dépenses. Cette action est irréversible.",
   leaveTripConnectRequired:
     "Connectez-vous à internet pour quitter ce budget.",
   leaveTripNowShowing: "Affichage de %{name}",
@@ -2086,6 +2092,8 @@ const ru = {
   leaveTrip: "Покинуть бюджет",
   leaveTripSure:
     "Вы уверены, что хотите покинуть этот бюджет? Ваши прошлые расходы останутся для остальных номадов.",
+  leaveTripPermanentDeleteSure:
+    "Вы последний номад в этом бюджете. Выход безвозвратно удалит его и все расходы. Это нельзя отменить.",
   leaveTripConnectRequired:
     "Подключитесь к интернету, чтобы покинуть этот бюджет.",
   leaveTripNowShowing: "Сейчас показан: %{name}",

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -1,6 +1,7 @@
 import Toast from "react-native-toast-message";
 import { i18n } from "../i18n/i18n";
 import {
+  deleteTrip,
   putTravelerInTrip,
   removeTravelerFromTrip,
   removeTripFromHistory as removeTripFromHistoryRemote,
@@ -40,7 +41,7 @@ export type LeaveTripDeps = {
 };
 
 export type LeaveTripResult = PlanTripLeaveResult & {
-  /** True when roster + Trip history writes ran (plain leave only). */
+  /** True when leave or cascade-delete writes ran. */
   performed: boolean;
   /** Trip name after Active trip promotion; null when no promotion ran. */
   promotedTripName: string | null;
@@ -117,9 +118,9 @@ function showLeftTripToast(
 }
 
 /**
- * Leave trip orchestration for the plain-leave path, including Active trip
- * promotion via `activateTrip` when the left trip was active, and an Undo toast
- * mirroring delete-expense. Cascade-delete is planned but not executed here.
+ * Leave trip orchestration: plain leave (roster + Trip history + optional Undo)
+ * or cascade-delete when the leaver is the last Traveller (DELETE trip; no Undo).
+ * Active trip promotion runs before either write path when needed.
  */
 export async function leaveTrip(
   tripid: string,
@@ -134,24 +135,14 @@ export async function leaveTrip(
     tripid,
   });
 
-  if (!plan.allowed || plan.mode !== "leave") {
+  if (!plan.allowed) {
     return { ...plan, performed: false, promotedTripName: null };
   }
-
-  const leaver = roster.find((t) => t.uid === deps.uid);
-  if (!leaver?.userName) {
-    throw new Error(
-      "leaveTrip: Traveller roster entry with userName required for leave"
-    );
-  }
-  const userName = leaver.userName;
-  const previousTripHistory = [...deps.tripHistory];
-  const previousActiveTripId = plan.nextActiveTripId ? tripid : null;
 
   let promotedTripName: string | null = null;
 
   // Promote first when leaving the Active trip so a failed activateTrip does
-  // not leave the User without a valid Active trip after roster/history writes.
+  // not leave the User without a valid Active trip after leave/cascade writes.
   if (plan.nextActiveTripId) {
     if (!deps.activate) {
       throw new Error(
@@ -164,6 +155,31 @@ export async function leaveTrip(
     });
     promotedTripName = tripData.tripName ?? null;
   }
+
+  if (plan.mode === "cascadeDelete") {
+    const deleted = await deleteTrip(tripid);
+    if (!deleted) {
+      throw new Error("leaveTrip: cascade-delete failed");
+    }
+    await removeTripFromHistoryRemote(deps.uid, tripid);
+    deps.removeFromTripHistoryLocal(tripid);
+    Toast.hide();
+    return {
+      ...plan,
+      performed: true,
+      promotedTripName,
+    };
+  }
+
+  const leaver = roster.find((t) => t.uid === deps.uid);
+  if (!leaver?.userName) {
+    throw new Error(
+      "leaveTrip: Traveller roster entry with userName required for leave"
+    );
+  }
+  const userName = leaver.userName;
+  const previousTripHistory = [...deps.tripHistory];
+  const previousActiveTripId = plan.nextActiveTripId ? tripid : null;
 
   await removeTravelerFromTrip(tripid, deps.uid);
   await removeTripFromHistoryRemote(deps.uid, tripid);


### PR DESCRIPTION
## Summary
- Execute cascade-delete in `leaveTrip` when `mode: \"cascadeDelete\"` via existing `deleteTrip` (`DELETE /trips/{tripid}.json`), including Active trip promotion when needed
- Escalate TripForm confirm copy when planner warnings include `permanentDelete`; no Undo toast on the cascade path
- Add `leaveTripPermanentDeleteSure` i18n in EN/DE/FR/RU with TripForm confirm dialog tests

## Test plan
- [ ] Unit: `pnpm test -- __tests__/util/leave-trip.test.ts __tests__/components/trip-form-leave-confirm.test.tsx`
- [ ] Last Traveller on a non-last budget → confirm shows permanent-delete warning → leave deletes trip; no Undo toast
- [ ] Multi-Traveller leave still shows plain leave copy and Undo toast
- [ ] Leaving Active trip as last Traveller promotes another budget before cascade-delete

Closes #318