### PR TITLE
Fix trip history compact currency formatting for spent/budget pairs

### DIFF
--- a/TravelCostApp/__tests__/components/fitting-currency-amount-pair.test.tsx
+++ b/TravelCostApp/__tests__/components/fitting-currency-amount-pair.test.tsx
@@ -63,6 +63,36 @@ describe("pickFittingCurrencyPairDisplay", () => {
     expect(result.spentText).toMatch(/10\.000/);
     expect(result.budgetText).toMatch(/20\.000/);
   });
+
+  it("shows ∞ for total budget on a budget-free trip", () => {
+    const result = pickFittingCurrencyPairDisplay(
+      10_000,
+      0,
+      "EUR",
+      "de",
+      200,
+      150,
+      { noBudget: true }
+    );
+
+    expect(result.spentText).toMatch(/10\.000/);
+    expect(result.budgetText).toBe("∞");
+  });
+
+  it("uses compact trip total spent with ∞ when the pair overflows", () => {
+    const result = pickFittingCurrencyPairDisplay(
+      10_000,
+      0,
+      "EUR",
+      "de",
+      150,
+      200,
+      { noBudget: true }
+    );
+
+    expect(result.spentText).toBe("10k€");
+    expect(result.budgetText).toBe("∞");
+  });
 });
 
 describe("FittingCurrencyAmountPair", () => {
@@ -85,5 +115,54 @@ describe("FittingCurrencyAmountPair", () => {
 
     expect(screen.getByText("10k€")).toBeTruthy();
     expect(screen.getByText("20k€")).toBeTruthy();
+  });
+
+  it("shows full spent/budget when the row is wide enough", () => {
+    render(
+      <FittingCurrencyAmountPair
+        spent={10_000}
+        budget={20_000}
+        currency="EUR"
+        locale="de"
+        textStyle={{ fontSize: 12, fontWeight: "bold" }}
+        testID="fitting-currency-pair"
+      />
+    );
+
+    fireEvent(screen.getByTestId("fitting-currency-pair"), "layout", {
+      nativeEvent: { layout: { width: 200, height: 20, x: 0, y: 0 } },
+    });
+    firePairProbeTextLayout(150);
+
+    expect(screen.queryByText("10k€")).toBeNull();
+    expect(screen.queryByText("20k€")).toBeNull();
+    expect(
+      screen.getAllByText(/10\.000/, { includeHiddenElements: true }).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/20\.000/, { includeHiddenElements: true }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("shows ∞ for total budget when the trip has no total budget", () => {
+    render(
+      <FittingCurrencyAmountPair
+        spent={10_000}
+        budget={0}
+        currency="EUR"
+        locale="de"
+        noBudget
+        textStyle={{ fontSize: 12, fontWeight: "bold" }}
+        testID="fitting-currency-pair"
+      />
+    );
+
+    fireEvent(screen.getByTestId("fitting-currency-pair"), "layout", {
+      nativeEvent: { layout: { width: 200, height: 20, x: 0, y: 0 } },
+    });
+    firePairProbeTextLayout(150);
+
+    expect(screen.getByText("∞")).toBeTruthy();
+    expect(screen.queryByText("10k€")).toBeNull();
   });
 });

--- a/TravelCostApp/__tests__/components/fitting-currency-amount-pair.test.tsx
+++ b/TravelCostApp/__tests__/components/fitting-currency-amount-pair.test.tsx
@@ -1,0 +1,89 @@
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageTag: "de-DE", languageCode: "de" }],
+}));
+
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import {
+  FittingCurrencyAmountPair,
+  pickFittingCurrencyPairDisplay,
+} from "../../components/UI/FittingCurrencyAmount";
+
+function firePairProbeTextLayout(width: number) {
+  fireEvent(
+    screen.getByTestId("fitting-currency-pair-full-probe", {
+      includeHiddenElements: true,
+    }),
+    "textLayout",
+    {
+      nativeEvent: {
+        lines: [
+          {
+            width,
+            height: 20,
+            x: 0,
+            y: 0,
+            ascender: 0,
+            capHeight: 0,
+            descender: 0,
+            xHeight: 0,
+          },
+        ],
+      },
+    }
+  );
+}
+
+describe("pickFittingCurrencyPairDisplay", () => {
+  it("uses compact for both when combined full spent/budget overflows the row", () => {
+    const result = pickFittingCurrencyPairDisplay(
+      10_000,
+      20_000,
+      "EUR",
+      "de",
+      150,
+      200
+    );
+
+    expect(result.spentText).toBe("10k€");
+    expect(result.budgetText).toBe("20k€");
+  });
+
+  it("uses full formatting when combined width fits the row", () => {
+    const result = pickFittingCurrencyPairDisplay(
+      10_000,
+      20_000,
+      "EUR",
+      "de",
+      200,
+      150
+    );
+
+    expect(result.spentText).toMatch(/10\.000/);
+    expect(result.budgetText).toMatch(/20\.000/);
+  });
+});
+
+describe("FittingCurrencyAmountPair", () => {
+  it("shows compact spent/budget when the trip amount row is too narrow", () => {
+    render(
+      <FittingCurrencyAmountPair
+        spent={10_000}
+        budget={20_000}
+        currency="EUR"
+        locale="de"
+        textStyle={{ fontSize: 12, fontWeight: "bold" }}
+        testID="fitting-currency-pair"
+      />
+    );
+
+    fireEvent(screen.getByTestId("fitting-currency-pair"), "layout", {
+      nativeEvent: { layout: { width: 150, height: 20, x: 0, y: 0 } },
+    });
+    firePairProbeTextLayout(200);
+
+    expect(screen.getByText("10k€")).toBeTruthy();
+    expect(screen.getByText("20k€")).toBeTruthy();
+  });
+});

