### PR TITLE
Fix logout button failing silently after confirm

### DIFF
--- a/TravelCostApp/__tests__/components/profile-form.test.tsx
+++ b/TravelCostApp/__tests__/components/profile-form.test.tsx
@@ -25,6 +25,12 @@ import { renderWithAppProviders } from "../fixtures/app-providers";
 import { asyncStoreSafeClear } from "../../store/async-storage";
 
 describe("Profile", () => {
+  let alertSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    alertSpy?.mockRestore();
+  });
+
   it("shows the signed-in User name", () => {
     const navigation = { navigate: jest.fn() };
     const screen = renderWithAppProviders(
@@ -57,7 +63,7 @@ describe("Profile", () => {
     const setTripHistory = jest.fn();
     const setUserName = jest.fn(async () => {});
     const setIsFetchingLogout = jest.fn();
-    const alertSpy = jest
+    alertSpy = jest
       .spyOn(Alert, "alert")
       .mockImplementation((_title, _message, buttons) => {
         const yesButton = buttons?.find(
@@ -99,7 +105,40 @@ describe("Profile", () => {
     expect(asyncStoreSafeClear).toHaveBeenCalled();
     expect(setIsFetchingLogout).toHaveBeenCalledWith(true);
     expect(setIsFetchingLogout).toHaveBeenCalledWith(false);
+  });
 
-    alertSpy.mockRestore();
+  it("does not sign the User out when they dismiss logout", () => {
+    const logout = jest.fn();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <ProfileForm
+        navigation={navigation as any}
+        setIsFetchingLogout={jest.fn()}
+      />,
+      {
+        wrapNavigation: false,
+        auth: { uid: "u1", logout },
+        trip: { tripid: "t1", setCurrentTrip: jest.fn(async () => {}) },
+        expenses: { setExpenses: jest.fn() },
+        user: {
+          userName: "Alice",
+          hasNewChanges: false,
+          setHasNewChanges: jest.fn(),
+          setUserName: jest.fn(async () => {}),
+          setTripHistory: jest.fn(),
+        },
+      }
+    );
+
+    fireEvent.press(screen.getByTestId("icon-exit-outline"));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      i18n.t("sure"),
+      i18n.t("signOutAlertMess"),
+      expect.any(Array)
+    );
+    expect(logout).not.toHaveBeenCalled();
   });
 });

--- a/TravelCostApp/__tests__/components/profile-form.test.tsx
+++ b/TravelCostApp/__tests__/components/profile-form.test.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { Alert } from "react-native";
+import { fireEvent, waitFor } from "@testing-library/react-native";
 
 jest.mock("../../util/vexo-tracking", () => ({
   trackEvent: jest.fn(),
@@ -8,13 +10,19 @@ jest.mock("../../util/http", () => ({
   fetchChangelog: jest.fn(async () => null),
 }));
 
+jest.mock("../../store/async-storage", () => ({
+  asyncStoreSafeClear: jest.fn(async () => {}),
+}));
+
 jest.mock("expo-haptics", () => ({
   impactAsync: jest.fn(async () => {}),
   ImpactFeedbackStyle: { Light: "Light" },
 }));
 
 import ProfileForm from "../../components/ManageProfile/ProfileForm";
+import { i18n } from "../../i18n/i18n";
 import { renderWithAppProviders } from "../fixtures/app-providers";
+import { asyncStoreSafeClear } from "../../store/async-storage";
 
 describe("Profile", () => {
   it("shows the signed-in User name", () => {
@@ -40,5 +48,58 @@ describe("Profile", () => {
     );
 
     expect(screen.getByText("Alice")).toBeTruthy();
+  });
+
+  it("signs the User out when they confirm logout", async () => {
+    const logout = jest.fn();
+    const setCurrentTrip = jest.fn(async () => {});
+    const setExpenses = jest.fn();
+    const setTripHistory = jest.fn();
+    const setUserName = jest.fn(async () => {});
+    const setIsFetchingLogout = jest.fn();
+    const alertSpy = jest
+      .spyOn(Alert, "alert")
+      .mockImplementation((_title, _message, buttons) => {
+        const yesButton = buttons?.find(
+          (button) => button.text === i18n.t("yes")
+        );
+        yesButton?.onPress?.();
+      });
+
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <ProfileForm
+        navigation={navigation as any}
+        setIsFetchingLogout={setIsFetchingLogout}
+      />,
+      {
+        wrapNavigation: false,
+        auth: { uid: "u1", logout },
+        trip: { tripid: "t1", setCurrentTrip },
+        expenses: { setExpenses },
+        user: {
+          userName: "Alice",
+          hasNewChanges: false,
+          setHasNewChanges: jest.fn(),
+          setUserName,
+          setTripHistory,
+        },
+      }
+    );
+
+    fireEvent.press(screen.getByTestId("icon-exit-outline"));
+
+    await waitFor(() => {
+      expect(logout).toHaveBeenCalledWith("t1");
+    });
+    expect(setCurrentTrip).toHaveBeenCalledWith("reset", null);
+    expect(setExpenses).toHaveBeenCalledWith([]);
+    expect(setTripHistory).toHaveBeenCalledWith([]);
+    expect(setUserName).toHaveBeenCalledWith("");
+    expect(asyncStoreSafeClear).toHaveBeenCalled();
+    expect(setIsFetchingLogout).toHaveBeenCalledWith(true);
+    expect(setIsFetchingLogout).toHaveBeenCalledWith(false);
+
+    alertSpy.mockRestore();
   });
 });

--- a/TravelCostApp/changelog.txt
+++ b/TravelCostApp/changelog.txt
@@ -5,6 +5,7 @@ __Newest Changes:
 1.3.005j
 - Updated Onboarding
 - Added Leave Trip/Budget Functionality
+- Fixed profile logout button not signing out after confirm
 - Bugfixes and performance improvements
 
 __Other Changes:

--- a/TravelCostApp/components/ManageProfile/ProfileForm.tsx
+++ b/TravelCostApp/components/ManageProfile/ProfileForm.tsx
@@ -22,6 +22,8 @@ import { getMMKVString, MMKV_KEYS } from "../../store/mmkv";
 import { NetworkContext } from "../../store/network-context";
 import { OrientationContext } from "../../store/orientation-context";
 import { dynamicScale } from "../../util/scalingUtil";
+import { trackEvent } from "../../util/vexo-tracking";
+import { VexoEvents } from "../../util/vexo-constants";
 
 const ProfileForm = ({ navigation, setIsFetchingLogout }) => {
   const authCtx = useContext(AuthContext);


### PR DESCRIPTION
## Summary
- Add missing `trackEvent` / `VexoEvents` imports in `ProfileForm` so the sign-out confirmation handler can complete
- Add a ProfileForm test that confirms logout clears session state and calls `auth.logout`

## Test plan
- [x] `pnpm test -- __tests__/components/profile-form.test.tsx`
- [ ] Tap logout on profile, confirm — User is signed out