### PR TITLE
Leave trip — slice 5: open-balance warning

### DIFF
--- a/TravelCostApp/__tests__/components/trip-form-leave-confirm.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-leave-confirm.test.tsx
@@ -285,6 +285,41 @@ describe("TripForm Leave trip confirm dialog", () => {
     );
   });
 
+  it("does not warn the leaver about open Balances that only involve other Travellers", async () => {
+    getTravellersMock.mockResolvedValue([
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+      { uid: "u3", userName: "Charlie" },
+    ]);
+    getAllExpensesMock.mockResolvedValue([
+      makeExpense({
+        whoPaid: "Bob",
+        amount: 80,
+        calcAmount: 80,
+        currency: "EUR",
+        splitList: [
+          { userName: "Bob", amount: 40 },
+          { userName: "Charlie", amount: 40 },
+        ],
+      }),
+    ]);
+
+    const screen = renderEditForm();
+    fireEvent.press(await screen.findByText(i18n.t("leaveTrip")));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        i18n.t("leaveTripSure"),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+    expect(alertSpy.mock.calls[0][1]).not.toContain(
+      i18n.t("leaveTripOpenBalancesWarning")
+    );
+  });
+
   it("has open-Balance warning copy in EN/DE/FR/RU", () => {
     for (const locale of [en, de, fr, ru]) {
       expect(locale.leaveTripOpenBalancesWarning.length).toBeGreaterThan(10);

--- a/TravelCostApp/__tests__/components/trip-form-leave-confirm.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-leave-confirm.test.tsx
@@ -59,7 +59,8 @@ import { fireEvent, waitFor } from "@testing-library/react-native";
 import TripForm from "../../components/ManageTrip/TripForm";
 import { i18n } from "../../i18n/i18n";
 import { renderWithAppProviders } from "../fixtures/app-providers";
-import { getTravellers } from "../../util/http";
+import { makeExpense } from "../fixtures/expense";
+import { getAllExpenses, getTravellers } from "../../util/http";
 import {
   de,
   en,
@@ -75,6 +76,9 @@ const navigation = {
 
 const getTravellersMock = getTravellers as jest.MockedFunction<
   typeof getTravellers
+>;
+const getAllExpensesMock = getAllExpenses as jest.MockedFunction<
+  typeof getAllExpenses
 >;
 
 describe("TripForm Leave trip confirm dialog", () => {
@@ -177,5 +181,118 @@ describe("TripForm Leave trip confirm dialog", () => {
       );
     }
     expect(en.leaveTripPermanentDeleteSure).toMatch(/permanent/i);
+  });
+
+  it("shows an open-Balance warning when the leaver has unsettled Balances", async () => {
+    getTravellersMock.mockResolvedValue([
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ]);
+    getAllExpensesMock.mockResolvedValue([
+      makeExpense({
+        whoPaid: "Alice",
+        amount: 100,
+        calcAmount: 100,
+        currency: "EUR",
+        splitList: [
+          { userName: "Alice", amount: 50 },
+          { userName: "Bob", amount: 50 },
+        ],
+      }),
+    ]);
+
+    const screen = renderEditForm();
+    fireEvent.press(await screen.findByText(i18n.t("leaveTrip")));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        expect.stringContaining(i18n.t("leaveTripOpenBalancesWarning")),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("still offers Leave after the open-Balance warning (warn, do not block)", async () => {
+    getTravellersMock.mockResolvedValue([
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ]);
+    getAllExpensesMock.mockResolvedValue([
+      makeExpense({
+        whoPaid: "Bob",
+        amount: 40,
+        calcAmount: 40,
+        currency: "EUR",
+        splitList: [
+          { userName: "Alice", amount: 20 },
+          { userName: "Bob", amount: 20 },
+        ],
+      }),
+    ]);
+
+    const screen = renderEditForm();
+    fireEvent.press(await screen.findByText(i18n.t("leaveTrip")));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        expect.stringContaining(i18n.t("leaveTripOpenBalancesWarning")),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+
+    const buttons = alertSpy.mock.calls[0][2] as Array<{
+      text: string;
+      style?: string;
+      onPress?: () => void;
+    }>;
+    expect(buttons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: i18n.t("leaveTrip"),
+          style: "destructive",
+        }),
+      ])
+    );
+    expect(typeof buttons.find((b) => b.style === "destructive")?.onPress).toBe(
+      "function"
+    );
+  });
+
+  it("does not show the open-Balance warning when Balances are zero", async () => {
+    getTravellersMock.mockResolvedValue([
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ]);
+    getAllExpensesMock.mockResolvedValue([]);
+
+    const screen = renderEditForm();
+    fireEvent.press(await screen.findByText(i18n.t("leaveTrip")));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        i18n.t("leaveTripSure"),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+    expect(alertSpy.mock.calls[0][1]).not.toContain(
+      i18n.t("leaveTripOpenBalancesWarning")
+    );
+  });
+
+  it("has open-Balance warning copy in EN/DE/FR/RU", () => {
+    for (const locale of [en, de, fr, ru]) {
+      expect(locale.leaveTripOpenBalancesWarning.length).toBeGreaterThan(10);
+      expect(locale.leaveTripOpenBalancesWarning).not.toBe(locale.leaveTripSure);
+      expect(locale.leaveTripOpenBalancesWarning).not.toBe(
+        locale.leaveTripPermanentDeleteSure
+      );
+    }
+    expect(en.leaveTripOpenBalancesWarning.toLowerCase()).toMatch(/balance/);
   });
 });

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -59,6 +59,10 @@ import {
   secureStoreSetItem,
 } from "../../store/secure-storage";
 import { activateTrip } from "../../util/activate-trip";
+import {
+  leaveConfirmMessage,
+  openBalancesForTraveller,
+} from "../../util/leave-trip";
 import { planTripLeave } from "../../util/plan-trip-leave";
 import BackButton from "../UI/BackButton";
 import { onShare } from "../ProfileOutput/ShareTrip";
@@ -281,6 +285,39 @@ const TripForm = ({ navigation, route }) => {
     navigation.pop();
   }
 
+  async function resolveLeaverOpenBalances(
+    tripid: string,
+    uid: string,
+    roster: { uid: string; userName?: string }[]
+  ) {
+    const leaverUserName =
+      roster.find((traveller) => traveller.uid === uid)?.userName ??
+      userCtx.userName;
+    if (!leaverUserName) {
+      return [];
+    }
+
+    if (tripid === tripCtx.tripid) {
+      return openBalancesForTraveller(
+        expenseCtx.expenses ?? [],
+        tripCtx.tripCurrency,
+        tripCtx.isPaidTimestamp,
+        leaverUserName
+      );
+    }
+
+    const [expenses, trip] = await Promise.all([
+      getAllExpenses(tripid, uid),
+      fetchTrip(tripid),
+    ]);
+    return openBalancesForTraveller(
+      expenses ?? [],
+      trip?.tripCurrency ?? inputs.tripCurrency.value,
+      trip?.isPaidTimestamp,
+      leaverUserName
+    );
+  }
+
   async function leaveAcceptHandler() {
     const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
     if (!uid || !editedTripId) return;
@@ -293,11 +330,17 @@ const TripForm = ({ navigation, route }) => {
     });
 
     try {
+      const roster = await getTravellers(editedTripId);
+      const openBalances = await resolveLeaverOpenBalances(
+        editedTripId,
+        uid,
+        roster
+      );
       const result = await tripCtx.leaveTrip(editedTripId, {
         uid,
         tripHistory: userCtx.tripHistory ?? [],
         getTravellers,
-        openBalances: [],
+        openBalances,
         removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
         restoreTripHistoryLocal: userCtx.restoreTripHistory,
         activate: {
@@ -348,20 +391,24 @@ const TripForm = ({ navigation, route }) => {
     }
     if (!editedTripId) return;
     try {
+      const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
+      if (!uid) return;
       const roster = await getTravellers(editedTripId);
+      const openBalances = await resolveLeaverOpenBalances(
+        editedTripId,
+        uid,
+        roster
+      );
       const plan = planTripLeave({
         tripHistory: userCtx.tripHistory ?? [],
         roster,
-        openBalances: [],
+        openBalances,
         activeTripId: tripCtx.tripid,
         tripid: editedTripId,
       });
-      const message = plan.warnings.includes("permanentDelete")
-        ? i18n.t("leaveTripPermanentDeleteSure")
-        : i18n.t("leaveTripSure");
       Alert.alert(
         i18n.t("leaveTrip"),
-        message,
+        leaveConfirmMessage(plan.warnings),
         [
           {
             text: i18n.t("cancel"),

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -61,7 +61,7 @@ import {
 import { activateTrip } from "../../util/activate-trip";
 import {
   leaveConfirmMessage,
-  openBalancesForTraveller,
+  resolveLeaverOpenBalances,
 } from "../../util/leave-trip";
 import { planTripLeave } from "../../util/plan-trip-leave";
 import BackButton from "../UI/BackButton";
@@ -285,37 +285,17 @@ const TripForm = ({ navigation, route }) => {
     navigation.pop();
   }
 
-  async function resolveLeaverOpenBalances(
-    tripid: string,
-    uid: string,
-    roster: { uid: string; userName?: string }[]
-  ) {
-    const leaverUserName =
-      roster.find((traveller) => traveller.uid === uid)?.userName ??
-      userCtx.userName;
-    if (!leaverUserName) {
-      return [];
-    }
-
-    if (tripid === tripCtx.tripid) {
-      return openBalancesForTraveller(
-        expenseCtx.expenses ?? [],
-        tripCtx.tripCurrency,
-        tripCtx.isPaidTimestamp,
-        leaverUserName
-      );
-    }
-
-    const [expenses, trip] = await Promise.all([
-      getAllExpenses(tripid, uid),
-      fetchTrip(tripid),
-    ]);
-    return openBalancesForTraveller(
-      expenses ?? [],
-      trip?.tripCurrency ?? inputs.tripCurrency.value,
-      trip?.isPaidTimestamp,
-      leaverUserName
-    );
+  function leaverOpenBalancesDeps() {
+    return {
+      activeTripId: tripCtx.tripid,
+      activeExpenses: expenseCtx.expenses ?? [],
+      activeTripCurrency: tripCtx.tripCurrency,
+      activeIsPaidTimestamp: tripCtx.isPaidTimestamp,
+      fallbackTripCurrency: inputs.tripCurrency.value,
+      userNameFallback: userCtx.userName,
+      getAllExpenses,
+      fetchTrip,
+    };
   }
 
   async function leaveAcceptHandler() {
@@ -334,7 +314,8 @@ const TripForm = ({ navigation, route }) => {
       const openBalances = await resolveLeaverOpenBalances(
         editedTripId,
         uid,
-        roster
+        roster,
+        leaverOpenBalancesDeps()
       );
       const result = await tripCtx.leaveTrip(editedTripId, {
         uid,
@@ -397,7 +378,8 @@ const TripForm = ({ navigation, route }) => {
       const openBalances = await resolveLeaverOpenBalances(
         editedTripId,
         uid,
-        roster
+        roster,
+        leaverOpenBalancesDeps()
       );
       const plan = planTripLeave({
         tripHistory: userCtx.tripHistory ?? [],

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -200,6 +200,8 @@ const en = {
   leaveTripSure: "Are you sure you want to leave this budget? Your past expenses stay for the remaining nomads.",
   leaveTripPermanentDeleteSure:
     "You are the last nomad on this budget. Leaving permanently deletes it and all its expenses. This cannot be undone.",
+  leaveTripOpenBalancesWarning:
+    "You still have unsettled balances on this budget. You can leave anyway, but money matters remain unresolved.",
   leaveTripConnectRequired: "Connect to the internet to leave this budget.",
   leaveTripNowShowing: "Now showing %{name}",
   toastLeftTrip1: "Left budget",
@@ -812,6 +814,8 @@ const de = {
     "Möchtest du dieses Budget wirklich verlassen? Deine bisherigen Ausgaben bleiben für die anderen Nomaden erhalten.",
   leaveTripPermanentDeleteSure:
     "Du bist der letzte Nomade in diesem Budget. Verlassen löscht es und alle Ausgaben endgültig. Das kann nicht rückgängig gemacht werden.",
+  leaveTripOpenBalancesWarning:
+    "Du hast noch offene Salden in diesem Budget. Du kannst trotzdem verlassen, aber offene Geldbeträge bleiben ungelöst.",
   leaveTripConnectRequired:
     "Verbinde dich mit dem Internet, um dieses Budget zu verlassen.",
   leaveTripNowShowing: "Jetzt angezeigt: %{name}",
@@ -1458,6 +1462,8 @@ const fr = {
     "Voulez-vous vraiment quitter ce budget ? Vos dépenses passées restent pour les autres nomades.",
   leaveTripPermanentDeleteSure:
     "Vous êtes le dernier nomade sur ce budget. Quitter le supprime définitivement avec toutes ses dépenses. Cette action est irréversible.",
+  leaveTripOpenBalancesWarning:
+    "Vous avez encore des soldes non réglés sur ce budget. Vous pouvez quand même quitter, mais les questions d'argent restent en suspens.",
   leaveTripConnectRequired:
     "Connectez-vous à internet pour quitter ce budget.",
   leaveTripNowShowing: "Affichage de %{name}",
@@ -2094,6 +2100,8 @@ const ru = {
     "Вы уверены, что хотите покинуть этот бюджет? Ваши прошлые расходы останутся для остальных номадов.",
   leaveTripPermanentDeleteSure:
     "Вы последний номад в этом бюджете. Выход безвозвратно удалит его и все расходы. Это нельзя отменить.",
+  leaveTripOpenBalancesWarning:
+    "У вас ещё есть незакрытые балансы в этом бюджете. Вы можете уйти, но денежные вопросы останутся нерешёнными.",
   leaveTripConnectRequired:
     "Подключитесь к интернету, чтобы покинуть этот бюджет.",
   leaveTripNowShowing: "Сейчас показан: %{name}",

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -11,13 +11,46 @@ import {
   activateTrip,
   type ActivateTripDeps,
 } from "./activate-trip";
+import type { ExpenseData, Split } from "./expense";
 import {
   planTripLeave,
   type PlanTripLeaveResult,
+  type TripLeaveWarning,
 } from "./plan-trip-leave";
+import { rollupOpenBalances } from "./split";
 import type { Traveller } from "./traveler";
 
 export const UNDO_LEAVE_WINDOW_MS = 8000;
+
+/**
+ * Open Balances that involve a Traveller (as debtor or who paid),
+ * from the trip-wide rollup — used to feed `planTripLeave` warnings.
+ */
+export function openBalancesForTraveller(
+  expenses: ExpenseData[],
+  tripCurrency: string,
+  isPaidTimestamp: number | undefined,
+  travellerUserName: string
+): Split[] {
+  return rollupOpenBalances(expenses, tripCurrency, isPaidTimestamp).filter(
+    (balance) =>
+      balance.userName === travellerUserName ||
+      balance.whoPaid === travellerUserName
+  );
+}
+
+/** Confirm-dialog body for Leave trip: base copy plus optional open-Balance warning. */
+export function leaveConfirmMessage(
+  warnings: readonly TripLeaveWarning[]
+): string {
+  const base = warnings.includes("permanentDelete")
+    ? i18n.t("leaveTripPermanentDeleteSure")
+    : i18n.t("leaveTripSure");
+  if (!warnings.includes("openBalances")) {
+    return base;
+  }
+  return `${base}\n\n${i18n.t("leaveTripOpenBalancesWarning")}`;
+}
 
 export type LeaveTripDeps = {
   uid: string;

--- a/TravelCostApp/util/leave-trip.ts
+++ b/TravelCostApp/util/leave-trip.ts
@@ -52,6 +52,61 @@ export function leaveConfirmMessage(
   return `${base}\n\n${i18n.t("leaveTripOpenBalancesWarning")}`;
 }
 
+export type ResolveLeaverOpenBalancesDeps = {
+  activeTripId: string | null | undefined;
+  activeExpenses: ExpenseData[];
+  activeTripCurrency: string;
+  activeIsPaidTimestamp: number | undefined;
+  fallbackTripCurrency?: string;
+  userNameFallback?: string;
+  getAllExpenses: (
+    tripid: string,
+    uid: string
+  ) => Promise<ExpenseData[] | null | undefined>;
+  fetchTrip: (tripid: string) => Promise<{
+    tripCurrency?: string;
+    isPaidTimestamp?: number;
+  } | null>;
+};
+
+/**
+ * Resolve open Balances for the leaver on a trip: Active trip uses local
+ * expenses; other trips fetch expenses + trip meta, then filter via rollup.
+ */
+export async function resolveLeaverOpenBalances(
+  tripid: string,
+  uid: string,
+  roster: readonly Pick<Traveller, "uid" | "userName">[],
+  deps: ResolveLeaverOpenBalancesDeps
+): Promise<Split[]> {
+  const leaverUserName =
+    roster.find((traveller) => traveller.uid === uid)?.userName ??
+    deps.userNameFallback;
+  if (!leaverUserName) {
+    return [];
+  }
+
+  if (tripid === deps.activeTripId) {
+    return openBalancesForTraveller(
+      deps.activeExpenses,
+      deps.activeTripCurrency,
+      deps.activeIsPaidTimestamp,
+      leaverUserName
+    );
+  }
+
+  const [expenses, trip] = await Promise.all([
+    deps.getAllExpenses(tripid, uid),
+    deps.fetchTrip(tripid),
+  ]);
+  return openBalancesForTraveller(
+    expenses ?? [],
+    trip?.tripCurrency ?? deps.fallbackTripCurrency ?? deps.activeTripCurrency,
+    trip?.isPaidTimestamp,
+    leaverUserName
+  );
+}
+
 export type LeaveTripDeps = {
   uid: string;
   tripHistory: readonly string[];


### PR DESCRIPTION
## Summary
- Feed the leaver’s open **Balances** (via `rollupOpenBalances`) into `planTripLeave` from TripForm
- Confirm dialog appends an open-balance warning when `warnings` includes `openBalances`; Leave remains available
- Add `leaveTripOpenBalancesWarning` i18n in EN/DE/FR/RU plus TripForm confirm-dialog tests

## Test plan
- [ ] `pnpm test -- __tests__/components/trip-form-leave-confirm.test.tsx __tests__/util/plan-trip-leave.test.ts`
- [ ] Leave a multi-Traveller budget with unsettled Balances → confirm shows open-balance warning + Leave still works
- [ ] Leave with zero Balances → plain leave copy only (no open-balance warning)
- [ ] Cascade-delete + open Balances still shows permanent-delete base copy with open-balance warning appended

Closes #319