--- a/TravelCostApp/components/ProfileOutput/TripHistoryItem.tsx
+++ b/TravelCostApp/components/ProfileOutput/TripHistoryItem.tsx
@@ -21,7 +21,7 @@ import {
 import { fetchTripName, getTravellers } from "../../util/http";
 import type { Traveller } from "../../util/traveler";
 import { normalizeTravellers } from "../../util/normalize-travellers";
-import { FittingCurrencyAmount } from "../UI/FittingCurrencyAmount";
+import { FittingCurrencyAmount, FittingCurrencyAmountPair } from "../UI/FittingCurrencyAmount";
 
 import { i18n } from "../../i18n/i18n";
 
@@ -549,27 +549,15 @@ function TripHistoryItem({ tripid, trips }) {
             </View>
           </View>
           <View style={styles.amountContainer}>
-            <View style={styles.amountRow}>
-              <FittingCurrencyAmount
-                amount={Number(sumOfExpenses) || 0}
-                currency={tripCurrency}
-                locale={i18n.locale}
-                style={amountTextStyle}
-                containerStyle={styles.amountFit}
-              />
-              <Text style={amountTextStyle}>/</Text>
-              {noTotalBudget ? (
-                <Text style={amountTextStyle}>∞</Text>
-              ) : (
-                <FittingCurrencyAmount
-                  amount={Number(totalBudget) || 0}
-                  currency={tripCurrency}
-                  locale={i18n.locale}
-                  style={amountTextStyle}
-                  containerStyle={styles.amountFit}
-                />
-              )}
-            </View>
+            <FittingCurrencyAmountPair
+              spent={Number(sumOfExpenses) || 0}
+              budget={Number(totalBudget) || 0}
+              currency={tripCurrency}
+              locale={i18n.locale}
+              textStyle={amountTextStyle}
+              rowStyle={styles.amountRow}
+              noBudget={noTotalBudget}
+            />
             <Progress.Bar
               color={
                 isOverBudget
@@ -702,10 +690,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     width: "100%",
-  },
-  amountFit: {
-    flexShrink: 1,
-    maxWidth: "45%",
   },
   amount: {
     fontSize: dynamicScale(12, false, 0.5),

--- a/TravelCostApp/components/UI/FittingCurrencyAmount.tsx
+++ b/TravelCostApp/components/UI/FittingCurrencyAmount.tsx
@@ -104,17 +104,20 @@ type FittingCurrencyPairDisplay = {
   budgetText: string;
 };
 
-/** Chooses compact for both spent and budget when the full pair overflows the row. */
-export function pickFittingCurrencyPairDisplay(
+type SpentBudgetPairLabels = {
+  spentFull: string;
+  spentCompact: string;
+  budgetFull: string;
+  budgetCompact: string;
+};
+
+function formatSpentBudgetPairLabels(
   spent: number,
   budget: number,
   currency: string,
   locale: string,
-  rowWidth: number | null,
-  fullCombinedWidth: number | null,
-  options?: { noBudget?: boolean }
-): FittingCurrencyPairDisplay {
-  const { noBudget = false } = options ?? {};
+  noBudget = false
+): SpentBudgetPairLabels {
   const spentFull = formatExpenseWithCurrency(
     spent,
     currency,
@@ -133,15 +136,45 @@ export function pickFittingCurrencyPairDisplay(
     ? "∞"
     : formatCompactExpenseWithCurrency(budget, currency, locale);
 
+  return { spentFull, spentCompact, budgetFull, budgetCompact };
+}
+
+/** Chooses compact for both spent and budget when the full pair overflows the row. */
+export function pickFittingCurrencyPairLabels(
+  labels: SpentBudgetPairLabels,
+  rowWidth: number | null,
+  fullCombinedWidth: number | null
+): FittingCurrencyPairDisplay {
   const useCompact =
     rowWidth != null &&
     fullCombinedWidth != null &&
     fullCombinedWidth > rowWidth;
 
   return {
-    spentText: useCompact ? spentCompact : spentFull,
-    budgetText: useCompact ? budgetCompact : budgetFull,
+    spentText: useCompact ? labels.spentCompact : labels.spentFull,
+    budgetText: useCompact ? labels.budgetCompact : labels.budgetFull,
   };
+}
+
+/** Chooses compact for both spent and budget when the full pair overflows the row. */
+export function pickFittingCurrencyPairDisplay(
+  spent: number,
+  budget: number,
+  currency: string,
+  locale: string,
+  rowWidth: number | null,
+  fullCombinedWidth: number | null,
+  options?: { noBudget?: boolean }
+): FittingCurrencyPairDisplay {
+  const { noBudget = false } = options ?? {};
+  const labels = formatSpentBudgetPairLabels(
+    spent,
+    budget,
+    currency,
+    locale,
+    noBudget
+  );
+  return pickFittingCurrencyPairLabels(labels, rowWidth, fullCombinedWidth);
 }
 
 export function useFittingCurrencyPairText(
@@ -158,27 +191,27 @@ export function useFittingCurrencyPairText(
 
   const resolvedLocale = resolveFittingLocale(locale);
 
-  const fullProbeText = useMemo(() => {
-    const spentFull = formatExpenseWithCurrency(
-      spent,
-      currency,
-      undefined,
-      resolvedLocale
-    );
-    const budgetFull = noBudget
-      ? "∞"
-      : formatExpenseWithCurrency(budget, currency, undefined, resolvedLocale);
-    return `${spentFull}/${budgetFull}`;
-  }, [spent, budget, currency, resolvedLocale, noBudget]);
+  const labels = useMemo(
+    () =>
+      formatSpentBudgetPairLabels(
+        spent,
+        budget,
+        currency,
+        resolvedLocale,
+        noBudget
+      ),
+    [spent, budget, currency, resolvedLocale, noBudget]
+  );
 
-  const { spentText, budgetText } = pickFittingCurrencyPairDisplay(
-    spent,
-    budget,
-    currency,
-    resolvedLocale,
+  const fullProbeText = useMemo(
+    () => `${labels.spentFull}/${labels.budgetFull}`,
+    [labels]
+  );
+
+  const { spentText, budgetText } = pickFittingCurrencyPairLabels(
+    labels,
     rowWidth,
-    fullCombinedWidth,
-    { noBudget }
+    fullCombinedWidth
   );
 
   function onRowLayout(event: LayoutChangeEvent) {

--- a/TravelCostApp/components/UI/FittingCurrencyAmount.tsx
+++ b/TravelCostApp/components/UI/FittingCurrencyAmount.tsx
@@ -99,6 +99,174 @@ export function useFittingCurrencyText(
  * space-saving compact form. Full width is measured via a hidden probe
  * so the visible text never feeds back into the fit decision.
  */
+type FittingCurrencyPairDisplay = {
+  spentText: string;
+  budgetText: string;
+};
+
+/** Chooses compact for both spent and budget when the full pair overflows the row. */
+export function pickFittingCurrencyPairDisplay(
+  spent: number,
+  budget: number,
+  currency: string,
+  locale: string,
+  rowWidth: number | null,
+  fullCombinedWidth: number | null,
+  options?: { noBudget?: boolean }
+): FittingCurrencyPairDisplay {
+  const { noBudget = false } = options ?? {};
+  const spentFull = formatExpenseWithCurrency(
+    spent,
+    currency,
+    undefined,
+    locale
+  );
+  const spentCompact = formatCompactExpenseWithCurrency(
+    spent,
+    currency,
+    locale
+  );
+  const budgetFull = noBudget
+    ? "∞"
+    : formatExpenseWithCurrency(budget, currency, undefined, locale);
+  const budgetCompact = noBudget
+    ? "∞"
+    : formatCompactExpenseWithCurrency(budget, currency, locale);
+
+  const useCompact =
+    rowWidth != null &&
+    fullCombinedWidth != null &&
+    fullCombinedWidth > rowWidth;
+
+  return {
+    spentText: useCompact ? spentCompact : spentFull,
+    budgetText: useCompact ? budgetCompact : budgetFull,
+  };
+}
+
+export function useFittingCurrencyPairText(
+  spent: number,
+  budget: number,
+  currency: string,
+  locale?: string,
+  noBudget = false
+) {
+  const [rowWidth, setRowWidth] = useState<number | null>(null);
+  const [fullCombinedWidth, setFullCombinedWidth] = useState<number | null>(
+    null
+  );
+
+  const resolvedLocale = resolveFittingLocale(locale);
+
+  const fullProbeText = useMemo(() => {
+    const spentFull = formatExpenseWithCurrency(
+      spent,
+      currency,
+      undefined,
+      resolvedLocale
+    );
+    const budgetFull = noBudget
+      ? "∞"
+      : formatExpenseWithCurrency(budget, currency, undefined, resolvedLocale);
+    return `${spentFull}/${budgetFull}`;
+  }, [spent, budget, currency, resolvedLocale, noBudget]);
+
+  const { spentText, budgetText } = pickFittingCurrencyPairDisplay(
+    spent,
+    budget,
+    currency,
+    resolvedLocale,
+    rowWidth,
+    fullCombinedWidth,
+    { noBudget }
+  );
+
+  function onRowLayout(event: LayoutChangeEvent) {
+    setRowWidth(event.nativeEvent.layout.width);
+  }
+
+  function onFullProbeTextLayout(
+    event: NativeSyntheticEvent<TextLayoutEventData>
+  ) {
+    const lineWidth = event.nativeEvent.lines[0]?.width;
+    if (lineWidth != null) {
+      setFullCombinedWidth(lineWidth);
+    }
+  }
+
+  return {
+    spentText,
+    budgetText,
+    fullProbeText,
+    onRowLayout,
+    onFullProbeTextLayout,
+  };
+}
+
+type FittingCurrencyAmountPairProps = {
+  spent: number;
+  budget: number;
+  currency: string;
+  locale?: string;
+  textStyle?: StyleProp<TextStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
+  rowStyle?: StyleProp<ViewStyle>;
+  noBudget?: boolean;
+  testID?: string;
+};
+
+/**
+ * Shows full spent/budget formatting when the pair fits the row; otherwise
+ * compact form for both amounts so neither side ellipsizes alone.
+ */
+export function FittingCurrencyAmountPair({
+  spent,
+  budget,
+  currency,
+  locale,
+  textStyle,
+  containerStyle,
+  rowStyle,
+  noBudget = false,
+  testID = "fitting-currency-pair",
+}: FittingCurrencyAmountPairProps) {
+  const {
+    spentText,
+    budgetText,
+    fullProbeText,
+    onRowLayout,
+    onFullProbeTextLayout,
+  } = useFittingCurrencyPairText(spent, budget, currency, locale, noBudget);
+
+  return (
+    <View
+      testID={testID}
+      style={[styles.pairContainer, containerStyle]}
+      onLayout={onRowLayout}
+    >
+      <Text
+        testID={`${testID}-full-probe`}
+        style={[textStyle, styles.fullProbe]}
+        onTextLayout={onFullProbeTextLayout}
+        numberOfLines={1}
+        importantForAccessibility="no-hide-descendants"
+        accessibilityElementsHidden
+      >
+        {fullProbeText}
+      </Text>
+      <View style={[styles.pairRow, rowStyle]}>
+        <Text style={textStyle} numberOfLines={1}>
+          {spentText}
+        </Text>
+        <Text style={textStyle}>/</Text>
+        <Text style={textStyle} numberOfLines={1}>
+          {budgetText}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
 export function FittingCurrencyAmount({
   amount,
   currency,
@@ -138,6 +306,16 @@ const styles = StyleSheet.create({
     flexShrink: 1,
     alignSelf: "stretch",
     overflow: "hidden",
+  },
+  pairContainer: {
+    width: "100%",
+    overflow: "hidden",
+  },
+  pairRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
   },
   fullProbe: {
     position: "absolute",


### PR DESCRIPTION
## Summary
- Add `FittingCurrencyAmountPair` to measure spent/budget as one row and switch both amounts to compact form when the pair overflows
- Replace per-amount fitting in trip history cards so amounts like `10.000€/20.000€` render as `10k€/20k€` instead of `10.../20.000€`
- Add tests for pair-level fit logic and component behavior

## Test plan
- [x] `pnpm test -- fitting-currency-amount-pair.test.tsx fitting-currency-amount.test.tsx currency-ticker-fitting.test.tsx`
- [ ] Trip history card with `10.000€/20.000€` shows `10k€/20k€` on device
- [ ] Smaller amounts still show full formatting when the pair fits