### PR TITLE
Soften trip list item press feedback

### DIFF
--- a/TravelCostApp/__tests__/components/trip-history-item.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-history-item.test.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet } from "react-native";
 import { waitFor } from "@testing-library/react-native";
 
 import TripHistoryItem from "../../components/ProfileOutput/TripHistoryItem";
+import { GlobalStyles } from "../../constants/styles";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
 jest.mock("../../util/vexo-tracking", () => ({
@@ -19,6 +20,10 @@ jest.mock("../../util/http", () => ({
   })),
 }));
 
+jest.mock("../../util/trip", () => ({
+  getTripData: jest.fn(),
+}));
+
 jest.mock("../../store/mmkv", () => {
   const actual = jest.requireActual("../../store/mmkv-keys");
   return {
@@ -29,19 +34,47 @@ jest.mock("../../store/mmkv", () => {
   };
 });
 
+const { getTripData } = jest.requireMock("../../util/trip") as {
+  getTripData: jest.Mock;
+};
+const http = jest.requireMock("../../util/http") as {
+  fetchTripName: jest.Mock;
+  getTravellers: jest.Mock;
+};
+
 function getPressedPressableStyle(
   screen: ReturnType<typeof renderWithAppProviders>
 ) {
-  screen.getByTestId("trip-history-card-t1");
+  screen.getByTestId(/^trip-history-card-/);
   const pressable = screen.UNSAFE_getByType(Pressable);
   const rawStyle = pressable.props.style;
   return StyleSheet.flatten(
     typeof rawStyle === "function" ? rawStyle({ pressed: true }) : rawStyle
-  ) as Record<string, unknown>;
+  );
+}
+
+function expectPressedTripListItemStyle(
+  screen: ReturnType<typeof renderWithAppProviders>
+) {
+  expect(getPressedPressableStyle(screen)).toEqual(
+    GlobalStyles.pressedTripListItem
+  );
 }
 
 describe("TripHistoryItem", () => {
-  it("uses a subtle press scale on trip list items", async () => {
+  beforeEach(() => {
+    getTripData.mockResolvedValue({
+      dailyBudget: "100",
+      totalBudget: "3000",
+      tripCurrency: "EUR",
+      startDate: "2026-01-01",
+      endDate: "2026-01-31",
+    });
+    http.fetchTripName.mockResolvedValue("Japan 2026");
+    http.getTravellers.mockResolvedValue([{ uid: "u1", userName: "Alice" }]);
+  });
+
+  it("uses the trip list pressed style after trip data has loaded", async () => {
     const screen = renderWithAppProviders(
       <TripHistoryItem tripid="t1" trips={["t1"]} />,
       {
@@ -54,9 +87,23 @@ describe("TripHistoryItem", () => {
       expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
     });
 
-    const pressedStyle = getPressedPressableStyle(screen);
-    const transform = pressedStyle.transform as Array<{ scale: number }>;
+    expectPressedTripListItemStyle(screen);
+  });
 
-    expect(transform).toEqual([{ scale: 0.975 }]);
+  it("uses the trip list pressed style while trip data is loading", () => {
+    getTripData.mockImplementation(() => new Promise(() => {}));
+    http.fetchTripName.mockImplementation(() => new Promise(() => {}));
+    http.getTravellers.mockImplementation(() => new Promise(() => {}));
+
+    const screen = renderWithAppProviders(
+      <TripHistoryItem tripid="t2" trips={["t1", "t2"]} />,
+      {
+        trip: { tripid: "t1" },
+        expenses: { expenses: [], getExpensesSum: () => 0 },
+      }
+    );
+
+    expect(screen.getByTestId("trip-history-card-t2")).toBeTruthy();
+    expectPressedTripListItemStyle(screen);
   });
 });

--- a/TravelCostApp/__tests__/components/trip-history-item.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-history-item.test.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import { Pressable, StyleSheet } from "react-native";
+import { waitFor } from "@testing-library/react-native";
+
+import TripHistoryItem from "../../components/ProfileOutput/TripHistoryItem";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("../../util/http", () => ({
+  fetchTripName: jest.fn(async () => "Japan 2026"),
+  getTravellers: jest.fn(async () => [{ uid: "u1", userName: "Alice" }]),
+  getTripData: jest.fn(async () => ({
+    dailyBudget: "100",
+    totalBudget: "3000",
+    tripCurrency: "EUR",
+  })),
+}));
+
+jest.mock("../../store/mmkv", () => {
+  const actual = jest.requireActual("../../store/mmkv-keys");
+  return {
+    getMMKVObject: jest.fn(() => null),
+    setMMKVObject: jest.fn(),
+    MMKV_KEYS: actual.MMKV_KEYS,
+    MMKV_KEY_PATTERNS: actual.MMKV_KEY_PATTERNS,
+  };
+});
+
+function getPressedPressableStyle(
+  screen: ReturnType<typeof renderWithAppProviders>
+) {
+  screen.getByTestId("trip-history-card-t1");
+  const pressable = screen.UNSAFE_getByType(Pressable);
+  const rawStyle = pressable.props.style;
+  return StyleSheet.flatten(
+    typeof rawStyle === "function" ? rawStyle({ pressed: true }) : rawStyle
+  ) as Record<string, unknown>;
+}
+
+describe("TripHistoryItem", () => {
+  it("uses a subtle press scale on trip list items", async () => {
+    const screen = renderWithAppProviders(
+      <TripHistoryItem tripid="t1" trips={["t1"]} />,
+      {
+        trip: { tripid: "t1" },
+        expenses: { expenses: [], getExpensesSum: () => 0 },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-history-card-t1")).toBeTruthy();
+    });
+
+    const pressedStyle = getPressedPressableStyle(screen);
+    const transform = pressedStyle.transform as Array<{ scale: number }>;
+
+    expect(transform).toEqual([{ scale: 0.975 }]);
+  });
+});

--- a/TravelCostApp/components/ProfileOutput/TripHistoryItem.tsx
+++ b/TravelCostApp/components/ProfileOutput/TripHistoryItem.tsx
@@ -399,7 +399,7 @@ function TripHistoryItem({ tripid, trips }) {
     return (
       <Pressable
         onPress={tripPressHandler}
-        style={({ pressed }) => pressed && GlobalStyles.pressed}
+        style={({ pressed }) => pressed && GlobalStyles.pressedTripListItem}
       >
         <View
           testID={`trip-history-card-${tripid}`}
@@ -483,7 +483,7 @@ function TripHistoryItem({ tripid, trips }) {
   return (
     <Pressable
       onPress={tripPressHandler}
-      style={({ pressed }) => pressed && GlobalStyles.pressed}
+      style={({ pressed }) => pressed && GlobalStyles.pressedTripListItem}
     >
       <View
         testID={`trip-history-card-${tripid}`}

--- a/TravelCostApp/constants/styles.ts
+++ b/TravelCostApp/constants/styles.ts
@@ -156,6 +156,11 @@ export const GlobalStyles = {
     transform: [{ scale: 0.9 }],
     opacity: 0.9,
   },
+  pressedTripListItem: {
+    elevation: 0,
+    transform: [{ scale: 0.975 }],
+    opacity: 0.975,
+  },
   countryFlagStyle: {
     width: dynamicScale(30, false, 0.5),
     height: dynamicScale(25, false, 0.5),


### PR DESCRIPTION
## Summary
- Add `GlobalStyles.pressedTripListItem` with a subtler press scale (0.975 vs 0.9) and opacity
- Apply the new style to profile trip list cards in `TripHistoryItem`
- Add a component test asserting the pressed scale on trip list items

## Test plan
- [x] `pnpm test -- __tests__/components/trip-history-item.test.tsx`
- [ ] Press a trip card on the profile screen and confirm the shrink feels lighter than before