### PR TITLE
Leave trip — slice 6: swipe-to-leave in My Trips

### DIFF
--- a/TravelCostApp/__tests__/components/trip-list-leave-confirm.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-list-leave-confirm.test.tsx
@@ -1,0 +1,305 @@
+import * as React from "react";
+import { Alert, Platform } from "react-native";
+import Swipeable from "react-native-gesture-handler/Swipeable";
+import { waitFor } from "@testing-library/react-native";
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("../../util/http", () => ({
+  fetchTripName: jest.fn(async () => "Japan 2026"),
+  getTravellers: jest.fn(async () => [
+    { uid: "u1", userName: "Alice" },
+    { uid: "u2", userName: "Bob" },
+  ]),
+  getTripData: jest.fn(async () => ({
+    dailyBudget: "100",
+    totalBudget: "3000",
+    tripCurrency: "EUR",
+  })),
+  getAllExpenses: jest.fn(async () => []),
+  fetchTrip: jest.fn(async () => ({
+    tripCurrency: "EUR",
+  })),
+  updateUser: jest.fn(),
+}));
+
+jest.mock("../../store/mmkv", () => {
+  const actual = jest.requireActual("../../store/mmkv-keys");
+  return {
+    getMMKVObject: jest.fn(() => null),
+    setMMKVObject: jest.fn(),
+    MMKV_KEYS: actual.MMKV_KEYS,
+    MMKV_KEY_PATTERNS: actual.MMKV_KEY_PATTERNS,
+  };
+});
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => "u1"),
+  secureStoreSetItem: jest.fn(async () => {}),
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+import TripList from "../../components/ProfileOutput/TripList";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { i18n } from "../../i18n/i18n";
+import { makeExpense } from "../fixtures/expense";
+import { getAllExpenses, getTravellers } from "../../util/http";
+
+const getTravellersMock = getTravellers as jest.MockedFunction<
+  typeof getTravellers
+>;
+const getAllExpensesMock = getAllExpenses as jest.MockedFunction<
+  typeof getAllExpenses
+>;
+
+function pressSwipeLeave(screen: ReturnType<typeof renderWithAppProviders>) {
+  const rows = screen.UNSAFE_getAllByType(Swipeable);
+  expect(rows.length).toBeGreaterThan(0);
+  const row = rows[0];
+  const actionEl =
+    Platform.OS === "android"
+      ? row.props.renderLeftActions?.()
+      : row.props.renderRightActions?.();
+  expect(actionEl).toBeTruthy();
+  const onPress = actionEl.props.onPress as () => void;
+  onPress();
+}
+
+describe("TripList swipe-to-leave", () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    getTravellersMock.mockResolvedValue([
+      { uid: "u1", userName: "Alice" },
+      { uid: "u2", userName: "Bob" },
+    ]);
+    getAllExpensesMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  function renderList(overrides: Parameters<typeof renderWithAppProviders>[1] = {}) {
+    return renderWithAppProviders(<TripList trips={["t1", "t2"]} />, {
+      network: { isConnected: true, strongConnection: true },
+      auth: { uid: "u1" },
+      trip: {
+        tripid: "t1",
+        tripCurrency: "EUR",
+        leaveTrip: jest.fn(async () => ({
+          allowed: true,
+          mode: "leave",
+          nextActiveTripId: null,
+          warnings: [],
+          performed: true,
+          promotedTripName: null,
+        })),
+        getcurrentTrip: jest.fn(() => ({})),
+        setCurrentTrip: jest.fn(),
+        saveTripDataInStorage: jest.fn(),
+        saveTravellersInStorage: jest.fn(),
+      },
+      user: {
+        userName: "Alice",
+        tripHistory: ["t1", "t2"],
+        removeTripFromHistory: jest.fn(),
+        restoreTripHistory: jest.fn(),
+        setFreshlyCreatedTo: jest.fn(),
+      },
+      expenses: { expenses: [], setExpenses: jest.fn() },
+      ...overrides,
+    });
+  }
+
+  it("exposes a swipe-to-leave action on each trip row when Trip history has more than one trip", async () => {
+    const screen = renderList();
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+    const rows = screen.UNSAFE_getAllByType(Swipeable);
+    expect(rows.length).toBe(2);
+    const action =
+      Platform.OS === "android"
+        ? rows[0].props.renderLeftActions?.()
+        : rows[0].props.renderRightActions?.();
+    expect(action?.props?.onPress).toEqual(expect.any(Function));
+  });
+
+  it("does not expose swipe-to-leave when the User has only one trip", async () => {
+    const screen = renderWithAppProviders(<TripList trips={["t1"]} />, {
+      network: { isConnected: true, strongConnection: true },
+      trip: { tripid: "t1" },
+      user: { tripHistory: ["t1"] },
+      expenses: { expenses: [] },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+    expect(screen.UNSAFE_queryAllByType(Swipeable)).toHaveLength(0);
+  });
+
+  it("shows the plain leave confirm when other Travellers remain", async () => {
+    const screen = renderList();
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+    pressSwipeLeave(screen);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        i18n.t("leaveTripSure"),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("shows the escalated permanent-delete warning when the leaver is the last Traveller", async () => {
+    getTravellersMock.mockResolvedValue([{ uid: "u1", userName: "Alice" }]);
+    const screen = renderList();
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+    pressSwipeLeave(screen);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        i18n.t("leaveTripPermanentDeleteSure"),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("shows an open-Balance warning when the leaver has unsettled Balances", async () => {
+    getAllExpensesMock.mockResolvedValue([
+      makeExpense({
+        whoPaid: "Alice",
+        amount: 100,
+        calcAmount: 100,
+        currency: "EUR",
+        splitList: [
+          { userName: "Alice", amount: 50 },
+          { userName: "Bob", amount: 50 },
+        ],
+      }),
+    ]);
+    const screen = renderList({
+      trip: {
+        tripid: "t1",
+        tripCurrency: "EUR",
+        leaveTrip: jest.fn(async () => ({
+          allowed: true,
+          mode: "leave",
+          nextActiveTripId: null,
+          warnings: [],
+          performed: true,
+          promotedTripName: null,
+        })),
+        getcurrentTrip: jest.fn(() => ({})),
+        setCurrentTrip: jest.fn(),
+        saveTripDataInStorage: jest.fn(),
+        saveTravellersInStorage: jest.fn(),
+      },
+      expenses: {
+        expenses: [
+          makeExpense({
+            whoPaid: "Alice",
+            amount: 100,
+            calcAmount: 100,
+            currency: "EUR",
+            splitList: [
+              { userName: "Alice", amount: 50 },
+              { userName: "Bob", amount: 50 },
+            ],
+          }),
+        ],
+        setExpenses: jest.fn(),
+      },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+    pressSwipeLeave(screen);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("leaveTrip"),
+        expect.stringContaining(i18n.t("leaveTripOpenBalancesWarning")),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("shows connect-required when offline", async () => {
+    const screen = renderList({
+      network: { isConnected: false, strongConnection: false },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+    pressSwipeLeave(screen);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("noConnection"),
+        i18n.t("leaveTripConnectRequired")
+      );
+    });
+  });
+
+  it("calls leaveTrip when the User confirms the swipe leave dialog", async () => {
+    const leaveTrip = jest.fn(async () => ({
+      allowed: true,
+      mode: "leave",
+      nextActiveTripId: null,
+      warnings: [],
+      performed: true,
+      promotedTripName: null,
+    }));
+    alertSpy.mockImplementation((_title, _msg, buttons) => {
+      const leaveBtn = (buttons as Array<{ style?: string; onPress?: () => void }>).find(
+        (b) => b.style === "destructive"
+      );
+      leaveBtn?.onPress?.();
+    });
+
+    const screen = renderList({
+      trip: {
+        tripid: "t1",
+        tripCurrency: "EUR",
+        leaveTrip,
+        getcurrentTrip: jest.fn(() => ({})),
+        setCurrentTrip: jest.fn(),
+        saveTripDataInStorage: jest.fn(),
+        saveTravellersInStorage: jest.fn(),
+      },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+    pressSwipeLeave(screen);
+
+    await waitFor(() => {
+      expect(leaveTrip).toHaveBeenCalledWith(
+        "t1",
+        expect.objectContaining({
+          uid: "u1",
+          tripHistory: ["t1", "t2"],
+        })
+      );
+    });
+  });
+});

--- a/TravelCostApp/__tests__/components/trip-list-leave-confirm.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-list-leave-confirm.test.tsx
@@ -260,6 +260,23 @@ describe("TripList swipe-to-leave", () => {
     });
   });
 
+  it("shows connect-required when the connection is weak (matches TripForm leave gating)", async () => {
+    const screen = renderList({
+      network: { isConnected: true, strongConnection: false },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+    pressSwipeLeave(screen);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        i18n.t("noConnection"),
+        i18n.t("leaveTripConnectRequired")
+      );
+    });
+  });
+
   it("calls leaveTrip when the User confirms the swipe leave dialog", async () => {
     const leaveTrip = jest.fn(async () => ({
       allowed: true,

--- a/TravelCostApp/__tests__/components/trip-swipe-leave-action.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-swipe-leave-action.test.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { Pressable, StyleSheet } from "react-native";
+
+import TripSwipeLeaveAction from "../../components/ProfileOutput/TripSwipeLeaveAction";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { GlobalStyles } from "../../constants/styles";
+
+describe("TripSwipeLeaveAction", () => {
+  it("centers the exit-door icon within the red swipe action background", () => {
+    const screen = renderWithAppProviders(
+      <TripSwipeLeaveAction onPress={jest.fn()} />,
+      { wrapNavigation: false }
+    );
+
+    const container = screen.getByTestId("trip-swipe-leave-action");
+    const containerStyle = StyleSheet.flatten(
+      container.props.style
+    ) as Record<string, unknown>;
+
+    expect(containerStyle.alignItems).toBe("center");
+    expect(containerStyle.justifyContent).toBe("center");
+    expect(containerStyle.backgroundColor).toBe(GlobalStyles.colors.error500);
+    expect(containerStyle.paddingLeft).toBeUndefined();
+    expect(containerStyle.paddingTop).toBeUndefined();
+
+    const button = container.findByType(Pressable);
+    const rawButtonStyle = button.props.style;
+    const buttonStyle = StyleSheet.flatten(
+      typeof rawButtonStyle === "function"
+        ? rawButtonStyle({ pressed: false })
+        : rawButtonStyle
+    ) as Record<string, unknown>;
+
+    expect(buttonStyle.marginLeft).toBeUndefined();
+    expect(buttonStyle.marginTop).toBeUndefined();
+  });
+});

--- a/TravelCostApp/__tests__/components/trip-swipe-leave-action.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-swipe-leave-action.test.tsx
@@ -13,6 +13,7 @@ describe("TripSwipeLeaveAction", () => {
     );
 
     const container = screen.getByTestId("trip-swipe-leave-action");
+    expect(screen.getByTestId("icon-exit-outline")).toBeTruthy();
     const containerStyle = StyleSheet.flatten(
       container.props.style
     ) as Record<string, unknown>;

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -59,11 +59,8 @@ import {
   secureStoreSetItem,
 } from "../../store/secure-storage";
 import { activateTrip } from "../../util/activate-trip";
-import {
-  leaveConfirmMessage,
-  resolveLeaverOpenBalances,
-} from "../../util/leave-trip";
-import { planTripLeave } from "../../util/plan-trip-leave";
+import { resolveLeaverOpenBalances } from "../../util/leave-trip";
+import { promptLeaveTrip } from "../../util/prompt-leave-trip";
 import BackButton from "../UI/BackButton";
 import { onShare } from "../ProfileOutput/ShareTrip";
 import { NetworkContext } from "../../store/network-context";
@@ -366,50 +363,21 @@ const TripForm = ({ navigation, route }) => {
   }
 
   async function leaveHandler() {
-    if (!isConnected) {
-      Alert.alert(i18n.t("noConnection"), i18n.t("leaveTripConnectRequired"));
-      return;
-    }
     if (!editedTripId) return;
-    try {
-      const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
-      if (!uid) return;
-      const roster = await getTravellers(editedTripId);
-      const openBalances = await resolveLeaverOpenBalances(
-        editedTripId,
-        uid,
-        roster,
-        leaverOpenBalancesDeps()
-      );
-      const plan = planTripLeave({
-        tripHistory: userCtx.tripHistory ?? [],
-        roster,
-        openBalances,
-        activeTripId: tripCtx.tripid,
-        tripid: editedTripId,
-      });
-      Alert.alert(
-        i18n.t("leaveTrip"),
-        leaveConfirmMessage(plan.warnings),
-        [
-          {
-            text: i18n.t("cancel"),
-            style: "cancel",
-          },
-          {
-            text: i18n.t("leaveTrip"),
-            style: "destructive",
-            onPress: () => {
-              void leaveAcceptHandler();
-            },
-          },
-        ],
-        { cancelable: false }
-      );
-    } catch (error) {
-      safeLogError(error);
-      Alert.alert(i18n.t("error"), i18n.t("error2"));
-    }
+    const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
+    if (!uid) return;
+    await promptLeaveTrip({
+      isConnected,
+      tripid: editedTripId,
+      uid,
+      tripHistory: userCtx.tripHistory ?? [],
+      activeTripId: tripCtx.tripid,
+      getTravellers,
+      openBalancesDeps: leaverOpenBalancesDeps(),
+      onConfirm: () => {
+        void leaveAcceptHandler();
+      },
+    });
   }
 
   async function editingTripData(tripData: TripData, setActive = false) {

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -59,8 +59,8 @@ import {
   secureStoreSetItem,
 } from "../../store/secure-storage";
 import { activateTrip } from "../../util/activate-trip";
-import { resolveLeaverOpenBalances } from "../../util/leave-trip";
 import { promptLeaveTrip } from "../../util/prompt-leave-trip";
+import { performLeaveTripUi } from "../../util/perform-leave-trip-ui";
 import BackButton from "../UI/BackButton";
 import { onShare } from "../ProfileOutput/ShareTrip";
 import { NetworkContext } from "../../store/network-context";
@@ -299,66 +299,35 @@ const TripForm = ({ navigation, route }) => {
     const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
     if (!uid || !editedTripId) return;
 
-    Toast.show({
-      type: "loading",
-      text1: i18n.t("toastSaving1"),
-      text2: i18n.t("toastSaving2"),
-      autoHide: false,
-    });
-
-    try {
-      const roster = await getTravellers(editedTripId);
-      const openBalances = await resolveLeaverOpenBalances(
-        editedTripId,
-        uid,
-        roster,
-        leaverOpenBalancesDeps()
-      );
-      const result = await tripCtx.leaveTrip(editedTripId, {
-        uid,
-        tripHistory: userCtx.tripHistory ?? [],
+    const performed = await performLeaveTripUi({
+      tripid: editedTripId,
+      uid,
+      tripHistory: userCtx.tripHistory ?? [],
+      getTravellers,
+      openBalancesDeps: leaverOpenBalancesDeps(),
+      leaveTrip: tripCtx.leaveTrip,
+      removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
+      restoreTripHistoryLocal: userCtx.restoreTripHistory,
+      activate: {
+        previousTripSnapshot: tripCtx.getcurrentTrip(),
+        previousExpensesSnapshot: expenseCtx.expenses,
+        fetchTrip,
         getTravellers,
-        openBalances,
-        removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
-        restoreTripHistoryLocal: userCtx.restoreTripHistory,
-        activate: {
-          previousTripSnapshot: tripCtx.getcurrentTrip(),
-          previousExpensesSnapshot: expenseCtx.expenses,
-          fetchTrip,
-          getTravellers,
-          getAllExpenses,
-          updateUser,
-          secureStoreGetItem,
-          secureStoreSetItem,
-          setCurrentTrip: tripCtx.setCurrentTrip,
-          saveTripDataInStorage: tripCtx.saveTripDataInStorage,
-          saveTravellersInStorage: tripCtx.saveTravellersInStorage,
-          setExpenses: expenseCtx.setExpenses,
-          setExpensesCache: (nextExpenses) =>
-            setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
-          setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
-        },
-      });
-
-      if (!result.performed) {
-        Toast.hide();
-        Toast.show({
-          text1: i18n.t("toastSavingError1"),
-          text2: i18n.t("error2"),
-          type: "error",
-        });
-        return;
-      }
-      // Plain leave: leaveTrip shows Undo toast. Cascade-delete: no Undo.
+        getAllExpenses,
+        updateUser,
+        secureStoreGetItem,
+        secureStoreSetItem,
+        setCurrentTrip: tripCtx.setCurrentTrip,
+        saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+        saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+        setExpenses: expenseCtx.setExpenses,
+        setExpensesCache: (nextExpenses) =>
+          setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+        setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
+      },
+    });
+    if (performed) {
       navigation.pop();
-    } catch (error) {
-      safeLogError(error);
-      Toast.hide();
-      Toast.show({
-        text1: i18n.t("toastSavingError1"),
-        text2: i18n.t("error2"),
-        type: "error",
-      });
     }
   }
 

--- a/TravelCostApp/components/ProfileOutput/TripList.tsx
+++ b/TravelCostApp/components/ProfileOutput/TripList.tsx
@@ -1,24 +1,248 @@
-import { FlatList, View } from "react-native";
-import TripHistoryItem from "./TripHistoryItem";
-import React, { useContext } from "react";
-import LoadingOverlay from "../UI/LoadingOverlay";
+import * as React from "react";
+import { FlatList, Platform, View } from "react-native";
+import Swipeable from "react-native-gesture-handler/Swipeable";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import Toast from "react-native-toast-message";
 import PropTypes from "prop-types";
 import uniqBy from "lodash.uniqby";
-import { TripData } from "../../store/trip-context";
+import { useCallback, useContext, useRef } from "react";
+
+import TripHistoryItem from "./TripHistoryItem";
+import TripSwipeLeaveAction from "./TripSwipeLeaveAction";
+import LoadingOverlay from "../UI/LoadingOverlay";
+import { TripContext, TripData } from "../../store/trip-context";
 import { OrientationContext } from "../../store/orientation-context";
+import { NetworkContext } from "../../store/network-context";
+import { AuthContext } from "../../store/auth-context";
+import { UserContext } from "../../store/user-context";
+import { ExpensesContext } from "../../store/expenses-context";
 import { constantScale, dynamicScale } from "../../util/scalingUtil";
+import { promptLeaveTrip } from "../../util/prompt-leave-trip";
+import { resolveLeaverOpenBalances } from "../../util/leave-trip";
+import {
+  fetchTrip,
+  getAllExpenses,
+  getTravellers,
+  updateUser,
+} from "../../util/http";
+import {
+  secureStoreGetItem,
+  secureStoreSetItem,
+} from "../../store/secure-storage";
+import { MMKV_KEYS, setMMKVObject } from "../../store/mmkv";
+import { i18n } from "../../i18n/i18n";
+import safeLogError from "../../util/error";
 
 function TripList({ trips }) {
   const { isLandscape } = useContext(OrientationContext);
+  const { isConnected, strongConnection } = useContext(NetworkContext);
+  const online = !!(isConnected && strongConnection);
+  const authCtx = useContext(AuthContext);
+  const tripCtx = useContext(TripContext);
+  const userCtx = useContext(UserContext);
+  const expenseCtx = useContext(ExpensesContext);
+  const row = useRef<Record<number, Swipeable | null>>({}).current;
+  const prevOpenedRow = useRef<Swipeable | null>(null);
+
+  const canLeave = (userCtx.tripHistory?.length ?? trips?.length ?? 0) > 1;
+
+  const forceCloseRow = useCallback(
+    (index: number) => {
+      row[index]?.close();
+    },
+    [row]
+  );
+
+  const closeRow = useCallback(
+    (index: number) => {
+      if (prevOpenedRow.current && prevOpenedRow.current !== row[index]) {
+        prevOpenedRow.current.close();
+      }
+      prevOpenedRow.current = row[index];
+      setTimeout(() => {
+        forceCloseRow(index);
+      }, 1500);
+    },
+    [forceCloseRow, row]
+  );
+
+  const openBalancesDeps = useCallback(
+    () => ({
+      activeTripId: tripCtx.tripid,
+      activeExpenses: expenseCtx.expenses ?? [],
+      activeTripCurrency: tripCtx.tripCurrency,
+      activeIsPaidTimestamp: tripCtx.isPaidTimestamp,
+      userNameFallback: userCtx.userName,
+      getAllExpenses,
+      fetchTrip,
+    }),
+    [
+      expenseCtx.expenses,
+      tripCtx.isPaidTimestamp,
+      tripCtx.tripCurrency,
+      tripCtx.tripid,
+      userCtx.userName,
+    ]
+  );
+
+  const performLeave = useCallback(
+    async (tripid: string) => {
+      const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
+      if (!uid) return;
+
+      Toast.show({
+        type: "loading",
+        text1: i18n.t("toastSaving1"),
+        text2: i18n.t("toastSaving2"),
+        autoHide: false,
+      });
+
+      try {
+        const roster = await getTravellers(tripid);
+        const openBalances = await resolveLeaverOpenBalances(
+          tripid,
+          uid,
+          roster,
+          openBalancesDeps()
+        );
+        const result = await tripCtx.leaveTrip(tripid, {
+          uid,
+          tripHistory: userCtx.tripHistory ?? [],
+          getTravellers,
+          openBalances,
+          removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
+          restoreTripHistoryLocal: userCtx.restoreTripHistory,
+          activate: {
+            previousTripSnapshot: tripCtx.getcurrentTrip(),
+            previousExpensesSnapshot: expenseCtx.expenses,
+            fetchTrip,
+            getTravellers,
+            getAllExpenses,
+            updateUser,
+            secureStoreGetItem,
+            secureStoreSetItem,
+            setCurrentTrip: tripCtx.setCurrentTrip,
+            saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+            saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+            setExpenses: expenseCtx.setExpenses,
+            setExpensesCache: (nextExpenses) =>
+              setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+            setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
+          },
+        });
+
+        if (!result.performed) {
+          Toast.hide();
+          Toast.show({
+            text1: i18n.t("toastSavingError1"),
+            text2: i18n.t("error2"),
+            type: "error",
+          });
+        }
+        // Plain leave: leaveTrip shows Undo toast. Cascade-delete: no Undo.
+      } catch (error) {
+        safeLogError(error);
+        Toast.hide();
+        Toast.show({
+          text1: i18n.t("toastSavingError1"),
+          text2: i18n.t("error2"),
+          type: "error",
+        });
+      }
+    },
+    [
+      authCtx.uid,
+      expenseCtx.expenses,
+      expenseCtx.setExpenses,
+      openBalancesDeps,
+      tripCtx,
+      userCtx.removeTripFromHistory,
+      userCtx.restoreTripHistory,
+      userCtx.setFreshlyCreatedTo,
+      userCtx.tripHistory,
+    ]
+  );
+
+  const onLeavePress = useCallback(
+    async (tripid: string) => {
+      const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
+      if (!uid) return;
+      await promptLeaveTrip({
+        isConnected: online,
+        tripid,
+        uid,
+        tripHistory: userCtx.tripHistory ?? trips ?? [],
+        activeTripId: tripCtx.tripid,
+        getTravellers,
+        openBalancesDeps: openBalancesDeps(),
+        onConfirm: () => {
+          void performLeave(tripid);
+        },
+      });
+    },
+    [
+      authCtx.uid,
+      online,
+      openBalancesDeps,
+      performLeave,
+      tripCtx.tripid,
+      trips,
+      userCtx.tripHistory,
+    ]
+  );
+
   if (!trips || trips?.length < 1) return <LoadingOverlay></LoadingOverlay>;
 
   const uniqTrips: TripData[] = uniqBy(trips);
+
   function renderTripItem(itemData) {
     if (!itemData || !itemData.item) return <></>;
-    if (typeof itemData.item === "string" || itemData.item instanceof String) {
-      return <TripHistoryItem {...{ tripid: itemData.item, trips: trips }} />;
-    } else return <></>;
+    if (!(typeof itemData.item === "string" || itemData.item instanceof String)) {
+      return <></>;
+    }
+    const tripid = itemData.item as string;
+    const index = itemData.index;
+    const card = <TripHistoryItem {...{ tripid, trips }} />;
+
+    if (!canLeave) {
+      return card;
+    }
+
+    const leaveAction = () => (
+      <TripSwipeLeaveAction onPress={() => void onLeavePress(tripid)} />
+    );
+
+    if (Platform.OS === "android") {
+      return (
+        <GestureHandlerRootView>
+          <Swipeable
+            renderLeftActions={leaveAction}
+            onSwipeableOpen={() => closeRow(index)}
+            ref={(ref) => {
+              row[index] = ref;
+            }}
+            overshootFriction={8}
+          >
+            {card}
+          </Swipeable>
+        </GestureHandlerRootView>
+      );
+    }
+
+    return (
+      <Swipeable
+        renderRightActions={leaveAction}
+        onSwipeableOpen={() => closeRow(index)}
+        ref={(ref) => {
+          row[index] = ref;
+        }}
+        overshootFriction={8}
+      >
+        {card}
+      </Swipeable>
+    );
   }
+
   return (
     <View
       testID="trip-list-wrapper"

--- a/TravelCostApp/components/ProfileOutput/TripList.tsx
+++ b/TravelCostApp/components/ProfileOutput/TripList.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { FlatList, Platform, View } from "react-native";
 import Swipeable from "react-native-gesture-handler/Swipeable";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import Toast from "react-native-toast-message";
 import PropTypes from "prop-types";
 import uniqBy from "lodash.uniqby";
 import { useCallback, useContext, useRef } from "react";
@@ -18,7 +17,7 @@ import { UserContext } from "../../store/user-context";
 import { ExpensesContext } from "../../store/expenses-context";
 import { constantScale, dynamicScale } from "../../util/scalingUtil";
 import { promptLeaveTrip } from "../../util/prompt-leave-trip";
-import { resolveLeaverOpenBalances } from "../../util/leave-trip";
+import { performLeaveTripUi } from "../../util/perform-leave-trip-ui";
 import {
   fetchTrip,
   getAllExpenses,
@@ -30,8 +29,6 @@ import {
   secureStoreSetItem,
 } from "../../store/secure-storage";
 import { MMKV_KEYS, setMMKVObject } from "../../store/mmkv";
-import { i18n } from "../../i18n/i18n";
-import safeLogError from "../../util/error";
 
 function TripList({ trips }) {
   const { isLandscape } = useContext(OrientationContext);
@@ -90,65 +87,33 @@ function TripList({ trips }) {
       const uid = authCtx.uid ?? (await secureStoreGetItem("uid"));
       if (!uid) return;
 
-      Toast.show({
-        type: "loading",
-        text1: i18n.t("toastSaving1"),
-        text2: i18n.t("toastSaving2"),
-        autoHide: false,
-      });
-
-      try {
-        const roster = await getTravellers(tripid);
-        const openBalances = await resolveLeaverOpenBalances(
-          tripid,
-          uid,
-          roster,
-          openBalancesDeps()
-        );
-        const result = await tripCtx.leaveTrip(tripid, {
-          uid,
-          tripHistory: userCtx.tripHistory ?? [],
+      await performLeaveTripUi({
+        tripid,
+        uid,
+        tripHistory: userCtx.tripHistory ?? [],
+        getTravellers,
+        openBalancesDeps: openBalancesDeps(),
+        leaveTrip: tripCtx.leaveTrip,
+        removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
+        restoreTripHistoryLocal: userCtx.restoreTripHistory,
+        activate: {
+          previousTripSnapshot: tripCtx.getcurrentTrip(),
+          previousExpensesSnapshot: expenseCtx.expenses,
+          fetchTrip,
           getTravellers,
-          openBalances,
-          removeFromTripHistoryLocal: userCtx.removeTripFromHistory,
-          restoreTripHistoryLocal: userCtx.restoreTripHistory,
-          activate: {
-            previousTripSnapshot: tripCtx.getcurrentTrip(),
-            previousExpensesSnapshot: expenseCtx.expenses,
-            fetchTrip,
-            getTravellers,
-            getAllExpenses,
-            updateUser,
-            secureStoreGetItem,
-            secureStoreSetItem,
-            setCurrentTrip: tripCtx.setCurrentTrip,
-            saveTripDataInStorage: tripCtx.saveTripDataInStorage,
-            saveTravellersInStorage: tripCtx.saveTravellersInStorage,
-            setExpenses: expenseCtx.setExpenses,
-            setExpensesCache: (nextExpenses) =>
-              setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
-            setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
-          },
-        });
-
-        if (!result.performed) {
-          Toast.hide();
-          Toast.show({
-            text1: i18n.t("toastSavingError1"),
-            text2: i18n.t("error2"),
-            type: "error",
-          });
-        }
-        // Plain leave: leaveTrip shows Undo toast. Cascade-delete: no Undo.
-      } catch (error) {
-        safeLogError(error);
-        Toast.hide();
-        Toast.show({
-          text1: i18n.t("toastSavingError1"),
-          text2: i18n.t("error2"),
-          type: "error",
-        });
-      }
+          getAllExpenses,
+          updateUser,
+          secureStoreGetItem,
+          secureStoreSetItem,
+          setCurrentTrip: tripCtx.setCurrentTrip,
+          saveTripDataInStorage: tripCtx.saveTripDataInStorage,
+          saveTravellersInStorage: tripCtx.saveTravellersInStorage,
+          setExpenses: expenseCtx.setExpenses,
+          setExpensesCache: (nextExpenses) =>
+            setMMKVObject(MMKV_KEYS.EXPENSES, nextExpenses),
+          setFreshlyCreatedTo: userCtx.setFreshlyCreatedTo,
+        },
+      });
     },
     [
       authCtx.uid,

--- a/TravelCostApp/components/ProfileOutput/TripSwipeLeaveAction.tsx
+++ b/TravelCostApp/components/ProfileOutput/TripSwipeLeaveAction.tsx
@@ -1,0 +1,34 @@
+import { StyleSheet, View } from "react-native";
+
+import IconButton from "../UI/IconButton";
+import { GlobalStyles } from "../../constants/styles";
+import { constantScale, dynamicScale } from "../../util/scalingUtil";
+
+type TripSwipeLeaveActionProps = {
+  onPress: () => void;
+};
+
+function TripSwipeLeaveAction({ onPress }: TripSwipeLeaveActionProps) {
+  return (
+    <View testID="trip-swipe-leave-action" style={styles.container}>
+      <IconButton
+        icon="exit-outline"
+        color={GlobalStyles.colors.backgroundColor}
+        size={constantScale(36, 0.5)}
+        onPress={onPress}
+      />
+    </View>
+  );
+}
+
+export default TripSwipeLeaveAction;
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: dynamicScale(2, true, 0.5),
+    alignItems: "center",
+    justifyContent: "center",
+    width: dynamicScale(56),
+    backgroundColor: GlobalStyles.colors.error500,
+  },
+});

--- a/TravelCostApp/util/perform-leave-trip-ui.ts
+++ b/TravelCostApp/util/perform-leave-trip-ui.ts
@@ -1,0 +1,81 @@
+import Toast from "react-native-toast-message";
+
+import { i18n } from "../i18n/i18n";
+import safeLogError from "./error";
+import {
+  resolveLeaverOpenBalances,
+  type LeaveTripDeps,
+  type LeaveTripResult,
+  type ResolveLeaverOpenBalancesDeps,
+} from "./leave-trip";
+import type { Traveller } from "./traveler";
+
+export type PerformLeaveTripUiInput = {
+  tripid: string;
+  uid: string;
+  tripHistory: readonly string[];
+  getTravellers: (tripid: string) => Promise<Traveller[]>;
+  openBalancesDeps: ResolveLeaverOpenBalancesDeps;
+  leaveTrip: (
+    tripid: string,
+    deps: Omit<LeaveTripDeps, "activeTripId">
+  ) => Promise<LeaveTripResult>;
+  removeFromTripHistoryLocal: LeaveTripDeps["removeFromTripHistoryLocal"];
+  restoreTripHistoryLocal: LeaveTripDeps["restoreTripHistoryLocal"];
+  activate: NonNullable<LeaveTripDeps["activate"]>;
+};
+
+/**
+ * Shared Leave trip accept path (loading toast + leaveTrip orchestration).
+ * Used by TripForm and My Trips swipe after confirm.
+ */
+export async function performLeaveTripUi(
+  input: PerformLeaveTripUiInput
+): Promise<boolean> {
+  Toast.show({
+    type: "loading",
+    text1: i18n.t("toastSaving1"),
+    text2: i18n.t("toastSaving2"),
+    autoHide: false,
+  });
+
+  try {
+    const roster = await input.getTravellers(input.tripid);
+    const openBalances = await resolveLeaverOpenBalances(
+      input.tripid,
+      input.uid,
+      roster,
+      input.openBalancesDeps
+    );
+    const result = await input.leaveTrip(input.tripid, {
+      uid: input.uid,
+      tripHistory: input.tripHistory,
+      getTravellers: input.getTravellers,
+      openBalances,
+      removeFromTripHistoryLocal: input.removeFromTripHistoryLocal,
+      restoreTripHistoryLocal: input.restoreTripHistoryLocal,
+      activate: input.activate,
+    });
+
+    if (!result.performed) {
+      Toast.hide();
+      Toast.show({
+        text1: i18n.t("toastSavingError1"),
+        text2: i18n.t("error2"),
+        type: "error",
+      });
+      return false;
+    }
+    // Plain leave: leaveTrip shows Undo toast. Cascade-delete: no Undo.
+    return true;
+  } catch (error) {
+    safeLogError(error);
+    Toast.hide();
+    Toast.show({
+      text1: i18n.t("toastSavingError1"),
+      text2: i18n.t("error2"),
+      type: "error",
+    });
+    return false;
+  }
+}

--- a/TravelCostApp/util/prompt-leave-trip.ts
+++ b/TravelCostApp/util/prompt-leave-trip.ts
@@ -1,0 +1,76 @@
+import { Alert } from "react-native";
+
+import { i18n } from "../i18n/i18n";
+import safeLogError from "./error";
+import {
+  leaveConfirmMessage,
+  resolveLeaverOpenBalances,
+  type ResolveLeaverOpenBalancesDeps,
+} from "./leave-trip";
+import { planTripLeave } from "./plan-trip-leave";
+import type { Traveller } from "./traveler";
+
+export type PromptLeaveTripInput = {
+  isConnected: boolean;
+  tripid: string;
+  uid: string;
+  tripHistory: readonly string[];
+  activeTripId: string | null | undefined;
+  getTravellers: (tripid: string) => Promise<Traveller[]>;
+  openBalancesDeps: ResolveLeaverOpenBalancesDeps;
+  onConfirm: () => void;
+};
+
+/**
+ * Shared Leave trip confirm dialog (TripForm button + My Trips swipe).
+ * Online-only; respects last-trip guard (no dialog when not allowed).
+ */
+export async function promptLeaveTrip(
+  input: PromptLeaveTripInput
+): Promise<void> {
+  if (!input.isConnected) {
+    Alert.alert(i18n.t("noConnection"), i18n.t("leaveTripConnectRequired"));
+    return;
+  }
+
+  try {
+    const roster = await input.getTravellers(input.tripid);
+    const openBalances = await resolveLeaverOpenBalances(
+      input.tripid,
+      input.uid,
+      roster,
+      input.openBalancesDeps
+    );
+    const plan = planTripLeave({
+      tripHistory: input.tripHistory,
+      roster,
+      openBalances,
+      activeTripId: input.activeTripId,
+      tripid: input.tripid,
+    });
+
+    if (!plan.allowed) {
+      return;
+    }
+
+    Alert.alert(
+      i18n.t("leaveTrip"),
+      leaveConfirmMessage(plan.warnings),
+      [
+        {
+          text: i18n.t("cancel"),
+          style: "cancel",
+        },
+        {
+          text: i18n.t("leaveTrip"),
+          style: "destructive",
+          onPress: input.onConfirm,
+        },
+      ],
+      { cancelable: false }
+    );
+  } catch (error) {
+    safeLogError(error);
+    Alert.alert(i18n.t("error"), i18n.t("error2"));
+  }
+}


### PR DESCRIPTION
## Summary
- Add swipe-to-leave on My Trips rows (`TripList`), styled like expense delete with an exit-door icon
- Extract shared `promptLeaveTrip` confirm dialog used by TripForm and swipe (plain leave, open-Balance warning, permanent cascade-delete)
- Respect last-trip guard (no swipe when only one trip) and online-only gating; confirm runs `leaveTrip` orchestration (Undo/cascade as prior slices)

## Test plan
- [ ] `pnpm test -- __tests__/components/trip-list-leave-confirm.test.tsx __tests__/components/trip-swipe-leave-action.test.tsx __tests__/components/trip-form-leave-confirm.test.tsx`
- [ ] My Trips with 2+ budgets: swipe row → confirm → leave works; Undo toast on plain leave
- [ ] Last Traveller: permanent-delete warning via swipe
- [ ] Open Balances: warning appended; Leave still available
- [ ] Only one trip: no swipe leave action
- [ ] Offline: connect-required alert on swipe leave

Closes #321