### PR TITLE
Introduce ActionRow and unify tappable actions across the app

### DIFF
--- a/TravelCostApp/__tests__/components/action-row-stack.test.tsx
+++ b/TravelCostApp/__tests__/components/action-row-stack.test.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import { Pressable, StyleSheet } from "react-native";
+import { fireEvent } from "@testing-library/react-native";
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+import ActionRowStack from "../../components/UI/ActionRowStack";
+import { ActionRowTokens } from "../../styles/action-row-tokens";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+describe("ActionRowStack", () => {
+  it("spaces stacked rows for modal footers", () => {
+    const screen = renderWithAppProviders(
+      <ActionRowStack
+        actions={[
+          {
+            testID: "stack-primary",
+            tier: "primary",
+            label: "Submit",
+            onPress: jest.fn(),
+          },
+          {
+            testID: "stack-cancel",
+            tier: "secondary",
+            label: "Cancel",
+            onPress: jest.fn(),
+          },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const stackStyle = StyleSheet.flatten(
+      screen.getByTestId("action-row-stack").props.style
+    ) as Record<string, unknown>;
+
+    expect(stackStyle.gap).toBe(ActionRowTokens.marginBottom);
+  });
+
+  it("hides chevrons by default for form and modal commits", () => {
+    const screen = renderWithAppProviders(
+      <ActionRowStack
+        actions={[
+          {
+            testID: "stack-no-chevron",
+            label: "Confirm",
+            onPress: jest.fn(),
+          },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
+    expect(screen.queryByText("›")).toBeNull();
+  });
+
+  it("does not fire disabled actions", () => {
+    const onPress = jest.fn();
+    const screen = renderWithAppProviders(
+      <ActionRowStack
+        actions={[
+          {
+            testID: "stack-disabled",
+            tier: "primary",
+            label: "Submit",
+            onPress,
+            disabled: true,
+          },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const pressable = screen.getByTestId("stack-disabled");
+    const rowStyle = StyleSheet.flatten(
+      typeof pressable.props.style === "function"
+        ? pressable.props.style({ pressed: false })
+        : pressable.props.style
+    ) as Record<string, unknown>;
+    expect(rowStyle.opacity).toBe(0.5);
+
+    fireEvent.press(pressable);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("clears per-row bottom margin so stack gap controls spacing", () => {
+    const screen = renderWithAppProviders(
+      <ActionRowStack
+        actions={[
+          { testID: "stack-row-a", label: "First", onPress: jest.fn() },
+          { testID: "stack-row-b", label: "Second", onPress: jest.fn() },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const pressables = screen.UNSAFE_getAllByType(Pressable);
+    for (const pressable of pressables) {
+      const rowStyle = StyleSheet.flatten(
+        typeof pressable.props.style === "function"
+          ? pressable.props.style({ pressed: false })
+          : pressable.props.style
+      ) as Record<string, unknown>;
+      expect(rowStyle.marginBottom).toBeUndefined();
+    }
+  });
+});

--- a/TravelCostApp/__tests__/components/action-row-stack.test.tsx
+++ b/TravelCostApp/__tests__/components/action-row-stack.test.tsx
@@ -86,6 +86,28 @@ describe("ActionRowStack", () => {
     expect(onPress).not.toHaveBeenCalled();
   });
 
+  it("renders duplicate labels when testIDs are omitted", () => {
+    const firstPress = jest.fn();
+    const secondPress = jest.fn();
+    const screen = renderWithAppProviders(
+      <ActionRowStack
+        actions={[
+          { label: "Cancel", onPress: firstPress },
+          { label: "Cancel", onPress: secondPress },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const pressables = screen.UNSAFE_getAllByType(Pressable);
+    expect(pressables).toHaveLength(2);
+
+    fireEvent.press(pressables[0]);
+    fireEvent.press(pressables[1]);
+    expect(firstPress).toHaveBeenCalledTimes(1);
+    expect(secondPress).toHaveBeenCalledTimes(1);
+  });
+
   it("clears per-row bottom margin so stack gap controls spacing", () => {
     const screen = renderWithAppProviders(
       <ActionRowStack

--- a/TravelCostApp/__tests__/components/action-row.test.tsx
+++ b/TravelCostApp/__tests__/components/action-row.test.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Pressable, StyleSheet } from "react-native";
+import { fireEvent } from "@testing-library/react-native";
 import { LinearGradient } from "expo-linear-gradient";
+import * as Haptics from "expo-haptics";
 
 jest.mock("expo-haptics", () => ({
   impactAsync: jest.fn(async () => {}),
@@ -24,6 +26,10 @@ function getPressedPressableStyle(
 }
 
 describe("ActionRow", () => {
+  beforeEach(() => {
+    jest.mocked(Haptics.impactAsync).mockClear();
+  });
+
   it("renders a gradient accent strip for primary tier", () => {
     const screen = renderWithAppProviders(
       <ActionRow
@@ -110,5 +116,74 @@ describe("ActionRow", () => {
     expect(cardStyle.backgroundColor).not.toBe(
       GlobalStyles.colors.backgroundColor
     );
+  });
+
+  it("exposes button accessibility with label and optional hint", () => {
+    const screen = renderWithAppProviders(
+      <ActionRow
+        testID="action-row-a11y"
+        label="Join budget"
+        hint="Enter an invite code"
+        onPress={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const pressable = screen.getByTestId("action-row-a11y");
+    expect(pressable.props.accessibilityRole).toBe("button");
+    expect(pressable.props.accessibilityLabel).toBe("Join budget");
+    expect(pressable.props.accessibilityHint).toBe("Enter an invite code");
+  });
+
+  it("omits accessibilityHint when no hint is provided", () => {
+    const screen = renderWithAppProviders(
+      <ActionRow
+        testID="action-row-a11y-no-hint"
+        label="Feedback"
+        onPress={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    expect(
+      screen.getByTestId("action-row-a11y-no-hint").props.accessibilityHint
+    ).toBeUndefined();
+  });
+
+  it("invokes onPress with light haptic feedback", () => {
+    const onPress = jest.fn();
+    const screen = renderWithAppProviders(
+      <ActionRow
+        testID="action-row-press"
+        label="Save"
+        onPress={onPress}
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent.press(screen.getByTestId("action-row-press"));
+
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(
+      Haptics.ImpactFeedbackStyle.Light
+    );
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke onPress or haptics when disabled", () => {
+    const onPress = jest.fn();
+    const screen = renderWithAppProviders(
+      <ActionRow
+        testID="action-row-disabled"
+        label="Save"
+        onPress={onPress}
+        disabled
+      />,
+      { wrapNavigation: false }
+    );
+
+    fireEvent.press(screen.getByTestId("action-row-disabled"));
+
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+    expect(onPress).not.toHaveBeenCalled();
   });
 });

--- a/TravelCostApp/__tests__/components/action-row.test.tsx
+++ b/TravelCostApp/__tests__/components/action-row.test.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+import { Pressable, StyleSheet } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+import ActionRow from "../../components/UI/ActionRow";
+import { GlobalStyles } from "../../constants/styles";
+import { ActionRowTokens } from "../../styles/action-row-tokens";
+import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function getPressedPressableStyle(
+  screen: ReturnType<typeof renderWithAppProviders>
+) {
+  const pressable = screen.UNSAFE_getByType(Pressable);
+  const rawStyle = pressable.props.style;
+  return StyleSheet.flatten(
+    typeof rawStyle === "function" ? rawStyle({ pressed: true }) : rawStyle
+  ) as Record<string, unknown>;
+}
+
+describe("ActionRow", () => {
+  it("renders a gradient accent strip for primary tier", () => {
+    const screen = renderWithAppProviders(
+      <ActionRow
+        testID="action-row-primary"
+        tier="primary"
+        label="Add another budget"
+        hint="Starts empty"
+        icon="add-circle-outline"
+        onPress={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const gradients = screen.UNSAFE_queryAllByType(LinearGradient);
+    expect(gradients.length).toBe(1);
+    expect(gradients[0].props.colors).toEqual(
+      ActionRowTokens.gradients.primary
+    );
+  });
+
+  it("renders no accent strip for secondary tier", () => {
+    const screen = renderWithAppProviders(
+      <ActionRow
+        testID="action-row-secondary"
+        tier="secondary"
+        label="Join budget"
+        icon="people-outline"
+        onPress={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    expect(screen.UNSAFE_queryAllByType(LinearGradient)).toHaveLength(0);
+  });
+
+  it("applies subtle pressed scale matching trip list items", () => {
+    const screen = renderWithAppProviders(
+      <ActionRow
+        testID="action-row-pressed"
+        label="Feedback"
+        onPress={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const pressedStyle = getPressedPressableStyle(screen);
+    expect(pressedStyle.transform).toEqual(
+      GlobalStyles.pressedActionRow.transform
+    );
+    expect(pressedStyle.opacity).toBe(GlobalStyles.pressedActionRow.opacity);
+  });
+
+  it("co-locates shadow, border, and background on the row shell", () => {
+    const screen = renderWithAppProviders(
+      <ActionRow
+        testID="action-row-shadow"
+        label="Local Price"
+        onPress={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const pressable = screen.getByTestId("action-row-shadow");
+    const rawStyle = pressable.props.style;
+    const rowStyle = StyleSheet.flatten(
+      typeof rawStyle === "function" ? rawStyle({ pressed: false }) : rawStyle
+    ) as Record<string, unknown>;
+    const cardStyle = StyleSheet.flatten(
+      shadowRegressionStyles.actionRowCard
+    ) as Record<string, unknown>;
+
+    expect(rowStyle.backgroundColor).toBe(cardStyle.backgroundColor);
+    expect(rowStyle.borderWidth).toBe(cardStyle.borderWidth);
+    expect(rowStyle.borderColor).toBe(cardStyle.borderColor);
+    expect(rowStyle.shadowOpacity).toBe(cardStyle.shadowOpacity);
+  });
+
+  it("uses a white surface that contrasts the page background", () => {
+    const cardStyle = StyleSheet.flatten(
+      shadowRegressionStyles.actionRowCard
+    ) as Record<string, unknown>;
+
+    expect(cardStyle.backgroundColor).toBe(ActionRowTokens.surface);
+    expect(cardStyle.backgroundColor).not.toBe(
+      GlobalStyles.colors.backgroundColor
+    );
+  });
+});

--- a/TravelCostApp/__tests__/components/expense-template-picker-modal.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-template-picker-modal.test.tsx
@@ -10,7 +10,9 @@ jest.mock("@react-navigation/native", () => ({
 
 import { fireEvent } from "@testing-library/react-native";
 
+import ExpenseTemplateHelpModal from "../../components/ManageExpense/ExpenseTemplateHelpModal";
 import ExpenseTemplatePickerModal from "../../components/ManageExpense/ExpenseTemplatePickerModal";
+import { i18n } from "../../i18n/i18n";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
@@ -34,5 +36,35 @@ describe("ExpenseTemplatePickerModal", () => {
     fireEvent(screen.getByTestId("expense-template-picker-list"), "onEndReached");
 
     expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a single confirm row without chevron in the help modal", () => {
+    const screen = renderWithAppProviders(
+      <ExpenseTemplateHelpModal isVisible onClose={jest.fn()} />,
+      { wrapNavigation: false }
+    );
+
+    expect(screen.getByTestId("expense-template-help-modal")).toBeTruthy();
+    expect(screen.getByText(i18n.t("confirm"))).toBeTruthy();
+    expect(screen.queryByText("›")).toBeNull();
+  });
+
+  it("shows header cancel row without chevron", () => {
+    const templates = [makeExpense({ id: "e-1", description: "Coffee shop" })];
+
+    const screen = renderWithAppProviders(
+      <ExpenseTemplatePickerModal
+        isVisible
+        onClose={jest.fn()}
+        templates={templates}
+        topDuplicateCount={0}
+        onSelectTemplate={jest.fn()}
+        onLoadMore={jest.fn()}
+      />,
+      { wrapNavigation: false }
+    );
+
+    expect(screen.getByTestId("expense-template-picker-close")).toBeTruthy();
+    expect(screen.queryByText("›")).toBeNull();
   });
 });

--- a/TravelCostApp/__tests__/components/form-action-row-footers.test.tsx
+++ b/TravelCostApp/__tests__/components/form-action-row-footers.test.tsx
@@ -1,0 +1,360 @@
+import * as React from "react";
+import { StyleSheet } from "react-native";
+import { within } from "@testing-library/react-native";
+
+jest.mock("../../util/http", () => ({
+  storeTrip: jest.fn(),
+  storeTripHistory: jest.fn(),
+  updateUser: jest.fn(),
+  fetchTrip: jest.fn(async () => ({
+    tripName: "Beach budget",
+    tripCurrency: "EUR",
+    dailyBudget: "0",
+    totalBudget: "0",
+    isDynamicDailyBudget: false,
+    travellers: [],
+  })),
+  updateTripHistory: jest.fn(),
+  updateTrip: jest.fn(),
+  getAllExpenses: jest.fn(async () => []),
+  getTravellers: jest.fn(async () => [{ uid: "u1", userName: "Alice" }]),
+  putTravelerInTrip: jest.fn(),
+  deleteTrip: jest.fn(),
+}));
+
+jest.mock("../../util/connectionSpeed", () => ({
+  isConnectionFastEnough: jest.fn(async () => true),
+  isConnectionFastEnoughAsBool: jest.fn(async () => true),
+}));
+
+jest.mock("../../util/activate-trip", () => ({
+  activateTrip: jest.fn(async () => {}),
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+jest.mock("@react-navigation/elements", () => ({
+  useHeaderHeight: () => 0,
+}));
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useFocusEffect: jest.fn(),
+  };
+});
+
+jest.mock("../../components/Currency/CurrencyPicker", () => () => null);
+jest.mock("../../components/UI/DatePickerModal", () => () => null);
+jest.mock("../../components/UI/DatePickerContainer", () => () => null);
+
+jest.mock("../../store/mmkv", () => ({
+  getExpenseDraft: jest.fn(() => undefined),
+  setExpenseDraft: jest.fn(),
+  clearExpenseDraft: jest.fn(),
+  getExpenseCat: jest.fn(() => undefined),
+  clearExpenseCat: jest.fn(),
+  getMMKVObject: jest.fn(() => undefined),
+  setExpenseCat: jest.fn(),
+  MMKV_KEYS: { CATEGORY_LIST: "categoryList", EXPENSES: "expenses" },
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => "u1"),
+  secureStoreSetItem: jest.fn(async () => {}),
+}));
+
+jest.mock("../../util/currencyExchange", () => ({
+  getRate: jest.fn(async () => 1),
+}));
+
+jest.mock("../../components/Premium/PremiumConstants", () => ({
+  isPremiumMember: jest.fn(async () => true),
+  ENTITLEMENT_ID: "premium",
+}));
+
+import TripForm from "../../components/ManageTrip/TripForm";
+import ExpenseForm from "../../components/ManageExpense/ExpenseForm";
+import JoinTrip from "../../screens/JoinTrip";
+import { i18n } from "../../i18n/i18n";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { makeExpense } from "../fixtures/expense";
+
+const navigation = {
+  navigate: jest.fn(),
+  pop: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+function stackActionTestIds(stack: ReturnType<typeof renderWithAppProviders>) {
+  const stackNode = stack.getByTestId("action-row-stack");
+  return React.Children.toArray(stackNode.props.children).map(
+    (child: React.ReactElement) => child.props.testID
+  );
+}
+
+function rowShowsChevron(
+  screen: ReturnType<typeof renderWithAppProviders>,
+  testID: string
+) {
+  const row = screen.getByTestId(testID);
+  return within(row).queryAllByText("›").length > 0;
+}
+
+describe("form ActionRow footers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("TripForm", () => {
+    it("stacks primary confirm above cancel in the footer", () => {
+      const screen = renderWithAppProviders(
+        <TripForm navigation={navigation} route={{ params: {} }} />,
+        {
+          network: { isConnected: true, strongConnection: true },
+          expenses: { expenses: [] },
+        }
+      );
+
+      expect(stackActionTestIds(screen)).toEqual([
+        "trip-form-confirm",
+        "trip-form-cancel",
+      ]);
+    });
+
+    it("hides chevrons on footer commits", () => {
+      const screen = renderWithAppProviders(
+        <TripForm navigation={navigation} route={{ params: {} }} />,
+        {
+          network: { isConnected: true, strongConnection: true },
+          expenses: { expenses: [] },
+        }
+      );
+
+      expect(rowShowsChevron(screen, "trip-form-confirm")).toBe(false);
+      expect(rowShowsChevron(screen, "trip-form-cancel")).toBe(false);
+    });
+
+    it("shows join budget as a header navigation row with chevron", () => {
+      const screen = renderWithAppProviders(
+        <TripForm navigation={navigation} route={{ params: {} }} />,
+        {
+          network: { isConnected: true, strongConnection: true },
+          expenses: { expenses: [] },
+        }
+      );
+
+      expect(screen.getByTestId("trip-form-join")).toBeTruthy();
+      expect(rowShowsChevron(screen, "trip-form-join")).toBe(true);
+    });
+  });
+
+  describe("ExpenseForm", () => {
+    it("stacks primary submit above cancel in the footer", async () => {
+      const screen = renderWithAppProviders(
+        <ExpenseForm
+          onCancel={jest.fn()}
+          onSubmit={jest.fn(async () => {})}
+          submitButtonLabel={i18n.t("add")}
+          isEditing={false}
+          defaultValues={makeExpense({
+            amount: 0,
+            description: "",
+            whoPaid: "",
+            splitList: [],
+            listEQUAL: [],
+          })}
+          pickedCat="food"
+          navigation={navigation as any}
+          editedExpenseId="TEMP_EXPENSE_ID"
+          newCat={false}
+          iconName="food"
+          dateISO=""
+        />,
+        {
+          trip: {
+            tripid: "t1",
+            tripCurrency: "EUR",
+            travellers: [{ uid: "u1", userName: "Alice" }],
+            fetchAndSetTravellers: jest.fn(async () => {}),
+          },
+          user: { userName: "Alice", lastCurrency: "EUR", lastCountry: "DE" },
+        }
+      );
+
+      expect(stackActionTestIds(screen)).toEqual([
+        "expense-form-submit",
+        "expense-form-cancel",
+      ]);
+    });
+
+    it("hides chevrons on footer commits", async () => {
+      const screen = renderWithAppProviders(
+        <ExpenseForm
+          onCancel={jest.fn()}
+          onSubmit={jest.fn(async () => {})}
+          submitButtonLabel={i18n.t("add")}
+          isEditing={false}
+          defaultValues={makeExpense({
+            amount: 0,
+            description: "",
+            whoPaid: "",
+            splitList: [],
+            listEQUAL: [],
+          })}
+          pickedCat="food"
+          navigation={navigation as any}
+          editedExpenseId="TEMP_EXPENSE_ID"
+          newCat={false}
+          iconName="food"
+          dateISO=""
+        />,
+        {
+          trip: {
+            tripid: "t1",
+            tripCurrency: "EUR",
+            travellers: [{ uid: "u1", userName: "Alice" }],
+            fetchAndSetTravellers: jest.fn(async () => {}),
+          },
+          user: { userName: "Alice", lastCurrency: "EUR", lastCountry: "DE" },
+        }
+      );
+
+      expect(rowShowsChevron(screen, "expense-form-submit")).toBe(false);
+      expect(rowShowsChevron(screen, "expense-form-cancel")).toBe(false);
+    });
+
+    it("shows contextual local price hint when product and country are set", () => {
+      const screen = renderWithAppProviders(
+        <ExpenseForm
+          onCancel={jest.fn()}
+          onSubmit={jest.fn(async () => {})}
+          submitButtonLabel={i18n.t("update")}
+          isEditing
+          defaultValues={makeExpense({
+            amount: 0,
+            description: "Coffee",
+            country: "Germany",
+            currency: "EUR",
+            whoPaid: "Alice",
+            splitList: [{ userName: "Alice", amount: 0 }],
+          })}
+          pickedCat="food"
+          navigation={navigation as any}
+          editedExpenseId="e1"
+          newCat={false}
+          iconName="food"
+          dateISO=""
+        />,
+        {
+          trip: {
+            tripid: "t1",
+            tripCurrency: "EUR",
+            travellers: [{ uid: "u1", userName: "Alice" }],
+            fetchAndSetTravellers: jest.fn(async () => {}),
+          },
+          user: { userName: "Alice", lastCurrency: "EUR", lastCountry: "DE" },
+        }
+      );
+
+      expect(screen.getByTestId("expense-form-get-local-price")).toBeTruthy();
+      expect(
+        screen.getByText('Get local price for "Coffee" in Germany')
+      ).toBeTruthy();
+      expect(rowShowsChevron(screen, "expense-form-get-local-price")).toBe(
+        false
+      );
+    });
+  });
+
+  describe("JoinTrip", () => {
+    it("stacks primary confirm above cancel when a budget is loaded", async () => {
+      const screen = renderWithAppProviders(
+        <JoinTrip navigation={navigation} route={{ params: { id: "t-beach" } }} />,
+        {
+          network: { isConnected: true, strongConnection: true },
+          auth: { uid: "u1" },
+          user: {
+            userName: "Alice",
+            freshlyCreated: false,
+            tripHistory: [],
+            setTripHistory: jest.fn(),
+            loadCatListFromAsyncInCtx: jest.fn(async () => {}),
+          },
+          trip: {
+            tripid: "t-other",
+            getcurrentTrip: jest.fn(() => ({ tripid: "t-other" })),
+            setCurrentTrip: jest.fn(async () => {}),
+            saveTripDataInStorage: jest.fn(async () => {}),
+            saveTravellersInStorage: jest.fn(async () => {}),
+          },
+          expenses: { expenses: [], setExpenses: jest.fn() },
+        }
+      );
+
+      expect(await screen.findByTestId("join-trip-confirm")).toBeTruthy();
+
+      const tree = JSON.stringify(screen.toJSON());
+      expect(tree.indexOf('"testID":"join-trip-confirm"')).toBeLessThan(
+        tree.indexOf('"testID":"join-trip-cancel"')
+      );
+    });
+
+    it("shows a labeled cancel row with a back icon at full width", async () => {
+      const screen = renderWithAppProviders(
+        <JoinTrip navigation={navigation} route={{ params: {} }} />,
+        {
+          network: { isConnected: true, strongConnection: true },
+        }
+      );
+
+      const cancelRow = await screen.findByTestId("join-trip-cancel");
+      expect(within(cancelRow).getByText(i18n.t("cancel"))).toBeTruthy();
+      expect(
+        StyleSheet.flatten(cancelRow.props.style).alignSelf
+      ).toBe("stretch");
+    });
+
+    it("hides chevrons on join and cancel commits", async () => {
+      const screen = renderWithAppProviders(
+        <JoinTrip navigation={navigation} route={{ params: { id: "t-beach" } }} />,
+        {
+          network: { isConnected: true, strongConnection: true },
+          auth: { uid: "u1" },
+          user: {
+            userName: "Alice",
+            freshlyCreated: false,
+            tripHistory: [],
+            setTripHistory: jest.fn(),
+            loadCatListFromAsyncInCtx: jest.fn(async () => {}),
+          },
+          trip: {
+            tripid: "t-other",
+            getcurrentTrip: jest.fn(() => ({ tripid: "t-other" })),
+            setCurrentTrip: jest.fn(async () => {}),
+            saveTripDataInStorage: jest.fn(async () => {}),
+            saveTravellersInStorage: jest.fn(async () => {}),
+          },
+          expenses: { expenses: [], setExpenses: jest.fn() },
+        }
+      );
+
+      expect(await screen.findByTestId("join-trip-confirm")).toBeTruthy();
+      expect(rowShowsChevron(screen, "join-trip-confirm")).toBe(false);
+      expect(rowShowsChevron(screen, "join-trip-cancel")).toBe(false);
+    });
+  });
+});

--- a/TravelCostApp/__tests__/components/get-local-price-button.test.tsx
+++ b/TravelCostApp/__tests__/components/get-local-price-button.test.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { Alert } from "react-native";
+import { fireEvent, within } from "@testing-library/react-native";
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import GetLocalPriceButton from "../../components/Settings/GetLocalPriceButton";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+const CHEVRON = "›";
+
+describe("GetLocalPriceButton", () => {
+  const navigation = { navigate: jest.fn() };
+
+  beforeEach(() => {
+    jest.mocked(navigation.navigate).mockClear();
+    jest.spyOn(Alert, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.mocked(Alert.alert).mockRestore();
+  });
+
+  it("shows no chevron on the profile trigger row that opens a modal", () => {
+    const screen = renderWithAppProviders(
+      <GetLocalPriceButton navigation={navigation as any} />,
+      { wrapNavigation: false, network: { isConnected: true } },
+    );
+
+    expect(
+      within(screen.getByTestId("profile-get-local-price")).queryByText(
+        CHEVRON,
+      ),
+    ).toBeNull();
+  });
+
+  it("shows hint text on the profile Local Price row", () => {
+    const screen = renderWithAppProviders(
+      <GetLocalPriceButton navigation={navigation as any} />,
+      { wrapNavigation: false, network: { isConnected: true } },
+    );
+
+    expect(
+      screen.getByText("Check prices with AI on the road"),
+    ).toBeTruthy();
+  });
+
+  it("hides chevrons on modal footer rows", () => {
+    const screen = renderWithAppProviders(
+      <GetLocalPriceButton navigation={navigation as any} />,
+      { wrapNavigation: false, network: { isConnected: true } },
+    );
+
+    fireEvent.press(screen.getByTestId("profile-get-local-price"));
+
+    expect(
+      within(screen.getByTestId("get-local-price-submit")).queryByText(
+        CHEVRON,
+      ),
+    ).toBeNull();
+    expect(
+      within(screen.getByTestId("get-local-price-cancel")).queryByText(
+        CHEVRON,
+      ),
+    ).toBeNull();
+  });
+});

--- a/TravelCostApp/__tests__/components/gradient-button.test.tsx
+++ b/TravelCostApp/__tests__/components/gradient-button.test.tsx
@@ -32,11 +32,11 @@ describe("GradientButton", () => {
       <GradientButton onPress={jest.fn()} style={{ marginHorizontal: "8%" }}>
         Save trip
       </GradientButton>,
-      { wrapNavigation: false }
+      { wrapNavigation: false },
     );
 
     const outerStyle = flattenStyle(
-      screen.getByTestId("gradient-button-layout").props.style
+      screen.getByTestId("gradient-button-layout").props.style,
     );
     expect(isVisibleOpaqueBackground(outerStyle.backgroundColor)).toBe(false);
     expect(styleHasShadow(outerStyle)).toBe(false);
@@ -45,11 +45,11 @@ describe("GradientButton", () => {
   it("casts shadow from a rounded shell that matches the gradient pill", () => {
     const screen = renderWithAppProviders(
       <GradientButton onPress={jest.fn()}>Save trip</GradientButton>,
-      { wrapNavigation: false }
+      { wrapNavigation: false },
     );
 
     const shadowStyle = flattenStyle(
-      screen.getByTestId("gradient-button-shadow").props.style
+      screen.getByTestId("gradient-button-shadow").props.style,
     );
     assertSolidBackgroundForShadow(shadowStyle);
     expect(styleHasShadow(shadowStyle)).toBe(true);
@@ -64,11 +64,11 @@ describe("GradientButton", () => {
       <GradientButton onPress={jest.fn()} colors={colors}>
         Local price
       </GradientButton>,
-      { wrapNavigation: false }
+      { wrapNavigation: false },
     );
 
     const shadowStyle = flattenStyle(
-      screen.getByTestId("gradient-button-shadow").props.style
+      screen.getByTestId("gradient-button-shadow").props.style,
     );
     expect(shadowStyle.backgroundColor).toBe("#A1D8C1");
   });
@@ -76,14 +76,14 @@ describe("GradientButton", () => {
   it("fills the shadow shell with gradient only, without its own shadow or inset", () => {
     const screen = renderWithAppProviders(
       <GradientButton onPress={jest.fn()}>Save trip</GradientButton>,
-      { wrapNavigation: false }
+      { wrapNavigation: false },
     );
 
     const gradient = screen.UNSAFE_getByType(LinearGradient);
     const gradientStyle = flattenStyle(gradient.props.style);
     expect(styleHasShadow(gradientStyle)).toBe(false);
     expect(isVisibleOpaqueBackground(gradientStyle.backgroundColor)).toBe(
-      false
+      false,
     );
     expect(gradientStyle.marginHorizontal).toBeUndefined();
     expect(gradientStyle.borderRadius).toBe(16);

--- a/TravelCostApp/__tests__/components/legacy-button-deprecation.test.ts
+++ b/TravelCostApp/__tests__/components/legacy-button-deprecation.test.ts
@@ -12,12 +12,17 @@ const LEGACY_IMPORT_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
     name: "FlatButton",
     pattern: /from\s+["'][^"']*\/FlatButton["']/,
   },
+  {
+    name: "Button",
+    pattern: /from\s+["'][^"']*(?:\/UI\/Button|\.\/Button)["']/,
+  },
 ];
 
 const ALLOWED_LEGACY_IMPORT_SUFFIXES = [
   "__tests__/",
   "components/UI/GradientButton.tsx",
   "components/UI/FlatButton.tsx",
+  "components/UI/Button.tsx",
 ];
 
 function walkSourceFiles(dir: string, acc: string[] = []): string[] {
@@ -40,7 +45,7 @@ function isAllowedLegacyImport(relPath: string): boolean {
 }
 
 describe("legacy button deprecation", () => {
-  it("keeps GradientButton and FlatButton out of production imports", () => {
+  it("keeps deprecated button components out of production imports", () => {
     const offenders: string[] = [];
 
     for (const file of walkSourceFiles(appRoot)) {
@@ -62,6 +67,7 @@ describe("legacy button deprecation", () => {
   it.each([
     "components/UI/GradientButton.tsx",
     "components/UI/FlatButton.tsx",
+    "components/UI/Button.tsx",
   ])("marks %s @deprecated with ActionRow migration note", (relPath) => {
     const src = readFileSync(join(appRoot, relPath), "utf8");
     expect(src).toMatch(/@deprecated[\s\S]*ActionRow/);

--- a/TravelCostApp/__tests__/components/legacy-button-deprecation.test.ts
+++ b/TravelCostApp/__tests__/components/legacy-button-deprecation.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+
+const appRoot = join(__dirname, "../..");
+
+const LEGACY_IMPORT_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  {
+    name: "GradientButton",
+    pattern: /from\s+["'][^"']*\/GradientButton["']/,
+  },
+  {
+    name: "FlatButton",
+    pattern: /from\s+["'][^"']*\/FlatButton["']/,
+  },
+];
+
+const ALLOWED_LEGACY_IMPORT_SUFFIXES = [
+  "__tests__/",
+  "components/UI/GradientButton.tsx",
+  "components/UI/FlatButton.tsx",
+];
+
+function walkSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (entry === "node_modules" || entry === "__tests__") continue;
+    if (statSync(full).isDirectory()) {
+      walkSourceFiles(full, acc);
+    } else if (/\.(tsx?|jsx?)$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function isAllowedLegacyImport(relPath: string): boolean {
+  return ALLOWED_LEGACY_IMPORT_SUFFIXES.some((allowed) =>
+    relPath.includes(allowed)
+  );
+}
+
+describe("legacy button deprecation", () => {
+  it("keeps GradientButton and FlatButton out of production imports", () => {
+    const offenders: string[] = [];
+
+    for (const file of walkSourceFiles(appRoot)) {
+      const rel = relative(appRoot, file);
+      if (isAllowedLegacyImport(rel)) continue;
+
+      const src = readFileSync(file, "utf8");
+      for (const { name, pattern } of LEGACY_IMPORT_PATTERNS) {
+        if (pattern.test(src)) {
+          offenders.push(`${rel} (${name})`);
+          break;
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it.each([
+    "components/UI/GradientButton.tsx",
+    "components/UI/FlatButton.tsx",
+  ])("marks %s @deprecated with ActionRow migration note", (relPath) => {
+    const src = readFileSync(join(appRoot, relPath), "utf8");
+    expect(src).toMatch(/@deprecated[\s\S]*ActionRow/);
+  });
+});

--- a/TravelCostApp/__tests__/components/modal-footer-actions.test.tsx
+++ b/TravelCostApp/__tests__/components/modal-footer-actions.test.tsx
@@ -1,0 +1,137 @@
+import * as React from "react";
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light", Medium: "Medium" },
+}));
+
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: { expoConfig: { version: "1.0.0" } },
+}));
+
+jest.mock("../../util/http", () => ({
+  storeFeedback: jest.fn(async () => {}),
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+jest.mock("expo-store-review", () => ({
+  isAvailableAsync: jest.fn(async () => true),
+  requestReview: jest.fn(async () => {}),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreSetObject: jest.fn(async () => {}),
+}));
+
+jest.mock("react-native-modal", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return ({
+    children,
+    isVisible,
+  }: {
+    children: React.ReactNode;
+    isVisible: boolean;
+  }) => (isVisible ? <View testID="rating-modal-root">{children}</View> : null);
+});
+
+import { fireEvent } from "@testing-library/react-native";
+import { StyleSheet } from "react-native";
+
+import FeedbackForm from "../../components/FeedbackForm/FeedbackForm";
+import ErrorOverlay from "../../components/UI/ErrorOverlay";
+import RatingModal from "../../screens/RatingModal";
+import { i18n } from "../../i18n/i18n";
+import { storeFeedback } from "../../util/http";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+describe("modal footer ActionRowStack pattern", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("FeedbackForm", () => {
+    it("disables submit until feedback text is entered", () => {
+      const screen = renderWithAppProviders(
+        <FeedbackForm isVisible onClose={jest.fn()} />,
+        { wrapNavigation: false }
+      );
+
+      const submitDisabledStyle = StyleSheet.flatten(
+        typeof screen.getByTestId("feedback-submit").props.style === "function"
+          ? screen.getByTestId("feedback-submit").props.style({ pressed: false })
+          : screen.getByTestId("feedback-submit").props.style
+      ) as Record<string, unknown>;
+      expect(submitDisabledStyle.opacity).toBe(0.5);
+
+      fireEvent.changeText(
+        screen.getByPlaceholderText(i18n.t("feedbackPlaceholder")),
+        "Love the budget splits!"
+      );
+
+      const submitEnabledStyle = StyleSheet.flatten(
+        typeof screen.getByTestId("feedback-submit").props.style === "function"
+          ? screen.getByTestId("feedback-submit").props.style({ pressed: false })
+          : screen.getByTestId("feedback-submit").props.style
+      ) as Record<string, unknown>;
+      expect(submitEnabledStyle.opacity).toBeUndefined();
+    });
+
+    it("renders primary submit above secondary cancel without chevrons", () => {
+      const screen = renderWithAppProviders(
+        <FeedbackForm isVisible onClose={jest.fn()} />,
+        { wrapNavigation: false }
+      );
+
+      expect(screen.getByTestId("action-row-stack")).toBeTruthy();
+      expect(screen.getByText(i18n.t("submit"))).toBeTruthy();
+      expect(screen.getByText(i18n.t("cancel"))).toBeTruthy();
+      expect(screen.queryByText("›")).toBeNull();
+    });
+
+    it("does not submit when disabled", () => {
+      const screen = renderWithAppProviders(
+        <FeedbackForm isVisible onClose={jest.fn()} />,
+        { wrapNavigation: false }
+      );
+
+      fireEvent.press(screen.getByTestId("feedback-submit"));
+      expect(storeFeedback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("RatingModal", () => {
+    it("renders three stacked footer rows without chevrons", () => {
+      const screen = renderWithAppProviders(
+        <RatingModal isModalVisible setIsModalVisible={jest.fn()} />,
+        { wrapNavigation: false }
+      );
+
+      expect(screen.getByTestId("rating-modal-rate")).toBeTruthy();
+      expect(screen.getByTestId("rating-modal-later")).toBeTruthy();
+      expect(screen.getByTestId("rating-modal-never")).toBeTruthy();
+      expect(screen.queryByText("›")).toBeNull();
+    });
+  });
+
+  describe("ErrorOverlay", () => {
+    it("renders a single primary confirm row without chevron", () => {
+      const onConfirm = jest.fn();
+      const screen = renderWithAppProviders(
+        <ErrorOverlay message="Sync failed" onConfirm={onConfirm} />,
+        { wrapNavigation: false }
+      );
+
+      expect(screen.getByText(i18n.t("okay"))).toBeTruthy();
+      expect(screen.queryByText("›")).toBeNull();
+
+      fireEvent.press(screen.getByText(i18n.t("okay")));
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/TravelCostApp/__tests__/components/my-budgets-hub-actions.test.tsx
+++ b/TravelCostApp/__tests__/components/my-budgets-hub-actions.test.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { within } from "@testing-library/react-native";
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import MyBudgetsHubActions from "../../components/ProfileOutput/MyBudgetsHubActions";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { fireEvent } from "@testing-library/react-native";
+import { trackEvent } from "../../util/vexo-tracking";
+import { VexoEvents } from "../../util/vexo-constants";
+
+const CHEVRON = "›";
+
+describe("MyBudgetsHubActions", () => {
+  beforeEach(() => {
+    jest.mocked(trackEvent).mockClear();
+  });
+
+  it("shows chevrons on navigation rows to join or add another budget", () => {
+    const screen = renderWithAppProviders(
+      <MyBudgetsHubActions onJoin={jest.fn()} onAddAnother={jest.fn()} />,
+      { wrapNavigation: false },
+    );
+
+    expect(
+      within(screen.getByTestId("my-budgets-add-another")).getByText(CHEVRON),
+    ).toBeTruthy();
+    expect(
+      within(screen.getByTestId("my-budgets-join")).getByText(CHEVRON),
+    ).toBeTruthy();
+  });
+
+  it("shows hints on both hub actions", () => {
+    const screen = renderWithAppProviders(
+      <MyBudgetsHubActions onJoin={jest.fn()} onAddAnother={jest.fn()} />,
+      { wrapNavigation: false },
+    );
+
+    expect(screen.getByText("New budgets start empty")).toBeTruthy();
+    expect(screen.getByText("Enter an invite code or link")).toBeTruthy();
+  });
+
+  it("calls onJoin when Join budget is pressed", () => {
+    const onJoin = jest.fn();
+    const screen = renderWithAppProviders(
+      <MyBudgetsHubActions onJoin={onJoin} onAddAnother={jest.fn()} />,
+      { wrapNavigation: false },
+    );
+
+    fireEvent.press(screen.getByTestId("my-budgets-join"));
+    expect(onJoin).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith(VexoEvents.TRIP_JOINED);
+  });
+
+  it("calls onAddAnother when Add another budget is pressed", () => {
+    const onAddAnother = jest.fn();
+    const screen = renderWithAppProviders(
+      <MyBudgetsHubActions onJoin={jest.fn()} onAddAnother={onAddAnother} />,
+      { wrapNavigation: false },
+    );
+
+    fireEvent.press(screen.getByTestId("my-budgets-add-another"));
+    expect(onAddAnother).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith(
+      VexoEvents.CREATE_TRIP_FROM_PROFILE_PRESSED,
+    );
+  });
+});

--- a/TravelCostApp/__tests__/components/profile-toolbar.test.tsx
+++ b/TravelCostApp/__tests__/components/profile-toolbar.test.tsx
@@ -20,15 +20,96 @@ jest.mock("expo-haptics", () => ({
 }));
 
 import ProfileToolbar from "../../components/ManageProfile/ProfileToolbar";
+import { GlobalStyles } from "../../constants/styles";
+import { ProfileToolbarTokens } from "../../styles/profile-toolbar-tokens";
 import { i18n } from "../../i18n/i18n";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import { asyncStoreSafeClear } from "../../store/async-storage";
+import { StyleSheet } from "react-native";
+
+const profileToolbarProviders = {
+  wrapNavigation: false,
+  safeAreaInsets: { top: 44, left: 0, right: 0, bottom: 34 },
+  auth: { uid: "u1", logout: jest.fn() },
+  trip: { tripid: "t1", setCurrentTrip: jest.fn(async () => {}) },
+  expenses: { setExpenses: jest.fn() },
+  user: {
+    userName: "Alice",
+    freshlyCreated: false,
+    hasNewChanges: false,
+    setHasNewChanges: jest.fn(),
+    setUserName: jest.fn(async () => {}),
+    setTripHistory: jest.fn(),
+  },
+};
 
 describe("Profile toolbar", () => {
   let alertSpy: jest.SpyInstance;
 
   afterEach(() => {
     alertSpy?.mockRestore();
+  });
+
+  it("does not add top safe-area padding because SafeAreaWrapper already insets the app", () => {
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <ProfileToolbar
+        navigation={navigation as any}
+        setIsFetchingLogout={jest.fn()}
+      />,
+      profileToolbarProviders,
+    );
+
+    const shell = StyleSheet.flatten(
+      screen.getByTestId("profile-floating-toolbar").props.style,
+    ) as Record<string, unknown>;
+    expect(shell.paddingTop).not.toBe(44);
+  });
+
+  it("keeps the icon row no taller than icon size plus small padding", () => {
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <ProfileToolbar
+        navigation={navigation as any}
+        setIsFetchingLogout={jest.fn()}
+      />,
+      {
+        wrapNavigation: false,
+        auth: { uid: "u1", logout: jest.fn() },
+        trip: { tripid: "t1", setCurrentTrip: jest.fn(async () => {}) },
+        expenses: { setExpenses: jest.fn() },
+        user: {
+          userName: "Alice",
+          freshlyCreated: false,
+          hasNewChanges: false,
+          setHasNewChanges: jest.fn(),
+          setUserName: jest.fn(async () => {}),
+          setTripHistory: jest.fn(),
+        },
+      }
+    );
+
+    const buttons = screen.getByTestId("profile-toolbar-buttons");
+    const buttonRow = StyleSheet.flatten(buttons.props.style) as Record<
+      string,
+      unknown
+    >;
+    expect(buttonRow.minHeight).toBe(ProfileToolbarTokens.contentHeight);
+    expect(buttonRow.minHeight).toBeLessThanOrEqual(
+      ProfileToolbarTokens.iconSize + 2 * ProfileToolbarTokens.iconHitPadding
+    );
+
+    const shell = StyleSheet.flatten(
+      screen.getByTestId("profile-floating-toolbar").props.style
+    ) as Record<string, unknown>;
+    expect(shell.backgroundColor).toBeUndefined();
+
+    const chrome = StyleSheet.flatten(
+      screen.getByTestId("profile-toolbar-chrome").props.style
+    ) as Record<string, unknown>;
+    expect(chrome.backgroundColor).toBe(GlobalStyles.colors.backgroundColor);
+    expect(chrome.paddingBottom).toBe(ProfileToolbarTokens.paddingVertical);
+    expect(chrome.minHeight).toBe(ProfileToolbarTokens.chromeHeight);
   });
 
   it("signs the User out when they confirm logout", async () => {

--- a/TravelCostApp/__tests__/components/share-trip.test.tsx
+++ b/TravelCostApp/__tests__/components/share-trip.test.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+import ShareTripButton from "../../components/ProfileOutput/ShareTrip";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { i18n } from "../../i18n/i18n";
+
+describe("ShareTrip invite action row", () => {
+  it("shows the budget invite description once, not again as the row hint", () => {
+    const navigation = { goBack: jest.fn() };
+    const route = { params: { tripId: "t1" } };
+    const description = i18n.t("shareTripDescription");
+
+    const screen = renderWithAppProviders(
+      <ShareTripButton navigation={navigation as any} route={route as any} />
+    );
+
+    expect(screen.getAllByText(description)).toHaveLength(1);
+    expect(screen.getByTestId("share-trip-invite")).toBeTruthy();
+  });
+});

--- a/TravelCostApp/__tests__/fixtures/app-providers.tsx
+++ b/TravelCostApp/__tests__/fixtures/app-providers.tsx
@@ -21,6 +21,12 @@ export type AppProviderOverrides = {
   settings?: Record<string, unknown>;
   orientation?: Record<string, unknown>;
   wrapNavigation?: boolean;
+  safeAreaInsets?: {
+    top: number;
+    left: number;
+    right: number;
+    bottom: number;
+  };
 };
 
 const defaultTrip = {
@@ -91,12 +97,18 @@ export function AppProviders({
     ...overrides.orientation,
   };
   const auth = { uid: "u1", ...overrides.auth };
+  const safeAreaInsets = overrides.safeAreaInsets ?? {
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  };
 
   const tree = (
     <SafeAreaProvider
       initialMetrics={{
         frame: { x: 0, y: 0, width: 390, height: 844 },
-        insets: { top: 0, left: 0, right: 0, bottom: 0 },
+        insets: safeAreaInsets,
       }}
     >
       <AuthContext.Provider value={auth as any}>

--- a/TravelCostApp/__tests__/i18n/action-row-hints.test.ts
+++ b/TravelCostApp/__tests__/i18n/action-row-hints.test.ts
@@ -1,0 +1,32 @@
+import { de, en, fr, ru } from "../../i18n/supportedLanguages";
+
+/** Keys passed to ActionRow `hint` — must ship in EN, DE, FR, and RU. */
+const ACTION_ROW_HINT_KEYS = [
+  "addAnotherBudgetHint",
+  "addExpHereHint",
+  "joinBudgetHint",
+  "supportFeedbackHint",
+  "getLocalPriceHint",
+  "getLocalPriceExpenseHint",
+  "getLocalPriceExpenseDealHint",
+  "summaryHint",
+] as const;
+
+describe("ActionRow hint i18n", () => {
+  it("ships EN+DE+FR+RU copy for every ActionRow hint key", () => {
+    for (const locale of [en, de, fr, ru]) {
+      for (const key of ACTION_ROW_HINT_KEYS) {
+        expect(locale[key]).toBeTruthy();
+      }
+    }
+  });
+
+  it("English hints match locked ActionRow UX wording", () => {
+    expect(en.addAnotherBudgetHint).toBe("New budgets start empty");
+    expect(en.addExpHereHint).toBe("On this day: %{date}");
+    expect(en.joinBudgetHint).toBe("Enter an invite code or link");
+    expect(en.supportFeedbackHint).toBe("Tell us what to improve");
+    expect(en.getLocalPriceHint).toBe("Check prices with AI on the road");
+    expect(en.summaryHint).toBe("Quick overview for one or more budgets");
+  });
+});

--- a/TravelCostApp/__tests__/i18n/my-budgets-hub-copy.test.ts
+++ b/TravelCostApp/__tests__/i18n/my-budgets-hub-copy.test.ts
@@ -9,6 +9,8 @@ describe("My Budgets hub i18n (issue #356)", () => {
       expect(locale.joinBudgetHint).toBeTruthy();
       expect(locale.addAnotherBudget).toBeTruthy();
       expect(locale.addAnotherBudgetHint).toBeTruthy();
+      expect(locale.getLocalPriceHint).toBeTruthy();
+      expect(locale.supportFeedbackHint).toBeTruthy();
       expect(locale.yourBudget).toBeTruthy();
       expect(locale.myBudgetAutoName).toBeTruthy();
       expect(locale.activeTripLabel).toBeTruthy();
@@ -25,5 +27,13 @@ describe("My Budgets hub i18n (issue #356)", () => {
     expect(en.yourBudget).toBe("Your budget");
     expect(en.myBudgetAutoName).toBe("My Budget");
     expect(en.activeTripLabel).toBe("Active");
+  });
+
+  it("German profile action hints stay readable for secondary rows", () => {
+    expect(de.joinBudgetHint).toBe("Einladungscode oder Link eingeben");
+    expect(de.getLocalPriceHint).toBe("Preise mit KI unterwegs prüfen");
+    expect(de.supportFeedbackHint).toBe(
+      "Sag uns, was wir verbessern können",
+    );
   });
 });

--- a/TravelCostApp/__tests__/screens/filtered-expenses.test.tsx
+++ b/TravelCostApp/__tests__/screens/filtered-expenses.test.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { within } from "@testing-library/react-native";
+import { DateTime } from "luxon";
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
@@ -93,6 +95,64 @@ describe("FilteredExpenses route params", () => {
         expenses: [],
       })
     );
+  });
+
+  it("stacks primary add-expense above secondary back in the footer", () => {
+    const expenses = [
+      makeExpense({
+        id: "earlier",
+        date: new Date("2026-03-05T00:00:00.000Z"),
+      }),
+    ];
+
+    const screen = renderWithAppProviders(
+      <FilteredExpenses
+        route={{
+          params: {
+            expenses: toExpenseNavigationDtos(expenses),
+            dayString: "Mar 2026",
+          },
+        }}
+      />
+    );
+
+    const stack = screen.getByTestId("action-row-stack");
+    const testIds = React.Children.toArray(stack.props.children).map(
+      (child: React.ReactElement) => child.props.testID
+    );
+
+    expect(testIds).toEqual(["add-expense-here", "filtered-expenses-back"]);
+  });
+
+  it("shows add-expense title and date hint on separate lines", () => {
+    const earliestDate = "2026-03-05T00:00:00.000Z";
+    const expenses = [
+      makeExpense({
+        id: "earlier",
+        date: new Date(earliestDate),
+      }),
+    ];
+
+    const screen = renderWithAppProviders(
+      <FilteredExpenses
+        route={{
+          params: {
+            expenses: toExpenseNavigationDtos(expenses),
+            dayString: "Mar 2026",
+          },
+        }}
+      />
+    );
+
+    const row = screen.getByTestId("add-expense-here");
+    expect(within(row).getByText(i18n.t("addExp"))).toBeTruthy();
+    expect(
+      within(row).getByText(
+        i18n.t("addExpHereHint", {
+          date: DateTime.fromISO(earliestDate).toLocaleString(),
+        })
+      )
+    ).toBeTruthy();
   });
 
   it("uses the earliest hydrated expense date for add-expense-here", () => {

--- a/TravelCostApp/__tests__/screens/filtered-pie-charts.test.tsx
+++ b/TravelCostApp/__tests__/screens/filtered-pie-charts.test.tsx
@@ -115,4 +115,24 @@ describe("FilteredPieCharts navigation arrows", () => {
 
     expectActiveTitle(screen, CATEGORIES);
   });
+
+  it("pops navigation when the footer back action row is pressed", () => {
+    const { screen, navigation } = renderScreen();
+
+    fireEvent.press(screen.getByTestId("filtered-pie-charts-back"));
+
+    expect(navigation.pop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stacks full-width add-expense above back in the footer", () => {
+    const { screen } = renderScreen();
+
+    const stack = screen.getByTestId("action-row-stack");
+    const testIds = React.Children.toArray(stack.props.children).map(
+      (child: React.ReactElement) => child.props.testID
+    );
+
+    expect(testIds).toEqual(["add-expense-here", "filtered-pie-charts-back"]);
+    expect(screen.getByText(i18n.t("addExp"))).toBeTruthy();
+  });
 });

--- a/TravelCostApp/__tests__/screens/finder-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/finder-screen.test.tsx
@@ -49,6 +49,7 @@ jest.mock("../../components/UI/DatePickerContainer", () => {
 jest.mock("../../components/UI/DatePickerModal", () => () => null);
 
 import FinderScreen from "../../screens/FinderScreen";
+import { ActionRowTokens } from "../../styles/action-row-tokens";
 import {
   FINDER_FILTER_CLEAR_SLOT_WIDTH,
   FINDER_FILTER_CONTENT_WIDTH,
@@ -171,6 +172,21 @@ describe("Finder screen", () => {
     ).width;
     expect(widthAfter).toBe(widthBefore);
     expect(widthAfter).toBe(FINDER_FILTER_CLEAR_SLOT_WIDTH);
+  });
+
+  it("uses a full-width ActionRow with standard border radius for results", async () => {
+    const screen = renderWithAppProviders(<FinderScreen />, {
+      wrapNavigation: false,
+      expenses: { expenses: [] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("finder-show-results")).toBeTruthy();
+    });
+
+    const rowStyle = flattenStyle(screen, "finder-show-results");
+    expect(rowStyle.borderRadius).toBe(ActionRowTokens.borderRadius);
+    expect(rowStyle.alignSelf).toBe("stretch");
   });
 
   it("keeps the date clear column width when the filter becomes active", async () => {

--- a/TravelCostApp/__tests__/screens/profile-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/profile-screen.test.tsx
@@ -73,17 +73,18 @@ jest.mock("../../util/vexo-tracking", () => ({
 jest.mock("../../components/FeedbackForm/FeedbackForm", () => () => null);
 
 import ProfileScreen from "../../screens/ProfileScreen";
+import { ProfileToolbarTokens } from "../../styles/profile-toolbar-tokens";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import { assertNoNestedVerticalFlatLists } from "../../test-utils/scroll-composition";
 import { isDescendantOf } from "../../test-utils/react-tree";
-import { fireEvent, waitFor } from "@testing-library/react-native";
+import { fireEvent, waitFor, within } from "@testing-library/react-native";
 import { StyleSheet } from "react-native";
 import { getTravellers } from "../../util/http";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 
 function profileUserOverrides(
-  overrides: Record<string, unknown> = {}
+  overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {
   return {
     userName: "Alice",
@@ -121,7 +122,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}) },
         expenses: { setExpenses: jest.fn() },
         user: profileUserOverrides({ freshlyCreated: true }),
-      }
+      },
     );
 
     expect(screen.getByText("Alice")).toBeTruthy();
@@ -130,10 +131,10 @@ describe("Profile screen", () => {
 
     await waitFor(() => {
       expect(trackEvent).not.toHaveBeenCalledWith(
-        VexoEvents.ONBOARDING_TOUR_STARTED
+        VexoEvents.ONBOARDING_TOUR_STARTED,
       );
       expect(trackEvent).not.toHaveBeenCalledWith(
-        VexoEvents.ONBOARDING_TOUR_SKIPPED
+        VexoEvents.ONBOARDING_TOUR_SKIPPED,
       );
       expect(navigation.navigate).not.toHaveBeenCalledWith("RecentExpenses");
       expect(navigation.navigate).not.toHaveBeenCalledWith("Overview");
@@ -149,7 +150,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}) },
         expenses: { setExpenses: jest.fn() },
         user: profileUserOverrides(),
-      }
+      },
     );
 
     expect(screen.getByText("Alice")).toBeTruthy();
@@ -168,7 +169,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}) },
         expenses: { setExpenses: jest.fn() },
         user: profileUserOverrides(),
-      }
+      },
     );
 
     fireEvent.press(screen.getByTestId("my-budgets-join"));
@@ -184,7 +185,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}) },
         expenses: { setExpenses: jest.fn() },
         user: profileUserOverrides(),
-      }
+      },
     );
 
     fireEvent.press(screen.getByTestId("my-budgets-add-another"));
@@ -218,7 +219,7 @@ describe("Profile screen", () => {
           ],
         },
         user: profileUserOverrides({ tripHistory: ["implicit-1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -240,7 +241,7 @@ describe("Profile screen", () => {
         },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -272,7 +273,7 @@ describe("Profile screen", () => {
           expenses: [],
         },
         user: profileUserOverrides({ tripHistory: ["implicit-1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -296,7 +297,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -315,7 +316,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -337,7 +338,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -355,7 +356,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -379,7 +380,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -387,10 +388,35 @@ describe("Profile screen", () => {
     });
 
     const flatLists = screen.UNSAFE_getAllByType(
-      require("react-native").FlatList
+      require("react-native").FlatList,
     );
     expect(flatLists).toHaveLength(1);
     assertNoNestedVerticalFlatLists(screen.root);
+  });
+
+  it("offsets scroll content by toolbar height only, not safe area twice", async () => {
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <ProfileScreen navigation={navigation as any} />,
+      {
+        wrapNavigation: false,
+        safeAreaInsets: { top: 44, left: 0, right: 0, bottom: 34 },
+        auth: { uid: "u1", logout: jest.fn() },
+        trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
+        expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
+        user: profileUserOverrides({ tripHistory: ["t1"] }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("profile-scroll")).toBeTruthy();
+    });
+
+    const scrollList = screen.getByTestId("profile-scroll");
+    const contentStyle = StyleSheet.flatten(
+      scrollList.props.contentContainerStyle,
+    ) as Record<string, unknown>;
+    expect(contentStyle.paddingTop).toBe(ProfileToolbarTokens.chromeHeight);
   });
 
   it("keeps the floating profile toolbar outside the scroll list", async () => {
@@ -402,7 +428,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -424,7 +450,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -448,7 +474,7 @@ describe("Profile screen", () => {
         trip: { setCurrentTrip: jest.fn(async () => {}), tripid: "t1" },
         expenses: { setExpenses: jest.fn(), getExpensesSum: () => 0 },
         user: profileUserOverrides({ tripHistory: ["t1"] }),
-      }
+      },
     );
 
     await waitFor(() => {
@@ -457,5 +483,54 @@ describe("Profile screen", () => {
 
     expect(screen.getByTestId("profile-scroll")).toBeTruthy();
     expect(screen.getByTestId("profile-scroll-header")).toBeTruthy();
+  });
+
+  it("shows chevrons only on budget navigation rows, not modal actions", () => {
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <ProfileScreen navigation={navigation as any} />,
+      {
+        auth: { uid: "u1", logout: jest.fn() },
+        trip: { setCurrentTrip: jest.fn(async () => {}) },
+        expenses: { setExpenses: jest.fn() },
+        user: profileUserOverrides(),
+        network: { isConnected: true, strongConnection: true },
+      },
+    );
+
+    const chevron = "›";
+    expect(
+      within(screen.getByTestId("my-budgets-add-another")).getByText(chevron),
+    ).toBeTruthy();
+    expect(
+      within(screen.getByTestId("my-budgets-join")).getByText(chevron),
+    ).toBeTruthy();
+    expect(
+      within(screen.getByTestId("profile-get-local-price")).queryByText(
+        chevron,
+      ),
+    ).toBeNull();
+    expect(
+      within(screen.getByTestId("profile-feedback")).queryByText(chevron),
+    ).toBeNull();
+  });
+
+  it("shows profile action hints for Local Price and Feedback rows", () => {
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <ProfileScreen navigation={navigation as any} />,
+      {
+        auth: { uid: "u1", logout: jest.fn() },
+        trip: { setCurrentTrip: jest.fn(async () => {}) },
+        expenses: { setExpenses: jest.fn() },
+        user: profileUserOverrides(),
+        network: { isConnected: true, strongConnection: true },
+      },
+    );
+
+    expect(
+      screen.getByText("Check prices with AI on the road"),
+    ).toBeTruthy();
+    expect(screen.getByText("Tell us what to improve")).toBeTruthy();
   });
 });

--- a/TravelCostApp/__tests__/screens/split-summary-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/split-summary-screen.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { StyleSheet } from "react-native";
-import { waitFor, within } from "@testing-library/react-native";
+import { fireEvent, waitFor, within } from "@testing-library/react-native";
 import { ScrollView } from "react-native";
 
 jest.mock("@react-navigation/native", () => {
@@ -124,6 +124,99 @@ describe("Split Summary screen", () => {
     });
 
     calcSpy.mockRestore();
+  });
+
+  it("shows simplify and settle rows before simplification, then back after simplify", async () => {
+    const openBalances = [
+      { userName: "Bob", whoPaid: "Alice", amount: 50 },
+      { userName: "Alice", whoPaid: "Bob", amount: 30 },
+    ];
+    const calcSpy = jest
+      .spyOn(splitUtil, "rollupOpenBalances")
+      .mockReturnValue(openBalances as any);
+
+    const navigation = { navigate: jest.fn(), pop: jest.fn() };
+    const screen = renderWithAppProviders(
+      <SplitSummaryScreen navigation={navigation as any} />,
+      {
+        trip: {
+          tripid: "t1",
+          tripCurrency: "EUR",
+          isPaid: "notPaid",
+          isPaidTimestamp: 0,
+          fetchAndSettleCurrentTrip: jest.fn(async () => {}),
+        },
+        user: { userName: "Alice", freshlyCreated: false },
+        expenses: {
+          expenses: [
+            makeExpense({
+              whoPaid: "Alice",
+              amount: 100,
+              calcAmount: 100,
+              currency: "EUR",
+              splitList: [
+                { userName: "Alice", amount: 50 },
+                { userName: "Bob", amount: 50 },
+              ],
+            }),
+          ],
+        },
+        orientation: { isPortrait: true, isLandscape: false, isTablet: false },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("split-summary-simplify")).toBeTruthy();
+      expect(screen.getByTestId("split-summary-settle")).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId("split-summary-back")).toBeNull();
+
+    fireEvent.press(screen.getByTestId("split-summary-simplify"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("split-summary-back")).toBeTruthy();
+      expect(screen.queryByTestId("split-summary-simplify")).toBeNull();
+    });
+
+    calcSpy.mockRestore();
+  });
+
+  it("hides settle when the budget is already settled", async () => {
+    const navigation = { navigate: jest.fn(), pop: jest.fn() };
+    const screen = renderWithAppProviders(
+      <SplitSummaryScreen navigation={navigation as any} />,
+      {
+        trip: {
+          tripid: "t1",
+          tripCurrency: "EUR",
+          isPaid: "paid",
+          isPaidTimestamp: Date.now(),
+          fetchAndSettleCurrentTrip: jest.fn(async () => {}),
+        },
+        user: { userName: "Alice", freshlyCreated: false },
+        expenses: {
+          expenses: [
+            makeExpense({
+              whoPaid: "Alice",
+              amount: 100,
+              calcAmount: 100,
+              currency: "EUR",
+              splitList: [
+                { userName: "Alice", amount: 50 },
+                { userName: "Bob", amount: 50 },
+              ],
+            }),
+          ],
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Split Summary")).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId("split-summary-settle")).toBeNull();
   });
 
   it("shows open Balance row text inside portrait StaticList rows", async () => {

--- a/TravelCostApp/__tests__/screens/trip-summary-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/trip-summary-screen.test.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { Pressable } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
 import { waitFor } from "@testing-library/react-native";
 
 jest.mock("expo-haptics", () => ({
@@ -100,5 +102,59 @@ describe("TripSummaryScreen", () => {
     assertSolidBackgroundForShadow(
       StyleSheet.flatten(shadowRegressionStyles.tripSummaryTripItemSelected)
     );
+  });
+
+  it("stacks summary gradient CTA above charts and back secondary rows", async () => {
+    const navigation = { navigate: jest.fn(), pop: jest.fn(), goBack: jest.fn() };
+
+    const screen = renderWithAppProviders(
+      <TripSummaryScreen navigation={navigation as any} />,
+      {
+        user: {
+          userName: "Alice",
+          freshlyCreated: false,
+          tripHistory: ["t1"],
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("trip-summary-summary")).toBeTruthy();
+      expect(screen.getByTestId("trip-summary-charts")).toBeTruthy();
+      expect(screen.getByTestId("trip-summary-back")).toBeTruthy();
+    });
+
+    expect(screen.UNSAFE_queryAllByType(LinearGradient)).toHaveLength(1);
+
+    const pressableTestIds = screen
+      .UNSAFE_queryAllByType(Pressable)
+      .map((node) => node.props.testID)
+      .filter(Boolean) as string[];
+
+    expect(pressableTestIds.indexOf("trip-summary-summary")).toBeLessThan(
+      pressableTestIds.indexOf("trip-summary-charts")
+    );
+    expect(pressableTestIds.indexOf("trip-summary-charts")).toBeLessThan(
+      pressableTestIds.indexOf("trip-summary-back")
+    );
+  });
+
+  it("shows a hint on the gradient summary row", async () => {
+    const navigation = { navigate: jest.fn(), pop: jest.fn(), goBack: jest.fn() };
+
+    const screen = renderWithAppProviders(
+      <TripSummaryScreen navigation={navigation as any} />,
+      {
+        user: {
+          userName: "Alice",
+          freshlyCreated: false,
+          tripHistory: ["t1"],
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t("summaryHint"))).toBeTruthy();
+    });
   });
 });

--- a/TravelCostApp/__tests__/styles/action-row-tokens.test.ts
+++ b/TravelCostApp/__tests__/styles/action-row-tokens.test.ts
@@ -1,0 +1,20 @@
+import { ActionRowTokens, actionRowCardShell } from "../../styles/action-row-tokens";
+import { GlobalStyles } from "../../constants/styles";
+
+describe("action-row-tokens", () => {
+  it("locks variant C surface contrast against page background", () => {
+    expect(ActionRowTokens.surface).toBe("#FFFFFF");
+    expect(ActionRowTokens.surface).not.toBe(GlobalStyles.colors.backgroundColor);
+  });
+
+  it("exports a co-located card shell for shadow regression", () => {
+    expect(actionRowCardShell.backgroundColor).toBe(ActionRowTokens.surface);
+    expect(actionRowCardShell.borderWidth).toBe(ActionRowTokens.borderWidth);
+    expect(actionRowCardShell.borderColor).toBe(ActionRowTokens.borderColor);
+  });
+
+  it("uses the same subtle press scale as trip list items", () => {
+    expect(ActionRowTokens.press).toBe(GlobalStyles.pressedActionRow);
+    expect(ActionRowTokens.press.transform).toEqual([{ scale: 0.975 }]);
+  });
+});

--- a/TravelCostApp/__tests__/util/expense-form-local-price-hint.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-local-price-hint.test.ts
@@ -1,0 +1,28 @@
+import { expenseFormLocalPriceHint } from "../../util/expense-form-local-price-hint";
+import { i18n } from "../../i18n/i18n";
+
+describe("expenseFormLocalPriceHint", () => {
+  beforeEach(() => {
+    i18n.locale = "en";
+  });
+
+  it("describes the product and country when no amount is entered", () => {
+    expect(
+      expenseFormLocalPriceHint({
+        product: "Coffee",
+        country: "Germany",
+      })
+    ).toBe('Get local price for "Coffee" in Germany');
+  });
+
+  it("includes price and currency when an amount is entered", () => {
+    expect(
+      expenseFormLocalPriceHint({
+        product: "Coworking",
+        country: "Portugal",
+        price: "25",
+        currency: "EUR",
+      })
+    ).toBe('Is 25 EUR a good deal for "Coworking" in Portugal?');
+  });
+});

--- a/TravelCostApp/__tests__/util/shadow-styles.test.ts
+++ b/TravelCostApp/__tests__/util/shadow-styles.test.ts
@@ -150,6 +150,21 @@ describe("shadow styles", () => {
     );
   });
 
+  it("action row card uses a lighter shadow than trip history cards", () => {
+    const actionRow = StyleSheet.flatten(
+      shadowRegressionStyles.actionRowCard
+    ) as Record<string, unknown>;
+    const tripCard = StyleSheet.flatten(
+      shadowRegressionStyles.tripHistoryCard
+    ) as Record<string, unknown>;
+
+    assertSolidBackgroundForShadow(actionRow);
+    expect(styleHasShadow(actionRow)).toBe(true);
+    expect(actionRow.shadowOpacity).toBeLessThan(
+      (tripCard.shadowOpacity as number) ?? 1
+    );
+  });
+
   it("trip traveller chip co-locates shadow and backgroundColor", () => {
     assertSolidBackgroundForShadow(
       StyleSheet.flatten(shadowRegressionStyles.tripTravellerChip)

--- a/TravelCostApp/components/Auth/AuthContent.tsx
+++ b/TravelCostApp/components/Auth/AuthContent.tsx
@@ -15,7 +15,7 @@ import { i18n } from "../../i18n/i18n";
 
 import { useNavigation } from "@react-navigation/native";
 
-import FlatButton from "../UI/FlatButton";
+import ActionRow from "../UI/ActionRow";
 import AuthForm from "./AuthForm";
 import { GlobalStyles } from "../../constants/styles";
 import PropTypes from "prop-types";
@@ -102,9 +102,14 @@ function AuthContent({ isLogin, onAuthenticate, isConnected }) {
             <Text style={styles.secondaryText}>
               {isLogin ? i18n.t("noAccountText") : i18n.t("alreadyAccountText")}
             </Text>
-            <FlatButton onPress={switchAuthModeHandler}>
-              {isLogin ? i18n.t("createNewUser") : i18n.t("loginInstead")}
-            </FlatButton>
+            <ActionRow
+              tier="secondary"
+              label={isLogin ? i18n.t("createNewUser") : i18n.t("loginInstead")}
+              icon="swap-horizontal-outline"
+              showChevron={false}
+              compact
+              onPress={switchAuthModeHandler}
+            />
           </View>
         </View>
       </ScrollView>

--- a/TravelCostApp/components/Auth/AuthForm.tsx
+++ b/TravelCostApp/components/Auth/AuthForm.tsx
@@ -6,7 +6,7 @@ import { i18n } from "../../i18n/i18n";
 
 import Input from "./Input";
 import PropTypes from "prop-types";
-import GradientButton from "../UI/GradientButton";
+import ActionRow from "../UI/ActionRow";
 import {
   secureStoreGetItem,
   secureStoreSetItem,
@@ -194,19 +194,18 @@ function AuthForm({ isLogin, onSubmit, credentialsInvalid, isConnected }) {
         />
 
         <View style={styles.buttons}>
-          <GradientButton
-            colors={
-              isConnected
-                ? GlobalStyles.gradientPrimaryButton
-                : [
-                    GlobalStyles.colors.primary500,
-                    GlobalStyles.colors.primaryGrayed,
-                  ]
-            }
+          <ActionRow
+            tier="primary"
+            label={isLogin ? i18n.t("loginText") : i18n.t("createAccountText")}
+            icon={isLogin ? "log-in-outline" : "person-add-outline"}
+            showChevron={false}
+            compact
             onPress={submitHandler}
-          >
-            {isLogin ? i18n.t("loginText") : i18n.t("createAccountText")}
-          </GradientButton>
+            style={[
+              styles.submitButton,
+              !isConnected && styles.submitButtonOffline,
+            ]}
+          />
         </View>
         <View style={styles.appleAuthContainer}>
           {/* {AppleAuthenticationJSX} */}
@@ -240,6 +239,12 @@ const styles = StyleSheet.create({
   },
   buttons: {
     marginTop: dynamicScale(12),
+  },
+  submitButton: {
+    width: "100%",
+  },
+  submitButtonOffline: {
+    opacity: 0.6,
   },
   iconContainer: {
     marginTop: dynamicScale(-30, true),

--- a/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
@@ -13,8 +13,7 @@ import { i18n } from "../../i18n/i18n";
 import { EXPENSES_LOAD_TIMEOUT } from "../../confAppConstants";
 import { memo } from "react";
 import { TripContext } from "../../store/trip-context";
-import FlatButton from "../UI/FlatButton";
-import GradientButton from "../UI/GradientButton";
+import ActionRow from "../UI/ActionRow";
 import { useNavigation } from "@react-navigation/native";
 import { ExpensesContext, RangeString } from "../../store/expenses-context";
 import { UserContext } from "../../store/user-context";
@@ -85,39 +84,39 @@ function ExpensesOutput({
             )}
             {!showLoading && emptyCtaLabel && onEmptyCtaPress && (
               <View testID="empty-expenses-cta" style={styles.emptyCta}>
-                <GradientButton
+                <ActionRow
+                  tier="primary"
+                  label={emptyCtaLabel}
+                  icon="add-circle-outline"
                   onPress={onEmptyCtaPress}
-                  buttonStyle={styles.emptyCtaInner}
-                >
-                  {emptyCtaLabel}
-                </GradientButton>
+                />
               </View>
             )}
             {showYesterday && (
-              <FlatButton
-                textStyle={{ marginVertical: dynamicScale(4, false, 0.5) }}
+              <ActionRow
+                tier="secondary"
+                label={`${i18n.t("showXResults1")} ${i18n.t("yesterday")}`}
+                icon="calendar-outline"
                 onPress={() => {
                   (navigation as any).navigate("FilteredExpenses", {
                     expenses: toExpenseNavigationDtos(yesterdayExpenses),
                     dayString: i18n.t("yesterday"),
                   });
                 }}
-              >
-                {i18n.t("showXResults1") + " " + i18n.t("yesterday")}
-              </FlatButton>
+              />
             )}
             {showTomorrow && (
-              <FlatButton
-                textStyle={{ marginVertical: dynamicScale(4, false, 0.5) }}
+              <ActionRow
+                tier="secondary"
+                label={`${i18n.t("showXResults1")} ${i18n.t("tomorrow")}`}
+                icon="calendar-outline"
                 onPress={() => {
                   (navigation as any).navigate("FilteredExpenses", {
                     expenses: toExpenseNavigationDtos(tomorrowExpenses),
                     dayString: i18n.t("tomorrow"),
                   });
                 }}
-              >
-                {i18n.t("showXResults1") + " " + i18n.t("tomorrow")}
-              </FlatButton>
+              />
             )}
           </View>
         </ScrollView>
@@ -198,11 +197,6 @@ const styles = StyleSheet.create({
     marginVertical: dynamicScale(32, false, 0.5),
   },
   emptyCta: {
-    alignSelf: "center",
     marginTop: dynamicScale(8, true),
-    minWidth: "70%",
-  },
-  emptyCtaInner: {
-    paddingVertical: dynamicScale(12, true),
   },
 });

--- a/TravelCostApp/components/FeedbackForm/FeedbackForm.tsx
+++ b/TravelCostApp/components/FeedbackForm/FeedbackForm.tsx
@@ -14,8 +14,8 @@ import * as Haptics from "expo-haptics";
 import { i18n } from "../../i18n/i18n";
 
 import PropTypes from "prop-types";
-import GradientButton from "../UI/GradientButton";
-import FlatButton from "../UI/FlatButton";
+import ActionRow from "../UI/ActionRow";
+import ActionRowStack from "../UI/ActionRowStack";
 import { GlobalStyles } from "../../constants/styles";
 import { UserContext } from "../../store/user-context";
 import { storeFeedback, FeedbackData } from "../../util/http";
@@ -128,23 +128,25 @@ const FeedbackForm: React.FC<FeedbackFormProps> = ({ isVisible, onClose }) => {
             </Text>
           </View>
 
-          <View style={styles.modalButtons}>
-            <FlatButton onPress={handleClose} textStyle={{ fontSize: 16 }}>
-              {i18n.t("cancel")}
-            </FlatButton>
-            <GradientButton
-              style={styles.submitButton}
-              colors={GlobalStyles.gradientColorsButton}
-              onPress={handleSubmit}
-              darkText
-              buttonStyle={[
-                { padding: 8, paddingHorizontal: 12 },
-                (isSubmitting || !feedbackText.trim()) && styles.disabledButton,
-              ]}
-            >
-              {isSubmitting ? i18n.t("submitting") : i18n.t("submit")}
-            </GradientButton>
-          </View>
+          <ActionRowStack
+            showChevron={false}
+            actions={[
+              {
+                testID: "feedback-submit",
+                tier: "primary",
+                label: isSubmitting ? i18n.t("submitting") : i18n.t("submit"),
+                icon: "paper-plane-outline",
+                onPress: handleSubmit,
+                disabled: isSubmitting || !feedbackText.trim(),
+              },
+              {
+                testID: "feedback-cancel",
+                tier: "secondary",
+                label: i18n.t("cancel"),
+                onPress: handleClose,
+              },
+            ]}
+          />
         </View>
       </KeyboardAvoidingView>
     </Modal>
@@ -208,18 +210,6 @@ const styles = StyleSheet.create({
     color: GlobalStyles.colors.gray500,
     textAlign: "right",
     marginTop: dynamicScale(4),
-  },
-  modalButtons: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  submitButton: {
-    marginLeft: dynamicScale(16, false, 0.5),
-    flex: 1,
-  },
-  disabledButton: {
-    opacity: 0.5,
   },
 });
 

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -18,7 +18,6 @@ import {
   FlatList,
   KeyboardAvoidingView,
   InputAccessoryView,
-  Image,
 } from "react-native";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { useFocusEffect } from "@react-navigation/native";
@@ -30,7 +29,6 @@ import { GlobalStyles } from "../../constants/styles";
 import { AuthContext } from "../../store/auth-context";
 import IconButton from "../UI/IconButton";
 import { UserContext } from "../../store/user-context";
-import FlatButton from "../UI/FlatButton";
 import {
   DEFAULTCATEGORIES,
   getCatSymbol,
@@ -85,6 +83,7 @@ import { i18n } from "../../i18n/i18n";
 
 import CurrencyPicker from "../Currency/CurrencyPicker";
 import { truncateString } from "../../util/string";
+import { expenseFormLocalPriceHint } from "../../util/expense-form-local-price-hint";
 import { Ionicons } from "@expo/vector-icons";
 import Animated, {
   Easing,
@@ -95,7 +94,8 @@ import Animated, {
 import { DateTime } from "luxon";
 import DatePickerModal from "../UI/DatePickerModal";
 import DatePickerContainer from "../UI/DatePickerContainer";
-import GradientButton from "../UI/GradientButton";
+import ActionRow from "../UI/ActionRow";
+import ActionRowStack from "../UI/ActionRowStack";
 import {
   DuplicateOption,
   ExpenseData,
@@ -1196,6 +1196,22 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     });
   };
 
+  const getLocalPriceRowHint = useMemo(
+    () =>
+      expenseFormLocalPriceHint({
+        product: inputs.description.value,
+        country: inputs.country.value,
+        price: amountValue,
+        currency: inputs.currency.value,
+      }),
+    [
+      inputs.description.value,
+      inputs.country.value,
+      inputs.currency.value,
+      amountValue,
+    ]
+  );
+
   const backButtonJsx = (
     <BackButton
       style={{
@@ -2038,40 +2054,37 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
             inputs.currency.value &&
             inputs.country.value && (
               <View style={styles.getLocalPriceContainer}>
-                <GradientButton
-                  style={styles.getLocalPriceButton}
-                  textStyle={{ fontSize: 16 }}
-                  buttonStyle={{ padding: 8, paddingHorizontal: 12 }}
-                  colors={GlobalStyles.gradientColorsButton}
+                <ActionRow
+                  testID="expense-form-get-local-price"
+                  tier="gradient"
+                  label={i18n.t("getLocalPriceTitle")}
+                  hint={getLocalPriceRowHint}
+                  imageIconSource={require("../../assets/chatgpt-logo.jpeg")}
                   onPress={askChatGPTHandler}
-                  darkText
-                >
-                  <View style={{ flexDirection: "row", alignItems: "center" }}>
-                    <Image
-                      source={require("../../assets/chatgpt-logo.jpeg")}
-                      style={{
-                        width: dynamicScale(16, false, 0.5),
-                        height: dynamicScale(16, false, 0.5),
-                        marginRight: 8,
-                      }}
-                    />
-                    <Text
-                      style={{
-                        fontSize: 16,
-                        color: GlobalStyles.colors.textColor,
-                      }}
-                    >
-                      {i18n.t("getLocalPriceTitle")}
-                    </Text>
-                  </View>
-                </GradientButton>
+                  showChevron={false}
+                  style={styles.getLocalPriceButton}
+                />
               </View>
             )}
           <View style={styles.buttonContainer}>
-            <FlatButton onPress={onCancel}>{i18n.t("cancel")}</FlatButton>
-            <GradientButton style={styles.button} onPress={debouncedSubmit}>
-              {submitButtonLabel}
-            </GradientButton>
+            <ActionRowStack
+              showChevron={false}
+              actions={[
+                {
+                  testID: "expense-form-submit",
+                  tier: "primary",
+                  label: submitButtonLabel,
+                  icon: "checkmark-circle-outline",
+                  onPress: debouncedSubmit,
+                },
+                {
+                  testID: "expense-form-cancel",
+                  tier: "secondary",
+                  label: i18n.t("cancel"),
+                  onPress: onCancel,
+                },
+              ]}
+            />
           </View>
         </Animated.View>
       </Animated.View>
@@ -2317,10 +2330,10 @@ const styles = StyleSheet.create({
     color: GlobalStyles.colors.textColor,
   },
   buttonContainer: {
-    flexDirection: "row",
-    justifyContent: "space-evenly",
-    alignItems: "baseline",
+    flexDirection: "column",
+    alignItems: "stretch",
     paddingTop: dynamicScale(20, true),
+    marginHorizontal: "4%",
   },
   currencyContainer: {
     maxWidth: "100%",
@@ -2471,13 +2484,11 @@ const styles = StyleSheet.create({
     overflow: "visible",
   },
   getLocalPriceContainer: {
-    flexDirection: "row",
-    justifyContent: "center",
-    alignItems: "center",
     paddingTop: dynamicScale(12, true),
     marginHorizontal: "4%",
   },
   getLocalPriceButton: {
+    alignSelf: "stretch",
     marginHorizontal: 0,
     marginVertical: 0,
   },

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplateHelpModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplateHelpModal.tsx
@@ -3,7 +3,7 @@ import { ScrollView, StyleSheet, Text } from "react-native";
 import PropTypes from "prop-types";
 
 import AppModal from "../UI/AppModal";
-import FlatButton from "../UI/FlatButton";
+import ActionRow from "../UI/ActionRow";
 import { GlobalStyles } from "../../constants/styles";
 import { i18n } from "../../i18n/i18n";
 import { dynamicScale } from "../../util/scalingUtil";
@@ -30,9 +30,12 @@ const ExpenseTemplateHelpModal = ({
       <ScrollView style={styles.bodyScroll}>
         <Text style={styles.body}>{i18n.t("templateExpensesHelpText")}</Text>
       </ScrollView>
-      <FlatButton onPress={onClose} textStyle={styles.dismissButtonText}>
-        {i18n.t("confirm")}
-      </FlatButton>
+      <ActionRow
+        tier="primary"
+        label={i18n.t("confirm")}
+        onPress={onClose}
+        showChevron={false}
+      />
     </AppModal>
   );
 };

--- a/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseTemplatePickerModal.tsx
@@ -11,7 +11,7 @@ import { i18n } from "../../i18n/i18n";
 import type { ExpenseData } from "../../util/expense";
 import { templatePickerModalContentWidth } from "../../util/modal-layout";
 import { dynamicScale } from "../../util/scalingUtil";
-import FlatButton from "../UI/FlatButton";
+import ActionRow from "../UI/ActionRow";
 import InfoButton from "../UI/InfoButton";
 
 export type ExpenseTemplatePickerModalProps = {
@@ -105,11 +105,14 @@ const ExpenseTemplatePickerModal = ({
           containerStyle={styles.infoButton}
           onPress={openHelp}
         />
-        <View testID="expense-template-picker-close">
-          <FlatButton onPress={onClose} textStyle={styles.closeButtonText}>
-            {i18n.t("cancel")}
-          </FlatButton>
-        </View>
+        <ActionRow
+          testID="expense-template-picker-close"
+          tier="secondary"
+          label={i18n.t("cancel")}
+          onPress={onClose}
+          showChevron={false}
+          style={styles.closeAction}
+        />
       </View>
       <ExpenseTemplateHelpModal isVisible={helpVisible} onClose={closeHelp} />
       <FlatList
@@ -160,8 +163,9 @@ const styles = StyleSheet.create({
   infoButton: {
     marginHorizontal: dynamicScale(6, false, 0.5),
   },
-  closeButtonText: {
-    fontSize: dynamicScale(16, false, 0.5),
+  closeAction: {
+    marginBottom: 0,
+    flex: 1,
   },
   sectionSubtitle: {
     fontWeight: "300",

--- a/TravelCostApp/components/ManageProfile/ProfileIdentity.tsx
+++ b/TravelCostApp/components/ManageProfile/ProfileIdentity.tsx
@@ -5,8 +5,7 @@ import PropTypes from "prop-types";
 
 import { GlobalStyles } from "../../constants/styles";
 import { UserContext } from "../../store/user-context";
-import FlatButton from "../UI/FlatButton";
-import GradientButton from "../UI/GradientButton";
+import ActionRow from "../UI/ActionRow";
 import { i18n } from "../../i18n/i18n";
 import { dynamicScale } from "../../util/scalingUtil";
 import { trackEvent } from "../../util/vexo-tracking";
@@ -28,15 +27,22 @@ const ProfileIdentity = ({ navigation }: ProfileIdentityProps) => {
 
   const freshlyNavigationButtons = freshlyCreated && (
     <View style={styles.navButtonContainer}>
-      <FlatButton onPress={joinInviteHandler}>
-        {i18n.t("invitationText")}
-      </FlatButton>
-      <GradientButton
-        style={styles.navButton}
+      <ActionRow
+        testID="profile-identity-join"
+        tier="secondary"
+        label={i18n.t("invitationText")}
+        hint={i18n.t("joinBudgetHint")}
+        icon="people-outline"
+        onPress={joinInviteHandler}
+      />
+      <ActionRow
+        testID="profile-identity-create"
+        tier="primary"
+        label={i18n.t("createFirstTrip")}
+        hint={i18n.t("addAnotherBudgetHint")}
+        icon="add-circle-outline"
         onPress={() => navigation.navigate("ManageTrip")}
-      >
-        {i18n.t("createFirstTrip")}
-      </GradientButton>
+      />
     </View>
   );
 
@@ -121,14 +127,7 @@ const styles = StyleSheet.create({
     color: GlobalStyles.colors.primary700,
   },
   navButtonContainer: {
-    justifyContent: "flex-end",
-    padding: dynamicScale(4, true),
-    marginVertical: dynamicScale(8, true),
-    marginTop: dynamicScale(16, true),
-  },
-  navButton: {
-    minWidth: dynamicScale(120),
-    marginVertical: dynamicScale(8, true),
-    marginTop: dynamicScale(16, true),
+    paddingHorizontal: dynamicScale(15),
+    marginTop: dynamicScale(8, true),
   },
 });

--- a/TravelCostApp/components/ManageProfile/ProfileToolbar.tsx
+++ b/TravelCostApp/components/ManageProfile/ProfileToolbar.tsx
@@ -3,7 +3,6 @@ import { View, Alert, StyleSheet, Platform } from "react-native";
 import React from "react";
 import * as Haptics from "expo-haptics";
 import PropTypes from "prop-types";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { GlobalStyles } from "../../constants/styles";
 import { AuthContext } from "../../store/auth-context";
@@ -17,6 +16,7 @@ import { fetchChangelog } from "../../util/http";
 import { asyncStoreSafeClear } from "../../store/async-storage";
 import { getMMKVString, MMKV_KEYS } from "../../store/mmkv";
 import { dynamicScale } from "../../util/scalingUtil";
+import { ProfileToolbarTokens } from "../../styles/profile-toolbar-tokens";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 
@@ -37,7 +37,6 @@ const ProfileToolbar = ({
   const isConnected = netCtx.strongConnection;
   const freshlyCreated = userCtx.freshlyCreated;
   const hasNewChanges = userCtx.hasNewChanges;
-  const insets = useSafeAreaInsets();
 
   function logoutHandler() {
     return Alert.alert(i18n.t("sure"), i18n.t("signOutAlertMess"), [
@@ -74,45 +73,46 @@ const ProfileToolbar = ({
   return (
     <View
       testID="profile-floating-toolbar"
-      style={[
-        styles.toolbar,
-        {
-          paddingTop: Math.max(insets.top, dynamicScale(8, true)),
-        },
-      ]}
+      pointerEvents="box-none"
+      style={styles.toolbarShell}
     >
-      <View style={styles.toolbarButtons}>
-        {!freshlyCreated && (
+      <View testID="profile-toolbar-chrome" style={styles.toolbarChrome}>
+        <View testID="profile-toolbar-buttons" style={styles.toolbarButtons}>
+          {!freshlyCreated && (
+            <IconButton
+              icon="newspaper-outline"
+              size={ProfileToolbarTokens.iconSize}
+              buttonStyle={styles.iconButton}
+              color={GlobalStyles.colors.textColor}
+              onPress={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                navigation.navigate("Changelog");
+                userCtx.setHasNewChanges(false);
+              }}
+              badge={hasNewChanges}
+              badgeStyle={{ backgroundColor: GlobalStyles.colors.error500 }}
+            />
+          )}
+          {!freshlyCreated && (
+            <IconButton
+              icon="settings-outline"
+              size={ProfileToolbarTokens.iconSize}
+              buttonStyle={styles.iconButton}
+              color={GlobalStyles.colors.textColor}
+              onPress={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                navigation.navigate("Settings");
+              }}
+            />
+          )}
           <IconButton
-            icon="newspaper-outline"
-            size={dynamicScale(36, false, 0.5)}
+            icon="exit-outline"
+            size={ProfileToolbarTokens.iconSize}
+            buttonStyle={styles.iconButton}
             color={GlobalStyles.colors.textColor}
-            onPress={() => {
-              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-              navigation.navigate("Changelog");
-              userCtx.setHasNewChanges(false);
-            }}
-            badge={hasNewChanges}
-            badgeStyle={{ backgroundColor: GlobalStyles.colors.error500 }}
+            onPress={logoutHandler}
           />
-        )}
-        {!freshlyCreated && (
-          <IconButton
-            icon="settings-outline"
-            size={dynamicScale(36, false, 0.5)}
-            color={GlobalStyles.colors.textColor}
-            onPress={() => {
-              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-              navigation.navigate("Settings");
-            }}
-          />
-        )}
-        <IconButton
-          icon="exit-outline"
-          size={dynamicScale(36, false, 0.5)}
-          color={GlobalStyles.colors.textColor}
-          onPress={logoutHandler}
-        />
+        </View>
       </View>
     </View>
   );
@@ -126,15 +126,18 @@ ProfileToolbar.propTypes = {
 };
 
 const styles = StyleSheet.create({
-  toolbar: {
+  toolbarShell: {
     position: "absolute",
     top: 0,
     left: 0,
     right: 0,
     zIndex: 10,
+  },
+  toolbarChrome: {
+    minHeight: ProfileToolbarTokens.chromeHeight,
     backgroundColor: GlobalStyles.colors.backgroundColor,
-    paddingBottom: dynamicScale(8, true),
-    paddingHorizontal: dynamicScale(8, false, 0.5),
+    paddingBottom: ProfileToolbarTokens.paddingVertical,
+    paddingHorizontal: ProfileToolbarTokens.paddingHorizontal,
     ...Platform.select({
       ios: {
         shadowColor: GlobalStyles.colors.textColor,
@@ -151,6 +154,11 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "flex-end",
     alignItems: "center",
-    gap: dynamicScale(4, false, 0.5),
+    minHeight: ProfileToolbarTokens.contentHeight,
+    gap: dynamicScale(2, false, 0.5),
+  },
+  iconButton: {
+    padding: ProfileToolbarTokens.iconHitPadding,
+    borderRadius: ProfileToolbarTokens.iconSize,
   },
 });

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -29,7 +29,8 @@ import { KeyboardAvoidingView } from "react-native";
 import Input from "../ManageExpense/Input";
 import { TripContext, TripData } from "../../store/trip-context";
 import { UserContext } from "../../store/user-context";
-import FlatButton from "../UI/FlatButton";
+import ActionRow from "../UI/ActionRow";
+import ActionRowStack from "../UI/ActionRowStack";
 import { ExpensesContext } from "../../store/expenses-context";
 import CurrencyPicker from "../Currency/CurrencyPicker";
 import { useHeaderHeight } from "@react-navigation/elements";
@@ -43,7 +44,6 @@ import * as Haptics from "expo-haptics";
 import DatePickerModal from "../UI/DatePickerModal";
 import IconButton from "../UI/IconButton";
 import DatePickerContainer from "../UI/DatePickerContainer";
-import GradientButton from "../UI/GradientButton";
 import PropTypes from "prop-types";
 import InfoButton from "../UI/InfoButton";
 import Modal from "react-native-modal";
@@ -767,9 +767,12 @@ const TripForm = ({ navigation, route }) => {
       <View style={styles.infoModalContainer}>
         <Text style={styles.infoTitleText}>{infoTitleText}</Text>
         <Text style={styles.infoContentText}>{infoContentText}</Text>
-        <FlatButton onPress={setInfoIsVisible.bind(this, false)}>
-          {i18n.t("confirm")}
-        </FlatButton>
+        <ActionRow
+          tier="primary"
+          label={i18n.t("confirm")}
+          onPress={setInfoIsVisible.bind(this, false)}
+          showChevron={false}
+        />
       </View>
     </Modal>
   );
@@ -815,33 +818,34 @@ const TripForm = ({ navigation, route }) => {
             ios: -100,
           })}
         >
-          <View
-            style={{
-              flexDirection: "row",
-              justifyContent: "space-between",
-              marginHorizontal: dynamicScale(8, false, 0.5),
-              marginBottom: dynamicScale(-8, false, 0.5),
-            }}
-          >
+          <View style={styles.headerRow}>
             <BackButton style={{ marginTop: dynamicScale(-8) }}></BackButton>
-            {!isEditing && (
-              <FlatButton
-                onPress={() => {
-                  navigation.navigate("Join");
-                }}
-              >
-                {i18n.t("joinTripLabel")}
-              </FlatButton>
-            )}
-            {isEditing && (
-              <FlatButton
-                onPress={() => {
-                  onShare(editedTripId, navigation);
-                }}
-              >
-                {i18n.t("shareTripLabel")}
-              </FlatButton>
-            )}
+            <View style={styles.headerAction}>
+              {!isEditing && (
+                <ActionRow
+                  testID="trip-form-join"
+                  tier="secondary"
+                  label={i18n.t("joinTripLabel")}
+                  icon="people-outline"
+                  onPress={() => {
+                    navigation.navigate("Join");
+                  }}
+                  style={styles.headerActionRow}
+                />
+              )}
+              {isEditing && (
+                <ActionRow
+                  testID="trip-form-share"
+                  tier="secondary"
+                  label={i18n.t("shareTripLabel")}
+                  icon="share-outline"
+                  onPress={() => {
+                    onShare(editedTripId, navigation);
+                  }}
+                  style={styles.headerActionRow}
+                />
+              )}
+            </View>
           </View>
           <View
             style={[
@@ -1074,62 +1078,73 @@ const TripForm = ({ navigation, route }) => {
           </View>
           {/* Add Currency Input field */}
           <View style={styles.buttonContainer}>
-            <FlatButton onPress={cancelHandler}>{i18n.t("cancel")}</FlatButton>
-            {!isEditing ? (
-              <GradientButton
-                buttonStyle={{}}
-                style={styles.button}
-                onPress={submitHandler.bind(this, true /* setActive */)}
-              >
-                {i18n.t("confirm2")}
-              </GradientButton>
-            ) : (
-              <FlatButton
-                onPress={submitHandler.bind(this, false /* setActive */)}
-              >
-                {i18n.t("saveChanges")}
-              </FlatButton>
-            )}
+            <ActionRowStack
+              showChevron={false}
+              actions={
+                !isEditing
+                  ? [
+                      {
+                        testID: "trip-form-confirm",
+                        tier: "primary",
+                        label: i18n.t("confirm2"),
+                        icon: "checkmark-circle-outline",
+                        onPress: submitHandler.bind(this, true),
+                      },
+                      {
+                        testID: "trip-form-cancel",
+                        tier: "secondary",
+                        label: i18n.t("cancel"),
+                        onPress: cancelHandler,
+                      },
+                    ]
+                  : [
+                      {
+                        testID: "trip-form-save",
+                        tier: "primary",
+                        label: i18n.t("saveChanges"),
+                        icon: "save-outline",
+                        onPress: submitHandler.bind(this, false),
+                      },
+                      {
+                        testID: "trip-form-cancel",
+                        tier: "secondary",
+                        label: i18n.t("cancel"),
+                        onPress: cancelHandler,
+                      },
+                    ]
+              }
+            />
           </View>
           {/* Horizontal container */}
           {isEditing && !isPromote && (
-            <GradientButton
-              buttonStyle={{}}
-              style={[
-                styles.button,
-                {
-                  marginVertical: dynamicScale(8, false, 0.5),
-                  marginHorizontal: dynamicScale(24, false, 0.5),
-                },
-              ]}
-              onPress={() => {
-                trackEvent(VexoEvents.SET_ACTIVE_TRIP_PRESSED, {
-                  tripId: editedTripId,
-                });
-                submitHandler(true /* setActive */);
-              }}
-            >
-              {i18n.t("setActive")}
-            </GradientButton>
+            <View style={styles.tripActionRows}>
+              <ActionRow
+                testID="trip-form-set-active"
+                tier="primary"
+                label={i18n.t("setActive")}
+                icon="star-outline"
+                showChevron={false}
+                onPress={() => {
+                  trackEvent(VexoEvents.SET_ACTIVE_TRIP_PRESSED, {
+                    tripId: editedTripId,
+                  });
+                  submitHandler(true /* setActive */);
+                }}
+              />
+            </View>
           )}
           {isEditing && !isPromote && (userCtx.tripHistory?.length ?? 0) > 1 && (
-            <GradientButton
-              buttonStyle={{
-                backgroundColor: GlobalStyles.colors.error300,
-                opacity: isConnected ? 1 : 0.5,
-              }}
-              style={[
-                styles.button,
-                {
-                  marginBottom: dynamicScale(8, false, 0.5),
-                  marginHorizontal: dynamicScale(24, false, 0.5),
-                },
-              ]}
-              onPress={leaveHandler}
-              colors={GlobalStyles.gradientErrorButton}
-            >
-              {i18n.t("leaveTrip")}
-            </GradientButton>
+            <View style={styles.tripActionRows}>
+              <ActionRow
+                testID="trip-form-leave"
+                tier="primary"
+                label={i18n.t("leaveTrip")}
+                icon="exit-outline"
+                onPress={leaveHandler}
+                showChevron={false}
+                style={{ opacity: isConnected ? 1 : 0.5 }}
+              />
+            </View>
           )}
         </KeyboardAvoidingView>
       </Animated.View>
@@ -1152,6 +1167,23 @@ TripForm.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginHorizontal: dynamicScale(8, false, 0.5),
+    marginBottom: dynamicScale(-8, false, 0.5),
+  },
+  headerAction: {
+    flex: 1,
+    marginLeft: dynamicScale(4, false, 0.5),
+  },
+  headerActionRow: {
+    marginBottom: 0,
+  },
+  tripActionRows: {
+    marginHorizontal: dynamicScale(24, false, 0.5),
+    marginVertical: dynamicScale(4, false, 0.5),
+  },
   form: {
     // flex: 1,
     backgroundColor: GlobalStyles.colors.backgroundColor,
@@ -1248,10 +1280,8 @@ const styles = StyleSheet.create({
     margin: dynamicScale(8, false, 0.5),
   },
   buttonContainer: {
-    flexDirection: "row",
-    justifyContent: "space-around",
-    alignItems: "center",
-
+    flexDirection: "column",
+    alignItems: "stretch",
     marginTop: "4%",
     marginBottom: "2%",
     marginHorizontal: "4%",

--- a/TravelCostApp/components/Premium/BlurPremium.tsx
+++ b/TravelCostApp/components/Premium/BlurPremium.tsx
@@ -1,7 +1,7 @@
 import { Alert, Platform, StyleSheet } from "react-native";
 import React, { useContext, useEffect, useState } from "react";
 import { BlurView } from "expo-blur";
-import GradientButton from "../UI/GradientButton";
+import ActionRow from "../UI/ActionRow";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import { GlobalStyles } from "../../constants/styles";
 
@@ -12,7 +12,6 @@ import { Card } from "react-native-paper";
 import { sleep } from "../../util/appState";
 import { NetworkContext } from "../../store/network-context";
 import { UserContext } from "../../store/user-context";
-import FlatButton from "../UI/FlatButton";
 import PropTypes from "prop-types";
 import { shouldShowOnboarding } from "../Rating/firstStartUtil";
 import { trackEvent } from "../../util/vexo-tracking";
@@ -90,10 +89,12 @@ const BlurPremium = ({ canBack = false }) => {
               // marginLeft: -55,
             }}
           >
-            <GradientButton
-              darkText
-              buttonStyle={{}}
-              colors={GlobalStyles.gradientColorsButton}
+            <ActionRow
+              tier="gradient"
+              label={i18n.t("paywallTitle")}
+              icon="diamond-outline"
+              showChevron={false}
+              compact
               onPress={() => {
                 if (!isConnected) {
                   Alert.alert(
@@ -105,16 +106,18 @@ const BlurPremium = ({ canBack = false }) => {
                 trackEvent(VexoEvents.PREMIUM_BLUR_CARD_PRESSED);
                 navigation.navigate("Paywall");
               }}
-            >
-              {i18n.t("paywallTitle")}
-            </GradientButton>
+            />
             {canBack && (
-              <FlatButton
+              <ActionRow
+                tier="secondary"
+                label={i18n.t("back")}
+                icon="chevron-back-outline"
                 onPress={() => navigation.goBack()}
-                textStyle={{ marginTop: 12, marginBottom: isAndroid ? 0 : -12 }}
-              >
-                Back
-              </FlatButton>
+                style={{
+                  marginTop: 12,
+                  marginBottom: isAndroid ? 0 : -12,
+                }}
+              />
             )}
           </Card>
         </Animated.View>

--- a/TravelCostApp/components/Premium/PayWall.tsx
+++ b/TravelCostApp/components/Premium/PayWall.tsx
@@ -18,7 +18,7 @@ import Purchases from "react-native-purchases";
 import { GlobalStyles } from "../../constants/styles";
 import PackageItem from "../Premium/PackageItem";
 import BackgroundGradient from "../UI/BackgroundGradient";
-import FlatButton from "../UI/FlatButton";
+import ActionRow from "../UI/ActionRow";
 import PropTypes from "prop-types";
 import IconButton from "../UI/IconButton";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
@@ -63,15 +63,16 @@ const PaywallScreen = ({ navigation }) => {
   const header = () => (
     <View>
       {/* <BackButton></BackButton> */}
-      <FlatButton
-        textStyle={styles.backButtonTextStyle}
+      <ActionRow
+        tier="secondary"
+        label={i18n.t("back")}
+        icon="chevron-back-outline"
         onPress={() => {
           trackEvent(VexoEvents.PAYWALL_BACK_PRESSED);
           navigation.pop();
         }}
-      >
-        {i18n.t("back")}
-      </FlatButton>
+        style={styles.backButton}
+      />
       <View
         style={{
           alignItems: "center",
@@ -288,11 +289,8 @@ const styles = StyleSheet.create({
     // text size
     fontSize: constantScale(12, 0.5),
   },
-  backButtonTextStyle: {
-    color: GlobalStyles.colors.accent250,
-    fontSize: constantScale(16, 0.5),
-    fontWeight: "bold",
-    textAlign: "left",
+  backButton: {
+    alignSelf: "stretch",
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,

--- a/TravelCostApp/components/ProfileOutput/MyBudgetsHubActions.tsx
+++ b/TravelCostApp/components/ProfileOutput/MyBudgetsHubActions.tsx
@@ -1,80 +1,39 @@
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
-import { GlobalStyles } from "../../constants/styles";
-import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
-import { dynamicScale } from "../../util/scalingUtil";
+import { View } from "react-native";
 import { i18n } from "../../i18n/i18n";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 import PropTypes from "prop-types";
+import ActionRow from "../UI/ActionRow";
 
 type MyBudgetsHubActionsProps = {
   onJoin: () => void;
   onAddAnother: () => void;
 };
 
-function ActionRow({
-  testID,
-  label,
-  hint,
-  icon,
-  onPress,
-}: {
-  testID: string;
-  label: string;
-  hint: string;
-  icon: React.ComponentProps<typeof Ionicons>["name"];
-  onPress: () => void;
-}) {
-  return (
-    <Pressable
-      testID={testID}
-      onPress={onPress}
-      style={({ pressed }) => [
-        styles.actionRow,
-        shadowRegressionStyles.tripHistoryCard,
-        pressed && GlobalStyles.pressed,
-      ]}
-    >
-      <View style={styles.actionIcon}>
-        <Ionicons
-          name={icon}
-          size={dynamicScale(20, false, 0.5)}
-          color={GlobalStyles.colors.primary500}
-        />
-      </View>
-      <View style={styles.actionText}>
-        <Text style={styles.actionLabel}>{label}</Text>
-        <Text style={styles.actionHint}>{hint}</Text>
-      </View>
-      <Text style={styles.chevron}>›</Text>
-    </Pressable>
-  );
-}
-
-/** Variant B hub actions: Join + Add another full-width rows above the budget list. */
 function MyBudgetsHubActions({ onJoin, onAddAnother }: MyBudgetsHubActionsProps) {
   return (
     <View testID="my-budgets-hub-actions">
       <ActionRow
-        testID="my-budgets-join"
-        label={i18n.t("joinBudget")}
-        hint={i18n.t("joinBudgetHint")}
-        icon="people-outline"
-        onPress={() => {
-          trackEvent(VexoEvents.TRIP_JOINED);
-          onJoin();
-        }}
-      />
-      <ActionRow
         testID="my-budgets-add-another"
+        tier="primary"
         label={i18n.t("addAnotherBudget")}
         hint={i18n.t("addAnotherBudgetHint")}
         icon="add-circle-outline"
         onPress={() => {
           trackEvent(VexoEvents.CREATE_TRIP_FROM_PROFILE_PRESSED);
           onAddAnother();
+        }}
+      />
+      <ActionRow
+        testID="my-budgets-join"
+        tier="secondary"
+        label={i18n.t("joinBudget")}
+        hint={i18n.t("joinBudgetHint")}
+        icon="people-outline"
+        onPress={() => {
+          trackEvent(VexoEvents.TRIP_JOINED);
+          onJoin();
         }}
       />
     </View>
@@ -87,30 +46,3 @@ MyBudgetsHubActions.propTypes = {
   onJoin: PropTypes.func.isRequired,
   onAddAnother: PropTypes.func.isRequired,
 };
-
-const styles = StyleSheet.create({
-  actionRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: GlobalStyles.colors.backgroundColorLight,
-    borderRadius: 16,
-    padding: dynamicScale(14),
-    marginBottom: dynamicScale(10, true),
-  },
-  actionIcon: { marginRight: dynamicScale(12) },
-  actionText: { flex: 1 },
-  actionLabel: {
-    fontSize: dynamicScale(16, false, 0.5),
-    fontWeight: "600",
-    color: GlobalStyles.colors.textColor,
-  },
-  actionHint: {
-    fontSize: dynamicScale(12, false, 0.5),
-    color: GlobalStyles.colors.textHidden,
-    marginTop: dynamicScale(2, true),
-  },
-  chevron: {
-    fontSize: dynamicScale(22, false, 0.5),
-    color: GlobalStyles.colors.gray600,
-  },
-});

--- a/TravelCostApp/components/ProfileOutput/ShareTrip.tsx
+++ b/TravelCostApp/components/ProfileOutput/ShareTrip.tsx
@@ -14,7 +14,7 @@ import PropTypes from "prop-types";
 import safeLogError from "../../util/error";
 import { loadKeys } from "../Premium/PremiumConstants";
 import { GlobalStyles } from "../../constants/styles";
-import GradientButton from "../UI/GradientButton";
+import ActionRow from "../UI/ActionRow";
 import IconButton from "../UI/IconButton";
 import { dynamicScale } from "../../util/scalingUtil";
 
@@ -77,12 +77,13 @@ const ShareTripButton = ({ route, navigation }) => {
           </Text>
 
           <View style={styles.buttonContainer}>
-            <GradientButton
+            <ActionRow
+              testID="share-trip-invite"
+              tier="primary"
+              label={i18n.t("inviteTraveller")}
+              icon="share-social-outline"
               onPress={() => onShare(shareId, navigation)}
-              style={styles.shareButton}
-            >
-              {i18n.t("inviteTraveller")}
-            </GradientButton>
+            />
           </View>
         </View>
       </ScrollView>

--- a/TravelCostApp/components/Settings/DevContent.tsx
+++ b/TravelCostApp/components/Settings/DevContent.tsx
@@ -10,7 +10,7 @@ import { DateTime } from "luxon";
 
 import { i18n } from "../../i18n/i18n";
 
-import Button from "../UI/Button";
+import ActionRow from "../UI/ActionRow";
 import { AuthContext } from "../../store/auth-context";
 import { TripContext } from "../../store/trip-context";
 import { NetworkContext } from "../../store/network-context";
@@ -96,8 +96,11 @@ const DevContent = ({ navigation }) => {
         <Text style={styles.titleText}>DEVCONTENT</Text>
       </View>
 
-      <Button
+      <ActionRow
         style={styles.settingsButton}
+        tier="primary"
+        label="showAdBanner"
+        showChevron={false}
         onPress={async () => {
           navigation.navigate("RecentExpenses");
           const onboardingFlags: OnboardingFlags = {
@@ -105,9 +108,7 @@ const DevContent = ({ navigation }) => {
           };
           await showBanner(navigation, onboardingFlags);
         }}
-      >
-        showAdBanner
-      </Button>
+      />
 
       <View style={{ padding: 12, flex: 1 }}>
         {currentVersion && <Text>Current Version: {currentVersion}</Text>}
@@ -139,8 +140,11 @@ const DevContent = ({ navigation }) => {
       />
       <Text>{errorMessage}</Text>
       {!isFetching && (
-        <Button
+        <ActionRow
           style={styles.settingsButton}
+          tier="primary"
+          label="Expo Token"
+          showChevron={false}
           onPress={async () => {
             setIsFetching(true);
             // testing the expo token routine
@@ -160,18 +164,17 @@ const DevContent = ({ navigation }) => {
             }
             setIsFetching(false);
           }}
-        >
-          Expo Token
-        </Button>
+        />
       )}
 
-      <Button
+      <ActionRow
         style={styles.settingsButton}
+        tier="primary"
+        label="trackPurchaseEvent"
+        showChevron={false}
         // onPress={async () => await trackPurchaseEvent()}
         onPress={async () => {}}
-      >
-        trackPurchaseEvent
-      </Button>
+      />
     </View>
   );
 };

--- a/TravelCostApp/components/Settings/GetLocalPriceButton.tsx
+++ b/TravelCostApp/components/Settings/GetLocalPriceButton.tsx
@@ -14,8 +14,8 @@ import { TripContext } from "../../store/trip-context";
 import { NetworkContext } from "../../store/network-context";
 import { GlobalStyles } from "../../constants/styles";
 import { dynamicScale } from "../../util/scalingUtil";
-import GradientButton from "../UI/GradientButton";
-import FlatButton from "../UI/FlatButton";
+import ActionRow from "../UI/ActionRow";
+import ActionRowStack from "../UI/ActionRowStack";
 import PropTypes from "prop-types";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
@@ -45,7 +45,6 @@ const GetLocalPriceButton = ({ navigation, style }) => {
       return;
     }
 
-    // Track get local price from profile
     trackEvent(VexoEvents.GET_LOCAL_PRICE_PROFILE_PRESSED, {
       product: productInput.trim(),
       currency: userCtx.lastCurrency || tripCtx.tripCurrency || "EUR",
@@ -67,26 +66,18 @@ const GetLocalPriceButton = ({ navigation, style }) => {
     setProductInput("");
   };
 
-  // Use different styles based on whether we're in header mode or standalone
-  const buttonStyle = style ? style : styles.settingsButton;
-
   return (
     <>
-      <GradientButton
-        style={buttonStyle}
-        buttonStyle={styles.gradientButtonStyle}
-        colors={GlobalStyles.gradientColorsButton}
+      <ActionRow
+        testID="profile-get-local-price"
+        tier="gradient"
+        label={i18n.t("getLocalPriceTitle")}
+        hint={i18n.t("getLocalPriceHint")}
+        imageIconSource={require("../../assets/chatgpt-logo.jpeg")}
         onPress={handleGetLocalPrice}
-        darkText
-      >
-        <View style={styles.buttonContent}>
-          <Image
-            source={require("../../assets/chatgpt-logo.jpeg")}
-            style={styles.buttonIcon}
-          />
-          <Text style={styles.buttonText}>{i18n.t("getLocalPriceTitle")}</Text>
-        </View>
-      </GradientButton>
+        showChevron={false}
+        style={style}
+      />
 
       <Modal
         visible={showLocalPriceModal}
@@ -122,23 +113,24 @@ const GetLocalPriceButton = ({ navigation, style }) => {
               onSubmitEditing={handleLocalPriceSubmit}
             />
 
-            <View style={styles.modalButtons}>
-              <FlatButton
-                onPress={handleModalClose}
-                textStyle={{ fontSize: 16 }}
-              >
-                {i18n.t("cancel")}
-              </FlatButton>
-              <GradientButton
-                style={styles.submitButton}
-                colors={GlobalStyles.gradientColorsButton}
-                onPress={handleLocalPriceSubmit}
-                darkText
-                buttonStyle={{ padding: 8, paddingHorizontal: 12 }}
-              >
-                {i18n.t("getLocalPriceTitle")}
-              </GradientButton>
-            </View>
+            <ActionRowStack
+              showChevron={false}
+              actions={[
+                {
+                  testID: "get-local-price-submit",
+                  tier: "gradient",
+                  label: i18n.t("getLocalPriceTitle"),
+                  onPress: handleLocalPriceSubmit,
+                  disabled: !productInput.trim(),
+                },
+                {
+                  testID: "get-local-price-cancel",
+                  tier: "secondary",
+                  label: i18n.t("cancel"),
+                  onPress: handleModalClose,
+                },
+              ]}
+            />
           </View>
         </KeyboardAvoidingView>
       </Modal>
@@ -152,38 +144,6 @@ GetLocalPriceButton.propTypes = {
 };
 
 const styles = StyleSheet.create({
-  settingsButton: {
-    marginVertical: "2%",
-    marginHorizontal: "8%",
-    borderRadius: 16,
-    justifyContent: "center",
-    alignItems: "center",
-    width: "100%",
-    alignSelf: "center",
-  },
-  gradientButtonStyle: {
-    justifyContent: "center",
-    alignItems: "center",
-    marginHorizontal: 0, // Override GradientButton's default margin
-  },
-  buttonContent: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    paddingTop: dynamicScale(2, true),
-    marginBottom: dynamicScale(-2, true),
-  },
-  buttonIcon: {
-    width: dynamicScale(18, false, 0.5),
-    height: dynamicScale(18, false, 0.5),
-    marginRight: dynamicScale(6, false, 0.5),
-  },
-  buttonText: {
-    fontSize: dynamicScale(16, false, 0.5),
-    fontWeight: "300",
-    fontStyle: "italic",
-    color: GlobalStyles.colors.textColor,
-  },
   modalOverlay: {
     flex: 1,
     backgroundColor: "rgba(0, 0, 0, 0.5)",

--- a/TravelCostApp/components/Settings/GetLocalPriceButton.tsx
+++ b/TravelCostApp/components/Settings/GetLocalPriceButton.tsx
@@ -194,15 +194,6 @@ const styles = StyleSheet.create({
     minHeight: dynamicScale(50, true),
     ...GlobalStyles.strongShadow,
   },
-  modalButtons: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  submitButton: {
-    marginLeft: dynamicScale(16, false, 0.5),
-    flex: 1,
-  },
 });
 
 export default GetLocalPriceButton;

--- a/TravelCostApp/components/UI/ActionRow.tsx
+++ b/TravelCostApp/components/UI/ActionRow.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import {
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type ImageSourcePropType,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import * as Haptics from "expo-haptics";
+import PropTypes from "prop-types";
+
+import { GlobalStyles } from "../../constants/styles";
+import { ActionRowTokens } from "../../styles/action-row-tokens";
+import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
+import { dynamicScale } from "../../util/scalingUtil";
+
+export type ActionRowTier = "primary" | "secondary" | "gradient";
+
+export type ActionRowProps = {
+  testID?: string;
+  label: string;
+  hint?: string;
+  icon?: React.ComponentProps<typeof Ionicons>["name"];
+  imageIconSource?: ImageSourcePropType;
+  tier?: ActionRowTier;
+  onPress: () => void;
+  showChevron?: boolean;
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+function ActionRow({
+  testID,
+  label,
+  hint,
+  icon,
+  imageIconSource,
+  tier = "secondary",
+  onPress,
+  showChevron = true,
+  disabled = false,
+  style,
+}: ActionRowProps) {
+  const isPrimary = tier === "primary";
+  const isGradient = tier === "gradient";
+  const showAccentStrip = isPrimary || isGradient;
+
+  const onPressHandler = () => {
+    if (disabled) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onPress();
+  };
+
+  return (
+    <Pressable
+      testID={testID}
+      onPress={onPressHandler}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.row,
+        hint ? styles.rowWithHint : null,
+        shadowRegressionStyles.actionRowCard,
+        isPrimary && styles.rowPrimaryTint,
+        disabled && styles.disabled,
+        pressed && !disabled && ActionRowTokens.press,
+        style,
+      ]}
+    >
+      {showAccentStrip && (
+        <LinearGradient
+          colors={
+            isGradient
+              ? ActionRowTokens.gradients.promotional
+              : ActionRowTokens.gradients.primary
+          }
+          style={styles.accentStrip}
+        />
+      )}
+      <View style={[styles.iconSlot, hint ? styles.iconSlotWithHint : null]}>
+        {imageIconSource ? (
+          <Image source={imageIconSource} style={styles.imageIcon} />
+        ) : icon ? (
+          <Ionicons
+            name={icon}
+            size={ActionRowTokens.iconSize}
+            color={GlobalStyles.colors.primary500}
+          />
+        ) : null}
+      </View>
+      <View style={styles.textCol}>
+        <Text style={[styles.label, isPrimary && styles.labelPrimary]}>
+          {label}
+        </Text>
+        {hint ? <Text style={styles.hint}>{hint}</Text> : null}
+      </View>
+      {showChevron ? <Text style={styles.chevron}>›</Text> : null}
+    </Pressable>
+  );
+}
+
+export default ActionRow;
+
+ActionRow.propTypes = {
+  testID: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  hint: PropTypes.string,
+  icon: PropTypes.string,
+  imageIconSource: PropTypes.number,
+  tier: PropTypes.oneOf(["primary", "secondary", "gradient"]),
+  onPress: PropTypes.func.isRequired,
+  showChevron: PropTypes.bool,
+  disabled: PropTypes.bool,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "stretch",
+    borderRadius: ActionRowTokens.borderRadius,
+    padding: ActionRowTokens.padding,
+    marginBottom: ActionRowTokens.marginBottom,
+    overflow: "hidden",
+  },
+  rowWithHint: {
+    alignItems: "flex-start",
+  },
+  rowPrimaryTint: {
+    backgroundColor: ActionRowTokens.primaryTint,
+  },
+  accentStrip: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: ActionRowTokens.accentStripWidth,
+  },
+  iconSlot: {
+    marginRight: dynamicScale(12),
+  },
+  iconSlotWithHint: {
+    marginTop: dynamicScale(1, true),
+  },
+  imageIcon: {
+    width: ActionRowTokens.imageIconSize,
+    height: ActionRowTokens.imageIconSize,
+    borderRadius: 4,
+  },
+  textCol: {
+    flex: 1,
+  },
+  label: {
+    fontSize: ActionRowTokens.labelFontSize,
+    fontWeight: "600",
+    color: GlobalStyles.colors.textColor,
+  },
+  labelPrimary: {
+    color: GlobalStyles.colors.primary700,
+  },
+  hint: {
+    fontSize: ActionRowTokens.hintFontSize,
+    color: GlobalStyles.colors.textHidden,
+    marginTop: dynamicScale(2, true),
+    flexShrink: 1,
+  },
+  chevron: {
+    fontSize: ActionRowTokens.chevronFontSize,
+    color: GlobalStyles.colors.gray600,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});

--- a/TravelCostApp/components/UI/ActionRow.tsx
+++ b/TravelCostApp/components/UI/ActionRow.tsx
@@ -61,6 +61,9 @@ function ActionRow({
       testID={testID}
       onPress={onPressHandler}
       disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={hint}
       style={({ pressed }) => [
         styles.row,
         hint ? styles.rowWithHint : null,

--- a/TravelCostApp/components/UI/ActionRowStack.tsx
+++ b/TravelCostApp/components/UI/ActionRowStack.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import PropTypes from "prop-types";
+
+import ActionRow, { type ActionRowTier } from "./ActionRow";
+import { ActionRowTokens } from "../../styles/action-row-tokens";
+
+export type ActionRowAction = {
+  testID?: string;
+  label: string;
+  hint?: string;
+  icon?: React.ComponentProps<
+    typeof import("@expo/vector-icons").Ionicons
+  >["name"];
+  tier?: ActionRowTier;
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+type ActionRowStackProps = {
+  actions: ActionRowAction[];
+  showChevron?: boolean;
+};
+
+/** Vertical stack of ActionRows — modal footers, form actions, settings lists. */
+function ActionRowStack({ actions, showChevron = false }: ActionRowStackProps) {
+  return (
+    <View testID="action-row-stack" style={styles.stack}>
+      {actions.map((action) => (
+        <ActionRow
+          key={action.testID ?? action.label}
+          testID={action.testID}
+          label={action.label}
+          hint={action.hint}
+          icon={action.icon}
+          tier={action.tier ?? "secondary"}
+          onPress={action.onPress}
+          showChevron={showChevron}
+          disabled={action.disabled}
+          style={styles.row}
+        />
+      ))}
+    </View>
+  );
+}
+
+export default ActionRowStack;
+
+ActionRowStack.propTypes = {
+  actions: PropTypes.arrayOf(
+    PropTypes.shape({
+      testID: PropTypes.string,
+      label: PropTypes.string.isRequired,
+      hint: PropTypes.string,
+      icon: PropTypes.string,
+      tier: PropTypes.oneOf(["primary", "secondary", "gradient"]),
+      onPress: PropTypes.func.isRequired,
+      disabled: PropTypes.bool,
+    })
+  ).isRequired,
+  showChevron: PropTypes.bool,
+};
+
+const styles = StyleSheet.create({
+  stack: {
+    width: "100%",
+    gap: ActionRowTokens.marginBottom,
+  },
+  row: {
+    marginBottom: undefined,
+  },
+});

--- a/TravelCostApp/components/UI/ActionRowStack.tsx
+++ b/TravelCostApp/components/UI/ActionRowStack.tsx
@@ -26,9 +26,9 @@ type ActionRowStackProps = {
 function ActionRowStack({ actions, showChevron = false }: ActionRowStackProps) {
   return (
     <View testID="action-row-stack" style={styles.stack}>
-      {actions.map((action) => (
+      {actions.map((action, index) => (
         <ActionRow
-          key={action.testID ?? action.label}
+          key={action.testID ?? `${action.label}-${index}`}
           testID={action.testID}
           label={action.label}
           hint={action.hint}

--- a/TravelCostApp/components/UI/AddExpensesHereButton.tsx
+++ b/TravelCostApp/components/UI/AddExpensesHereButton.tsx
@@ -1,35 +1,64 @@
-import { StyleSheet, View } from "react-native";
 import React from "react";
 
 import { i18n } from "../../i18n/i18n";
 
-import FlatButton from "./FlatButton";
+import ActionRow from "./ActionRow";
 import { useNavigation } from "@react-navigation/native";
 import { DateTime } from "luxon";
 import PropTypes from "prop-types";
 import { isIsoDate } from "../../util/date";
+import type { ActionRowAction } from "./ActionRowStack";
+
+type NavigateFn = (
+  screen: string,
+  params: Record<string, string>
+) => void;
+
+export function buildAddExpenseHereAction(
+  dayISO: string | null | undefined,
+  navigate: NavigateFn
+): ActionRowAction | null {
+  if (!isIsoDate(dayISO)) {
+    return null;
+  }
+
+  return {
+    testID: "add-expense-here",
+    tier: "primary",
+    label: i18n.t("addExp"),
+    hint: i18n.t("addExpHereHint", {
+      date: DateTime.fromISO(dayISO).toLocaleString(),
+    }),
+    icon: "add-circle-outline",
+    onPress: () => {
+      navigate("ManageExpense", {
+        pickedCat: "undefined",
+        dateISO: dayISO,
+      });
+    },
+  };
+}
 
 const AddExpenseHereButton = ({ dayISO }) => {
   const navigation = useNavigation();
-  if (!isIsoDate(dayISO)) {
-    return <></>;
+  const action = buildAddExpenseHereAction(dayISO, (screen, params) =>
+    navigation.navigate(screen as never, params as never)
+  );
+
+  if (!action) {
+    return null;
   }
-  const formattedDayString = `${i18n.t("addExp")}: ${DateTime.fromISO(
-    dayISO
-  ).toLocaleString()}`;
+
   return (
-    <View>
-      <FlatButton
-        onPress={() => {
-          navigation.navigate("ManageExpense", {
-            pickedCat: "undefined",
-            dateISO: dayISO,
-          });
-        }}
-      >
-        {formattedDayString}
-      </FlatButton>
-    </View>
+    <ActionRow
+      testID={action.testID}
+      tier={action.tier}
+      label={action.label}
+      hint={action.hint}
+      icon={action.icon}
+      onPress={action.onPress}
+      showChevron={false}
+    />
   );
 };
 
@@ -38,5 +67,3 @@ export default AddExpenseHereButton;
 AddExpenseHereButton.propTypes = {
   dayISO: PropTypes.string,
 };
-
-const styles = StyleSheet.create({});

--- a/TravelCostApp/components/UI/Button.tsx
+++ b/TravelCostApp/components/UI/Button.tsx
@@ -1,72 +1,55 @@
-import { StyleSheet, Text, View, Pressable } from "react-native";
 import React from "react";
-import { GlobalStyles } from "../../constants/styles";
-import * as Haptics from "expo-haptics";
+import { type StyleProp, type ViewStyle } from "react-native";
+import PropTypes from "prop-types";
 
+import { actionRowLabelFromChildren } from "../../util/action-row-label";
+import ActionRow from "./ActionRow";
+
+/**
+ * @deprecated Use {@link ActionRow} directly instead.
+ * Kept as a compatibility shim for legacy call sites; do not add new usages.
+ */
 const Button = ({
   children,
   onPress,
   mode = "",
   style = {},
   buttonStyle = {},
+  hint,
+  icon,
+}: {
+  children: React.ReactNode;
+  onPress: () => void;
+  mode?: string;
+  style?: StyleProp<ViewStyle>;
+  buttonStyle?: StyleProp<ViewStyle>;
+  hint?: string;
+  icon?: React.ComponentProps<typeof ActionRow>["icon"];
 }) => {
-  const onPressHandler = () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    onPress();
-    return;
-  };
+  const label = actionRowLabelFromChildren(children);
+  const tier = mode === "flat" ? "secondary" : "primary";
+
   return (
-    <View style={style}>
-      <Pressable
-        onPress={onPressHandler}
-        style={({ pressed }) => [
-          styles.button,
-          buttonStyle,
-          pressed && GlobalStyles.pressedWithShadow,
-        ]}
-      >
-        <View style={[mode === "flat" && styles.flat]}>
-          <Text
-            style={[
-              GlobalStyles.buttonTextPrimary,
-              mode === "flat" && styles.flatText,
-            ]}
-          >
-            {children}
-          </Text>
-        </View>
-      </Pressable>
-    </View>
+    <ActionRow
+      tier={tier}
+      label={label}
+      hint={hint}
+      icon={icon}
+      onPress={onPress}
+      showChevron={false}
+      style={[style, buttonStyle]}
+    />
   );
 };
 
 export default Button;
 
-const styles = StyleSheet.create({
-  button: {
-    padding: 16,
-    backgroundColor: GlobalStyles.colors.primary500,
-    borderRadius: 16,
-    elevation: 3,
-    shadowColor: GlobalStyles.colors.textColor,
-    shadowRadius: 3,
-    shadowOffset: { width: 2, height: 2 },
-    shadowOpacity: 0.4,
-    overflow: "visible",
-  },
-  flat: {
-    // TODO: find another way android
-    // backgroundColor: "transparent",
-  },
-  flatText: {
-    color: GlobalStyles.colors.primary200,
-  },
-  pressed: {
-    transform: [{ scale: 0.9 }],
-    opacity: 0.75,
-    backgroundColor: GlobalStyles.colors.primary100,
-    borderRadius: 16,
-    shadowColor: GlobalStyles.colors.backgroundColor,
-    shadowRadius: 0,
-  },
-});
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  onPress: PropTypes.func.isRequired,
+  mode: PropTypes.string,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  buttonStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  hint: PropTypes.string,
+  icon: PropTypes.string,
+};

--- a/TravelCostApp/components/UI/ErrorOverlay.tsx
+++ b/TravelCostApp/components/UI/ErrorOverlay.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, Text, View } from "react-native";
 import React from "react";
 import { GlobalStyles } from "../../constants/styles";
-import Button from "./Button";
+import ActionRow from "./ActionRow";
 import PropTypes from "prop-types";
 
 import { i18n } from "../../i18n/i18n";
@@ -11,7 +11,12 @@ const ErrorOverlay = ({ message, onConfirm }) => {
     <View style={styles.container}>
       <Text style={[styles.text, styles.title]}>{i18n.t("anErrorOccurred")}</Text>
       <Text style={styles.text}>{message}</Text>
-      <Button onPress={onConfirm}>{i18n.t("okay")}</Button>
+      <ActionRow
+        tier="primary"
+        label={i18n.t("okay")}
+        onPress={onConfirm}
+        showChevron={false}
+      />
     </View>
   );
 };

--- a/TravelCostApp/components/UI/FlatButton.tsx
+++ b/TravelCostApp/components/UI/FlatButton.tsx
@@ -3,6 +3,10 @@ import React, { Pressable, StyleSheet, Text, View } from "react-native";
 import { GlobalStyles } from "../../constants/styles";
 import PropTypes from "prop-types";
 
+/**
+ * @deprecated Use {@link ActionRow} with `tier="secondary"` instead.
+ * Kept as a deprecated shim; do not add new usages.
+ */
 function FlatButton({ children, onPress, textStyle }) {
   return (
     <Pressable
@@ -17,12 +21,6 @@ function FlatButton({ children, onPress, textStyle }) {
 }
 
 export default FlatButton;
-FlatButton.propTypes = {
-  children: PropTypes.string.isRequired,
-  onPress: PropTypes.func.isRequired,
-  textStyle: PropTypes.object,
-};
-
 FlatButton.propTypes = {
   children: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,

--- a/TravelCostApp/components/UI/GradientButton.tsx
+++ b/TravelCostApp/components/UI/GradientButton.tsx
@@ -7,6 +7,10 @@ import { LinearGradient } from "expo-linear-gradient";
 import PropTypes from "prop-types";
 import { dynamicScale } from "../../util/scalingUtil";
 
+/**
+ * @deprecated Use {@link ActionRow} with `tier="primary"` or `tier="gradient"` instead.
+ * Kept for shadow-regression tests only; do not add new usages.
+ */
 const GradientButton = ({
   children,
   onPress,

--- a/TravelCostApp/components/UI/LinkButton.tsx
+++ b/TravelCostApp/components/UI/LinkButton.tsx
@@ -1,6 +1,6 @@
 import { Linking } from "react-native";
 import React from "react";
-import GradientButton from "./GradientButton";
+import ActionRow from "./ActionRow";
 import PropTypes from "prop-types";
 import safeLogError from "../../util/error";
 import { trackEvent } from "../../util/vexo-tracking";
@@ -21,9 +21,13 @@ const LinkingButton = ({ children, URL, style = {} }) => {
     });
   };
   return (
-    <GradientButton onPress={handleClick} style={style}>
-      {children}
-    </GradientButton>
+    <ActionRow
+      tier="secondary"
+      label={typeof children === "string" ? children : String(children)}
+      icon="open-outline"
+      onPress={handleClick}
+      style={style}
+    />
   );
 };
 

--- a/TravelCostApp/components/UI/NamingBanner.tsx
+++ b/TravelCostApp/components/UI/NamingBanner.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import PropTypes from "prop-types";
 
-import GradientButton from "./GradientButton";
+import ActionRow from "./ActionRow";
+import ActionRowStack from "./ActionRowStack";
 import { GlobalStyles } from "../../constants/styles";
 import { dynamicScale } from "../../util/scalingUtil";
 import { i18n } from "../../i18n/i18n";
@@ -16,27 +17,24 @@ function NamingBanner({ onNameIt, onLater }: NamingBannerProps) {
   return (
     <View testID="naming-banner" style={styles.container}>
       <Text style={styles.message}>{i18n.t("namingBannerText")}</Text>
-      <View style={styles.actions}>
-        <Pressable
-          testID="naming-banner-later"
-          onPress={onLater}
-          style={({ pressed }) => [
-            styles.laterButton,
-            pressed && GlobalStyles.pressed,
-          ]}
-        >
-          <Text style={styles.laterText}>{i18n.t("later")}</Text>
-        </Pressable>
-        <View testID="naming-banner-name-it" style={styles.nameItWrap}>
-          <GradientButton
-            onPress={onNameIt}
-            style={styles.nameItButton}
-            buttonStyle={styles.nameItButtonInner}
-          >
-            {i18n.t("namingBannerNameIt")}
-          </GradientButton>
-        </View>
-      </View>
+      <ActionRowStack
+        showChevron={false}
+        actions={[
+          {
+            testID: "naming-banner-name-it",
+            tier: "primary",
+            label: i18n.t("namingBannerNameIt"),
+            icon: "create-outline",
+            onPress: onNameIt,
+          },
+          {
+            testID: "naming-banner-later",
+            tier: "secondary",
+            label: i18n.t("later"),
+            onPress: onLater,
+          },
+        ]}
+      />
     </View>
   );
 }
@@ -62,29 +60,5 @@ const styles = StyleSheet.create({
     fontSize: dynamicScale(14, false, 0.5),
     textAlign: "center",
     marginBottom: dynamicScale(8, true),
-  },
-  actions: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  laterButton: {
-    padding: dynamicScale(12),
-  },
-  laterText: {
-    color: GlobalStyles.colors.gray700,
-    fontSize: dynamicScale(14, false, 0.5),
-    textAlign: "center",
-  },
-  nameItWrap: {
-    flex: 1,
-    marginLeft: dynamicScale(8),
-  },
-  nameItButton: {
-    alignSelf: "stretch",
-  },
-  nameItButtonInner: {
-    paddingVertical: dynamicScale(10, true),
-    paddingHorizontal: dynamicScale(12),
   },
 });

--- a/TravelCostApp/components/UI/SplashScreenOverlay.tsx
+++ b/TravelCostApp/components/UI/SplashScreenOverlay.tsx
@@ -8,9 +8,8 @@ import Animated, {
   ZoomOutDown,
 } from "react-native-reanimated";
 import { SPLASH_SCREEN_DELAY } from "../../confAppConstants";
-import FlatButton from "./FlatButton";
 import { asyncStoreSafeClear } from "../../store/async-storage";
-import IconButton from "./IconButton";
+import ActionRow from "./ActionRow";
 
 const loadingColor = GlobalStyles.colors.backgroundColor;
 const delay = SPLASH_SCREEN_DELAY;
@@ -41,28 +40,17 @@ const SplashScreenOverlay = () => {
           >
             <ActivityIndicator size={"large"} color={loadingColor} />
           </Animated.View>
-          <Animated.View
-            entering={ZoomInDown.duration(1200).delay(3500)}
-            style={{ flexDirection: "row" }}
-          >
-            <IconButton
+          <Animated.View entering={ZoomInDown.duration(1200).delay(3500)}>
+            <ActionRow
+              tier="secondary"
+              label="Login / Signup"
+              icon="refresh-outline"
               onPress={async () => {
                 await asyncStoreSafeClear();
                 await reloadApp();
               }}
-              icon={"chevron-back-outline"}
-              size={24}
-              color={"black"}
-            ></IconButton>
-            <FlatButton
-              textStyle={{ color: "black" }}
-              onPress={async () => {
-                await asyncStoreSafeClear();
-                await reloadApp();
-              }}
-            >
-              Login / Signup
-            </FlatButton>
+              style={{ marginHorizontal: 24 }}
+            />
           </Animated.View>
         </ImageBackground>
       </Animated.View>

--- a/TravelCostApp/components/UI/TrafficLightInfoModal.tsx
+++ b/TravelCostApp/components/UI/TrafficLightInfoModal.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet } from "react-native";
 import Modal from "react-native-modal";
 import { i18n } from "../../i18n/i18n";
 import { GlobalStyles } from "../../constants/styles";
-import FlatButton from "./FlatButton";
+import ActionRow from "./ActionRow";
 import { dynamicScale } from "../../util/scalingUtil";
 import PropTypes from "prop-types";
 
@@ -25,7 +25,15 @@ const TrafficLightInfoModal = ({ isVisible, onClose }) => {
         <Text style={styles.infoContentText}>
           {i18n.t("trafficLightInfoText")}
         </Text>
-        <FlatButton onPress={onClose}>{i18n.t("confirm")}</FlatButton>
+        <ActionRow
+          tier="primary"
+          label={i18n.t("confirm")}
+          icon="checkmark-outline"
+          showChevron={false}
+          compact
+          onPress={onClose}
+          style={styles.confirmButton}
+        />
       </View>
     </Modal>
   );
@@ -65,5 +73,8 @@ const styles = StyleSheet.create({
     marginBottom: dynamicScale(24, true),
     textAlign: "center",
     lineHeight: dynamicScale(20, false, 0.5),
+  },
+  confirmButton: {
+    alignSelf: "stretch",
   },
 });

--- a/TravelCostApp/constants/styles.ts
+++ b/TravelCostApp/constants/styles.ts
@@ -161,6 +161,12 @@ export const GlobalStyles = {
     transform: [{ scale: 0.975 }],
     opacity: 0.975,
   },
+  /** Action rows — same subtle scale as trip list (75% less than legacy 0.9). */
+  pressedActionRow: {
+    elevation: 0,
+    transform: [{ scale: 0.975 }],
+    opacity: 0.975,
+  },
   countryFlagStyle: {
     width: dynamicScale(30, false, 0.5),
     height: dynamicScale(25, false, 0.5),

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -100,6 +100,7 @@ const en = {
   // Modal Titles
   editExp: "Edit Expense",
   addExp: "Add Expense",
+  addExpHereHint: "On this day: %{date}",
   whoPaid: "Who paid?",
   howShared: "How are the costs shared?",
   whoShared: "Who is the cost shared between?",
@@ -154,6 +155,7 @@ const en = {
   resetAppIntroductionLabel: "Reset App Introduction",
   visitFoodForNomadsLabel: "Visit Food For Nomads",
   supportFeedbackLabel: "Feedback?",
+  supportFeedbackHint: "Tell us what to improve",
 
   // Feedback Modal
   feedbackTitle: "Send Feedback",
@@ -310,6 +312,11 @@ const en = {
   gptSearchingWeb: "🔍 Searching current local prices and seasonal data...",
   gptAnalyzingData: "🧠 Analyzing market trends and pricing insights...",
   getLocalPriceTitle: "Local Price",
+  getLocalPriceHint: "Check prices with AI on the road",
+  getLocalPriceExpenseHint:
+    'Get local price for "%{product}" in %{country}',
+  getLocalPriceExpenseDealHint:
+    'Is %{price} %{currency} a good deal for "%{product}" in %{country}?',
   gettingLocalPrice: "Getting local price information...",
   day: "Day",
   week: "Week",
@@ -581,6 +588,7 @@ const en = {
   trips: "Budgets",
   trip: "Budget",
   summary: "Summary",
+  summaryHint: "Quick overview for one or more budgets",
   totalCosts: "Total Costs",
   averageCostPerDay: "Average Cost Per Day",
   averageCostPerMonth: "Average Cost Per Month",
@@ -710,6 +718,7 @@ const de = {
   // Modal Titles
   editExp: "Ausgabe bearbeiten",
   addExp: "Ausgabe hinzufügen",
+  addExpHereHint: "An diesem Tag: %{date}",
   whoPaid: "Wer hat bezahlt?",
   howShared: "Wie wurden die Kosten geteilt?",
   whoShared: "Zwischen wem wurden die Kosten geteilt?",
@@ -767,6 +776,7 @@ const de = {
   resetAppIntroductionLabel: "App Einführung wiederholen",
   visitFoodForNomadsLabel: "Food For Nomads besuchen",
   supportFeedbackLabel: "Feedback?",
+  supportFeedbackHint: "Sag uns, was wir verbessern können",
 
   // Feedback Modal
   feedbackTitle: "Feedback Senden",
@@ -936,6 +946,11 @@ const de = {
     "🔍 Aktuelle lokale Preise und saisonale Daten werden gesucht...",
   gptAnalyzingData: "🧠 Markttrends und Preisanalysen werden ausgewertet...",
   getLocalPriceTitle: "Lokaler Preis",
+  getLocalPriceHint: "Preise mit KI unterwegs prüfen",
+  getLocalPriceExpenseHint:
+    'Lokalen Preis für „%{product}“ in %{country} ermitteln',
+  getLocalPriceExpenseDealHint:
+    'Ist %{price} %{currency} ein gutes Angebot für „%{product}“ in %{country}?',
   gettingLocalPrice: "Lokale Preisinformationen werden abgerufen...",
   day: "Tag",
   week: "Woche",
@@ -1227,6 +1242,7 @@ const de = {
   trips: "Budgets",
   trip: "Budget",
   summary: "Zusammenfassung",
+  summaryHint: "Schneller Überblick für ein oder mehrere Budgets",
   totalCosts: "Gesamtkosten",
   averageCostPerDay: "Durchschnittskosten pro Tag",
   averageCostPerMonth: "Durchschnittskosten pro Monat",
@@ -1355,6 +1371,7 @@ const fr = {
   // Modal Titles
   editExp: "Modifier la dépense",
   addExp: "Ajouter une dépense",
+  addExpHereHint: "Ce jour-là : %{date}",
   whoPaid: "Qui a payé ?",
   howShared: "Comment les coûts sont-ils partagés ?",
   whoShared: "Avec qui les coûts sont-ils partagés ?",
@@ -1411,6 +1428,7 @@ const fr = {
   resetAppIntroductionLabel: "Réinitialiser l'introduction de l'application",
   visitFoodForNomadsLabel: "Visitez Food For Nomads",
   supportFeedbackLabel: "Commentaires?",
+  supportFeedbackHint: "Dites-nous quoi améliorer",
 
   // Feedback Modal
   feedbackTitle: "Envoyer des Commentaires",
@@ -1581,6 +1599,11 @@ const fr = {
   gptAnalyzingData:
     "🧠 Analyse des tendances du marché et des insights de prix...",
   getLocalPriceTitle: "Prix Local",
+  getLocalPriceHint: "Vérifiez les prix avec l'IA en voyage",
+  getLocalPriceExpenseHint:
+    'Obtenir le prix local pour « %{product} » en %{country}',
+  getLocalPriceExpenseDealHint:
+    'Est-ce que %{price} %{currency} est une bonne affaire pour « %{product} » en %{country} ?',
   gettingLocalPrice: "Obtention des informations sur les prix locaux...",
   day: "Jour",
   week: "Semaine",
@@ -1870,6 +1893,7 @@ const fr = {
   trips: "Budgets",
   trip: "Budget",
   summary: "Résumé",
+  summaryHint: "Aperçu rapide pour un ou plusieurs budgets",
   totalCosts: "Coûts totaux",
   averageCostPerDay: "Coût moyen par jour",
   averageCostPerMonth: "Coût moyen par mois",
@@ -1998,6 +2022,7 @@ const ru = {
   // Modal Titles
   editExp: "Изменить статью расходов",
   addExp: "Добавить статью расходов",
+  addExpHereHint: "В этот день: %{date}",
   whoPaid: "Кто заплатил?",
   howShared: "Как распределены расходы?",
   whoShared: "Кто участвует в распределении расходов?",
@@ -2053,6 +2078,7 @@ const ru = {
   resetAppIntroductionLabel: "Сбросить введение в приложение",
   visitFoodForNomadsLabel: "Посетить Food For Nomads",
   supportFeedbackLabel: "Отзыв?",
+  supportFeedbackHint: "Расскажите, что улучшить",
 
   // Feedback Modal
   feedbackTitle: "Отправить Отзыв",
@@ -2213,6 +2239,11 @@ const ru = {
   gptSearchingWeb: "🔍 Поиск актуальных местных цен и сезонных данных...",
   gptAnalyzingData: "🧠 Анализ рыночных трендов и ценовых инсайтов...",
   getLocalPriceTitle: "Местная Цена",
+  getLocalPriceHint: "Проверяйте цены с ИИ в пути",
+  getLocalPriceExpenseHint:
+    'Узнать местную цену для «%{product}» в %{country}',
+  getLocalPriceExpenseDealHint:
+    'Хорошая ли сделка — %{price} %{currency} за «%{product}» в %{country}?',
   gettingLocalPrice: "Получение информации о местных ценах...",
   day: "День",
   week: "Неделя",
@@ -2511,6 +2542,7 @@ const ru = {
   trips: "Бюджеты",
   trip: "Бюджет",
   summary: "Сводка",
+  summaryHint: "Быстрый обзор одного или нескольких бюджетов",
   totalCosts: "Общие расходы",
   averageCostPerDay: "Средние расходы в день",
   averageCostPerMonth: "Средние расходы в месяц",

--- a/TravelCostApp/screens/CategoryPickScreen.tsx
+++ b/TravelCostApp/screens/CategoryPickScreen.tsx
@@ -9,7 +9,7 @@ import {
 import * as Haptics from "expo-haptics";
 
 import React, { useState } from "react";
-import FlatButton from "../components/UI/FlatButton";
+import ActionRow from "../components/UI/ActionRow";
 import { GlobalStyles } from "../constants/styles";
 
 import { i18n } from "../i18n/i18n";
@@ -17,7 +17,6 @@ import { fetchCategories } from "../util/http";
 import { useContext } from "react";
 import { TripContext } from "../store/trip-context";
 import { Ionicons } from "@expo/vector-icons";
-import GradientButton from "../components/UI/GradientButton";
 import { useFocusEffect } from "@react-navigation/native";
 import { Alert } from "react-native";
 import { ActivityIndicator } from "react-native-paper";
@@ -221,31 +220,31 @@ const CategoryPickScreen = ({ route, navigation }: CategoryPickScreenProps) => {
         ListFooterComponent={
           <View>
             <View style={styles.buttonContainer}>
-              <FlatButton
+              <ActionRow
+                testID="category-pick-continue"
+                tier="primary"
+                label={i18n.t("continue")}
+                icon="arrow-forward-outline"
+                onPress={() => {
+                  if (expenseId) {
+                    updateTempCategory("undefined");
+                    navigation.goBack();
+                  } else {
+                    navigation.navigate("ManageExpense", {
+                      pickedCat: "undefined",
+                    });
+                  }
+                }}
+              />
+              <ActionRow
+                testID="category-pick-back"
+                tier="secondary"
+                label={i18n.t("cancel")}
+                icon="arrow-back-outline"
                 onPress={() => {
                   navigation.goBack();
                 }}
-                textStyle={{}}
-              >
-                {i18n.t("cancel")}
-              </FlatButton>
-              {true && (
-                <GradientButton
-                  buttonStyle={styles.continueButtonStyle}
-                  onPress={() => {
-                    if (expenseId) {
-                      updateTempCategory("undefined");
-                      navigation.goBack();
-                    } else {
-                      navigation.navigate("ManageExpense", {
-                        pickedCat: "undefined",
-                      });
-                    }
-                  }}
-                >
-                  {i18n.t("continue")}
-                </GradientButton>
-              )}
+              />
             </View>
           </View>
         }
@@ -303,9 +302,7 @@ const styles = StyleSheet.create({
   buttonContainer: {
     flex: 1,
     paddingVertical: "4%",
-    flexDirection: "row",
-    justifyContent: "space-around",
-    alignItems: "center",
+    paddingHorizontal: "2%",
   },
   buttonStyle: {
     backgroundColor: GlobalStyles.colors.gray500,
@@ -327,9 +324,5 @@ const styles = StyleSheet.create({
     color: GlobalStyles.colors.textColor,
     fontWeight: "200",
     fontStyle: "italic",
-  },
-  continueButtonStyle: {
-    paddingVertical: "12%",
-    paddingHorizontal: "12%",
   },
 });

--- a/TravelCostApp/screens/ChatGPTDealScreen.tsx
+++ b/TravelCostApp/screens/ChatGPTDealScreen.tsx
@@ -11,7 +11,7 @@ import Animated, { FadeInUp } from "react-native-reanimated";
 import Markdown, { MarkdownProps } from "react-native-markdown-display";
 import React, { useContext, useEffect } from "react";
 import PropTypes from "prop-types";
-import FlatButton from "../components/UI/FlatButton";
+import ActionRow from "../components/UI/ActionRow";
 import { i18n } from "../i18n/i18n";
 
 import {
@@ -341,24 +341,13 @@ const GPTDealScreen = ({ route, navigation }) => {
           </ScrollView>
         </View>
         <View style={styles.buttonContainer}>
-          <FlatButton
+          <ActionRow
+            testID="gpt-deal-back"
+            tier="secondary"
+            label={i18n.t("back")}
+            icon="arrow-back-outline"
             onPress={() => navigation.pop()}
-            textStyle={{ fontSize: 16 }}
-          >
-            {i18n.t("back")}
-          </FlatButton>
-          {/* {!isFetching && (
-            <GradientButton
-              style={[
-                Platform.OS == "ios" && { paddingHorizontal: 20 },
-                { elevation: 0 },
-              ]}
-              onPress={handleRegenerate}
-              buttonStyle={{ padding: 8, paddingHorizontal: 12 }}
-            >
-              Regenerate
-            </GradientButton>
-          )} */}
+          />
         </View>
         {/* <BlurPremium canBack /> */}
       </View>
@@ -430,10 +419,9 @@ const styles = StyleSheet.create({
   },
   buttonContainer: {
     flex: 0.5,
-    flexDirection: "row",
-    justifyContent: "space-around",
+    justifyContent: "center",
     backgroundColor: GlobalStyles.colors.backgroundColor,
-    alignItems: "center",
+    paddingHorizontal: dynamicScale(4, false, 0.5),
   },
   chatContainer: {
     // padding: dynamicScale(4, false, 0.5),

--- a/TravelCostApp/screens/FilteredExpenses.tsx
+++ b/TravelCostApp/screens/FilteredExpenses.tsx
@@ -8,9 +8,9 @@ import { GlobalStyles } from "../constants/styles";
 import PropTypes from "prop-types";
 import BackButton from "../components/UI/BackButton";
 import BlurPremium from "../components/Premium/BlurPremium";
-import FlatButton from "../components/UI/FlatButton";
+import ActionRowStack from "../components/UI/ActionRowStack";
+import { buildAddExpenseHereAction } from "../components/UI/AddExpensesHereButton";
 import { useNavigation } from "@react-navigation/native";
-import AddExpenseHereButton from "../components/UI/AddExpensesHereButton";
 import { getEarliestDate } from "../util/date";
 import { ExpenseData } from "../util/expense";
 import {
@@ -34,6 +34,9 @@ const FilteredExpenses = ({ route, expensesAsArg, dayStringAsArg }) => {
   const navigation = useNavigation();
   const earliestDate = getEarliestDate(
     expenses.map((exp: ExpenseData) => expenseDateToIsoString(exp.date))
+  );
+  const addExpenseAction = buildAddExpenseHereAction(earliestDate, (screen, params) =>
+    navigation.navigate(screen as never, params as never)
   );
   // ||new Date(dayString).toISOString();
 
@@ -67,11 +70,35 @@ const FilteredExpenses = ({ route, expensesAsArg, dayStringAsArg }) => {
       />
       {/* <BlurPremium canBack /> */}
       {!withArgs && (
-        <View style={{ flexDirection: "row" }}>
-          <FlatButton onPress={() => navigation.pop()}>
-            {i18n.t("back")}
-          </FlatButton>
-          <AddExpenseHereButton dayISO={earliestDate} />
+        <View style={styles.footerActions}>
+          {addExpenseAction ? (
+            <ActionRowStack
+              showChevron={false}
+              actions={[
+                addExpenseAction,
+                {
+                  testID: "filtered-expenses-back",
+                  tier: "secondary",
+                  label: i18n.t("back"),
+                  icon: "arrow-back-outline",
+                  onPress: () => navigation.pop(),
+                },
+              ]}
+            />
+          ) : (
+            <ActionRowStack
+              showChevron={false}
+              actions={[
+                {
+                  testID: "filtered-expenses-back",
+                  tier: "secondary",
+                  label: i18n.t("back"),
+                  icon: "arrow-back-outline",
+                  onPress: () => navigation.pop(),
+                },
+              ]}
+            />
+          )}
         </View>
       )}
     </View>
@@ -106,6 +133,10 @@ const styles = StyleSheet.create({
   titleContainer: {
     marginVertical: "4%",
     flexDirection: "row",
+  },
+  footerActions: {
+    paddingHorizontal: "2%",
+    paddingBottom: "2%",
   },
   shadow: {
     borderTopWidth: 1,

--- a/TravelCostApp/screens/FilteredPieCharts.tsx
+++ b/TravelCostApp/screens/FilteredPieCharts.tsx
@@ -11,10 +11,10 @@ import ExpenseCategories from "../components/ExpensesOutput/ExpenseStatistics/Ex
 import ExpenseTravellers from "../components/ExpensesOutput/ExpenseStatistics/ExpenseTravellers";
 import ExpenseCountries from "../components/ExpensesOutput/ExpenseStatistics/ExpenseCountries";
 import ExpenseCurrencies from "../components/ExpensesOutput/ExpenseStatistics/ExpenseCurrencies";
-import FlatButton from "../components/UI/FlatButton";
+import ActionRowStack from "../components/UI/ActionRowStack";
+import { buildAddExpenseHereAction } from "../components/UI/AddExpensesHereButton";
 import FilteredExpenses from "./FilteredExpenses";
 import BackButton from "../components/UI/BackButton";
-import AddExpenseHereButton from "../components/UI/AddExpensesHereButton";
 import { ExpenseData } from "../util/expense";
 import { getEarliestDate } from "../util/date";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
@@ -109,6 +109,16 @@ const FilteredPieCharts = ({ navigation, route }) => {
       ),
     [expenses]
   );
+  const addExpenseAction = buildAddExpenseHereAction(earliestDate, (screen, params) =>
+    navigation.navigate(screen, params)
+  );
+  const backAction = {
+    testID: "filtered-pie-charts-back",
+    tier: "secondary" as const,
+    label: i18n.t("back"),
+    icon: "arrow-back-outline" as const,
+    onPress: () => navigation.pop(),
+  };
 
   return (
     <View style={styles.container}>
@@ -164,10 +174,14 @@ const FilteredPieCharts = ({ navigation, route }) => {
       <View style={styles.shadow}></View>
       {contents[toggleGraphEnum]}
       <View style={styles.footerContainer}>
-        <FlatButton onPress={() => navigation.pop()}>
-          {i18n.t("back")}
-        </FlatButton>
-        <AddExpenseHereButton dayISO={earliestDate}></AddExpenseHereButton>
+        <ActionRowStack
+          showChevron={false}
+          actions={
+            addExpenseAction
+              ? [addExpenseAction, backAction]
+              : [backAction]
+          }
+        />
       </View>
     </View>
   );
@@ -255,10 +269,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   footerContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
     paddingHorizontal: "5%",
+    paddingBottom: dynamicScale(8, true),
     backgroundColor: GlobalStyles.colors.backgroundColor,
   },
 });

--- a/TravelCostApp/screens/FinancialScreen.tsx
+++ b/TravelCostApp/screens/FinancialScreen.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react";
 
 import { i18n } from "../i18n/i18n";
 
-import GradientButton from "../components/UI/GradientButton";
+import ActionRow from "../components/UI/ActionRow";
 import { TripContext } from "../store/trip-context";
 import { useNavigation } from "@react-navigation/native";
 import { UserContext } from "../store/user-context";
@@ -56,20 +56,19 @@ const FinancialScreen = () => {
 
       {/* <Ionicons name="wallet-outline" size={200} color="black" /> */}
 
-      <GradientButton
-        colors={GlobalStyles.gradientAccentButton}
-        darkText
-        onPress={async () => {
+      <ActionRow
+        style={styles.button}
+        tier="primary"
+        label={i18n.t("simplifySplitsLabel")}
+        icon="git-network-outline"
+        showChevron={false}
+        onPress={() => {
           trackEvent(VexoEvents.OPEN_SPLITS_SUMMARY_PRESSED, {
             tripId: tripCtx.tripid,
           });
           navigation.navigate("SplitSummary", { tripid: tripCtx.tripid });
         }}
-        buttonStyle={styles.button}
-        style={styles.button}
-      >
-        {i18n.t("simplifySplitsLabel")}
-      </GradientButton>
+      />
     </View>
   );
 };

--- a/TravelCostApp/screens/FinderScreen.tsx
+++ b/TravelCostApp/screens/FinderScreen.tsx
@@ -20,7 +20,7 @@ import { Toast } from "react-native-toast-message/lib/src/Toast";
 import FinderFilterRow from "../components/Finder/FinderFilterRow";
 import Autocomplete from "../components/UI/Autocomplete";
 import { finderFilterRowStyles } from "../styles/finder-filter-row-styles";
-import GradientButton from "../components/UI/GradientButton";
+import ActionRow from "../components/UI/ActionRow";
 import { GlobalStyles } from "../constants/styles";
 import {
   asyncStoreGetItem,
@@ -354,16 +354,21 @@ const FinderScreen = () => {
                   tripCtx.tripCurrency
                 )}{" "}
             </Text>
-            <GradientButton
-              onPress={() => findPressedHandler()}
+            <ActionRow
+              testID="finder-show-results"
               style={styles.findButton}
-            >
-              {foundResults
-                ? `${i18n.t("showXResults1")} ${numberOfResults} ${i18n.t(
-                    "showXResults2"
-                  )}`
-                : i18n.t("noResults")}
-            </GradientButton>
+              tier="primary"
+              icon="search-outline"
+              showChevron={false}
+              label={
+                foundResults
+                  ? `${i18n.t("showXResults1")} ${numberOfResults} ${i18n.t(
+                      "showXResults2"
+                    )}`
+                  : i18n.t("noResults")
+              }
+              onPress={findPressedHandler}
+            />
           </View>
         </ScrollView>
       </View>
@@ -429,8 +434,7 @@ const styles = StyleSheet.create({
     fontStyle: "italic",
   },
   findButton: {
-    marginHorizontal: dynamicScale(65),
-    borderRadius: 99,
+    alignSelf: "stretch",
   },
   autocompleteInFilterRow: {
     alignSelf: "stretch",

--- a/TravelCostApp/screens/JoinTrip.tsx
+++ b/TravelCostApp/screens/JoinTrip.tsx
@@ -32,8 +32,8 @@ import Input from "../components/Auth/Input";
 import { i18n } from "../i18n/i18n";
 import { ExpensesContext } from "../store/expenses-context";
 import React from "react";
-import FlatButton from "../components/UI/FlatButton";
-import Button from "../components/UI/Button";
+import ActionRow from "../components/UI/ActionRow";
+import ActionRowStack from "../components/UI/ActionRowStack";
 import PropTypes from "prop-types";
 import { ActivityIndicator } from "react-native-paper";
 
@@ -46,7 +46,6 @@ import {
 } from "../store/secure-storage";
 import { MMKV_KEYS, setMMKVObject } from "../store/mmkv";
 import safeLogError from "../util/error";
-import Animated, { FadeIn } from "react-native-reanimated";
 import {
   isConnectionFastEnough,
   isConnectionFastEnoughAsBool,
@@ -298,17 +297,16 @@ const JoinTrip = ({ navigation, route }) => {
             isInvalid={false}
           ></Input>
           {!isFetching && (
-            <Button
-              style={{ maxWidth: "100%", marginTop: "5%" }}
-              buttonStyle={{
-                backgroundColor: freshLink
-                  ? GlobalStyles.colors.primaryGrayed
-                  : GlobalStyles.colors.gray700,
-              }}
+            <ActionRow
+              testID="join-trip-update-link"
+              tier="secondary"
+              label={i18n.t("update")}
+              icon="refresh-outline"
               onPress={joinLinkHandler}
-            >
-              {i18n.t("update")}
-            </Button>
+              showChevron={false}
+              disabled={freshLink}
+              style={{ marginTop: "5%" }}
+            />
           )}
         </View>
       )}
@@ -334,20 +332,29 @@ const JoinTrip = ({ navigation, route }) => {
         {tripName}
       </Text>
       <View style={styles.buttonContainer}>
-        <FlatButton onPress={joinHandler.bind(this, false)}>
-          {i18n.t("cancel")}
-        </FlatButton>
-        {tripName?.length > 0 && !isFetching && (
-          <Animated.View entering={FadeIn}>
-            <Button
-              style={{ marginLeft: "10%" }}
-              buttonStyle={{ paddingHorizontal: "20%" }}
-              onPress={joinHandler.bind(this, true)}
-            >
-              {i18n.t("confirm2")}
-            </Button>
-          </Animated.View>
-        )}
+        <ActionRowStack
+          showChevron={false}
+          actions={[
+            ...(tripName?.length > 0 && !isFetching
+              ? [
+                  {
+                    testID: "join-trip-confirm",
+                    tier: "primary" as const,
+                    label: i18n.t("confirm2"),
+                    icon: "checkmark-circle-outline" as const,
+                    onPress: joinHandler.bind(this, true),
+                  },
+                ]
+              : []),
+            {
+              testID: "join-trip-cancel",
+              tier: "secondary" as const,
+              label: i18n.t("cancel"),
+              icon: "arrow-back-outline" as const,
+              onPress: joinHandler.bind(this, false),
+            },
+          ]}
+        />
       </View>
     </KeyboardAvoidingView>
   );
@@ -407,7 +414,7 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: "5%",
     marginTop: "5%",
-    flexDirection: "row",
+    width: "100%",
   },
   linkInputContainer: {
     flex: 1,

--- a/TravelCostApp/screens/ManageCategoryScreen.tsx
+++ b/TravelCostApp/screens/ManageCategoryScreen.tsx
@@ -22,7 +22,7 @@ import { TripContext } from "../store/trip-context";
 import { GlobalStyles } from "../constants/styles";
 import { fetchCategories, updateTrip } from "../util/http";
 import SelectCategoryIcon from "../components/UI/selectCategoryIcon";
-import GradientButton from "../components/UI/GradientButton";
+import ActionRow from "../components/UI/ActionRow";
 import BackgroundGradient from "../components/UI/BackgroundGradient";
 import { KeyboardAvoidingView } from "react-native";
 import { ActivityIndicator } from "react-native-paper";
@@ -37,7 +37,6 @@ import IconButton from "../components/UI/IconButton";
 import { NetworkContext } from "../store/network-context";
 import InfoButton from "../components/UI/InfoButton";
 import Modal from "react-native-modal";
-import FlatButton from "../components/UI/FlatButton";
 import BlurPremium from "../components/Premium/BlurPremium";
 import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "../store/mmkv";
 import safeLogError from "../util/error";
@@ -416,9 +415,12 @@ const ManageCategoryScreen = ({ navigation }) => {
       <View style={styles.infoModalContainer}>
         <Text style={styles.infoTitleText}>{infoTitleText}</Text>
         <Text style={styles.infoContentText}>{infoContentText}</Text>
-        <FlatButton onPress={setInfoIsVisible.bind(this, false)}>
-          {i18n.t("confirm")}
-        </FlatButton>
+        <ActionRow
+          tier="primary"
+          label={i18n.t("confirm")}
+          onPress={setInfoIsVisible.bind(this, false)}
+          showChevron={false}
+        />
       </View>
     </Modal>
   );
@@ -532,9 +534,7 @@ const ManageCategoryScreen = ({ navigation }) => {
               overflow: "visible",
             }}
           />
-          <View
-            style={{ flexDirection: "row", justifyContent: "space-evenly" }}
-          >
+          <View style={styles.footerActions}>
             <IconButton
               icon={"chevron-back-outline"}
               size={24}
@@ -544,9 +544,12 @@ const ManageCategoryScreen = ({ navigation }) => {
               }}
               color={GlobalStyles.colors.primaryGrayed}
             ></IconButton>
-            <GradientButton
-              colors={GlobalStyles.gradientAccentButton}
-              darkText
+            <ActionRow
+              testID="manage-category-reset"
+              tier="gradient"
+              accentColors={GlobalStyles.gradientAccentButton}
+              label={i18n.t("reset")}
+              icon="refresh-outline"
               onPress={() => {
                 alertYesNo(
                   i18n.t("reset"),
@@ -554,20 +557,19 @@ const ManageCategoryScreen = ({ navigation }) => {
                   handleResetCategoryList
                 );
               }}
-            >
-              {i18n.t("reset")}
-            </GradientButton>
-
+            />
             {touched && (
-              <GradientButton
+              <ActionRow
+                testID="manage-category-confirm"
+                tier="primary"
+                label={i18n.t("confirm")}
+                icon="checkmark-circle-outline"
                 onPress={() => {
                   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                   setTouched(false);
                   navigation.pop();
                 }}
-              >
-                {i18n.t("confirm")}
-              </GradientButton>
+              />
             )}
           </View>
         </KeyboardAvoidingView>
@@ -712,5 +714,9 @@ const styles = StyleSheet.create({
     fontSize: dynamicScale(16, false, 0.5),
     color: GlobalStyles.colors.textColor,
     textAlign: "center",
+  },
+  footerActions: {
+    paddingHorizontal: dynamicScale(8, false, 0.5),
+    paddingBottom: dynamicScale(8, true),
   },
 });

--- a/TravelCostApp/screens/ProfileScreen.tsx
+++ b/TravelCostApp/screens/ProfileScreen.tsx
@@ -1,5 +1,12 @@
 /* eslint-disable react/prop-types */
-import { useContext, useEffect, useRef, useState, useCallback, useMemo } from "react";
+import {
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+} from "react";
 import {
   Alert,
   FlatList,
@@ -39,12 +46,12 @@ import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "../store/mmkv";
 import { NetworkContext } from "../store/network-context";
 import { dynamicScale, constantScale } from "../util/scalingUtil";
 import GetLocalPriceButton from "../components/Settings/GetLocalPriceButton";
-import GradientButton from "../components/UI/GradientButton";
+import ActionRow from "../components/UI/ActionRow";
 import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
 import IconButton from "../components/UI/IconButton";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTripListLeave } from "../components/ProfileOutput/use-trip-list-leave";
+import { ProfileToolbarTokens } from "../styles/profile-toolbar-tokens";
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -108,7 +115,7 @@ async function storeToken() {
   }
 }
 
-const TOOLBAR_CONTENT_HEIGHT = dynamicScale(52, true);
+const TOOLBAR_CHROME_HEIGHT = ProfileToolbarTokens.chromeHeight;
 
 const ProfileScreen = ({ navigation }) => {
   const userCtx = useContext(UserContext);
@@ -117,14 +124,12 @@ const ProfileScreen = ({ navigation }) => {
   const uid = authCtx.uid;
   const netCtx = useContext(NetworkContext);
   const isConnected = netCtx.isConnected && netCtx.strongConnection;
-  const insets = useSafeAreaInsets();
 
   const [tripHistory, setTripHistory] = useState([]);
   const [isFetchingLogout, setIsFetchingLogout] = useState(false);
   const [isFeedbackModalVisible, setIsFeedbackModalVisible] = useState(false);
 
-  const scrollTopInset =
-    Math.max(insets.top, dynamicScale(8, true)) + TOOLBAR_CONTENT_HEIGHT;
+  const scrollTopInset = TOOLBAR_CHROME_HEIGHT;
 
   const { canLeave, closeRow, onLeavePress, setRowRef } =
     useTripListLeave(tripHistory);
@@ -151,12 +156,11 @@ const ProfileScreen = ({ navigation }) => {
       });
 
     responseListener.current =
-      Notifications.addNotificationResponseReceivedListener((response) => {
-      });
+      Notifications.addNotificationResponseReceivedListener((response) => {});
 
     return () => {
       Notifications.removeNotificationSubscription(
-        notificationListener.current
+        notificationListener.current,
       );
       Notifications.removeNotificationSubscription(responseListener.current);
     };
@@ -233,21 +237,20 @@ const ProfileScreen = ({ navigation }) => {
     () => (
       <View testID="profile-scroll-header">
         <ProfileIdentity navigation={navigation} />
-        <View style={styles.headerButtonsContainer}>
-          <GetLocalPriceButton
-            navigation={navigation}
-            style={styles.headerButton}
-          />
-          <GradientButton
-            style={styles.headerButton}
-            buttonStyle={{}}
+        <View style={styles.profileActions}>
+          <GetLocalPriceButton navigation={navigation} />
+          <ActionRow
+            testID="profile-feedback"
+            tier="secondary"
+            label={i18n.t("supportFeedbackLabel")}
+            hint={i18n.t("supportFeedbackHint")}
+            icon="chatbubble-ellipses-outline"
+            showChevron={false}
             onPress={() => {
               trackEvent(VexoEvents.FEEDBACK_BUTTON_PRESSED);
               setIsFeedbackModalVisible(true);
             }}
-          >
-            {i18n.t("supportFeedbackLabel")}
-          </GradientButton>
+          />
         </View>
         <View style={styles.tripHubSection}>
           <Text style={styles.tripListTitle}>{i18n.t("myBudgets")}</Text>
@@ -261,7 +264,7 @@ const ProfileScreen = ({ navigation }) => {
         </View>
       </View>
     ),
-    [navigation]
+    [navigation],
   );
 
   const renderTripItem = useCallback(
@@ -281,7 +284,7 @@ const ProfileScreen = ({ navigation }) => {
         />
       );
     },
-    [tripHistory, canLeave, onLeavePress, closeRow, setRowRef]
+    [tripHistory, canLeave, onLeavePress, closeRow, setRowRef],
   );
 
   const uniqTrips = uniqBy(tripHistory ?? []);
@@ -355,17 +358,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: dynamicScale(16, false, 0.5),
     paddingBottom: dynamicScale(8, true),
   },
-  headerButtonsContainer: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: dynamicScale(8, true),
+  profileActions: {
     marginBottom: dynamicScale(8, true),
-  },
-  headerButton: {
-    flex: 1,
-    marginHorizontal: dynamicScale(4, false, 0.5),
-    borderRadius: 16,
   },
   tripHubSection: {
     marginBottom: dynamicScale(8, true),

--- a/TravelCostApp/screens/RatingModal.tsx
+++ b/TravelCostApp/screens/RatingModal.tsx
@@ -14,8 +14,8 @@ import Modal from "react-native-modal";
 import { i18n } from "../i18n/i18n";
 
 import PropTypes from "prop-types";
-import FlatButton from "../components/UI/FlatButton";
-import GradientButton from "../components/UI/GradientButton";
+import ActionRow from "../components/UI/ActionRow";
+import ActionRowStack from "../components/UI/ActionRowStack";
 import { GlobalStyles } from "../constants/styles";
 import { secureStoreSetObject } from "../store/secure-storage";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
@@ -103,15 +103,30 @@ const RatingModal = ({ isModalVisible, setIsModalVisible }) => {
         <View style={styles.subTitleContainer}>
           <Text style={styles.subTitleText}>{i18n.t("rateModalSubTitle")}</Text>
         </View>
-        <View style={styles.buttonContainer}>
-          <FlatButton onPress={handleNeverAskAgain}>
-            {i18n.t("never")}
-          </FlatButton>
-          <FlatButton onPress={handleClose}>{i18n.t("later")}</FlatButton>
-          <GradientButton onPress={handleRate}>
-            {i18n.t("rateModalButton")}
-          </GradientButton>
-        </View>
+        <ActionRowStack
+          showChevron={false}
+          actions={[
+            {
+              testID: "rating-modal-rate",
+              tier: "primary",
+              label: i18n.t("rateModalButton"),
+              icon: "star-outline",
+              onPress: handleRate,
+            },
+            {
+              testID: "rating-modal-later",
+              tier: "secondary",
+              label: i18n.t("later"),
+              onPress: handleClose,
+            },
+            {
+              testID: "rating-modal-never",
+              tier: "secondary",
+              label: i18n.t("never"),
+              onPress: handleNeverAskAgain,
+            },
+          ]}
+        />
       </Pressable>
     </Modal>
   );
@@ -154,11 +169,6 @@ const styles = StyleSheet.create({
     fontSize: dynamicScale(16, false, 0.5),
     textAlign: "center",
     color: GlobalStyles.colors.textColor,
-  },
-  buttonContainer: {
-    flexDirection: "row",
-    justifyContent: "space-evenly",
-    width: "100%",
   },
   reviewContainer: {
     alignItems: "center",

--- a/TravelCostApp/screens/SettingsScreen.tsx
+++ b/TravelCostApp/screens/SettingsScreen.tsx
@@ -22,7 +22,7 @@ import { DEVELOPER_MODE } from "../confAppConstants";
 import { useFocusEffect } from "@react-navigation/native";
 import { ENTITLEMENT_ID } from "../components/Premium/PremiumConstants";
 import PropTypes from "prop-types";
-import GradientButton from "../components/UI/GradientButton";
+import ActionRow from "../components/UI/ActionRow";
 import SettingsSection from "../components/UI/SettingsSection";
 import Toast from "react-native-toast-message";
 import { useEffect } from "react";
@@ -190,11 +190,12 @@ const SettingsScreen = ({ navigation }) => {
       >
         {i18n.t("visitFoodForNomadsLabel")}
       </LinkingButton>
-      <GradientButton
+      <ActionRow
         style={styles.settingsButton}
-        buttonStyle={{}}
-        darkText
-        colors={GlobalStyles.gradientColorsButton}
+        tier="primary"
+        label={premiumButtonString}
+        icon="diamond-outline"
+        showChevron={false}
         onPress={() => {
           if (!isConnected) {
             Alert.alert(i18n.t("noConnection"), i18n.t("checkConnectionError"));
@@ -208,9 +209,7 @@ const SettingsScreen = ({ navigation }) => {
             navigation.navigate("Paywall");
           }
         }}
-      >
-        {premiumButtonString}
-      </GradientButton>
+      />
       <CurrencyExchangeInfo />
       {!isRestoringPurchases && (
         <TouchableOpacity onPress={() => restorePurchases()}>

--- a/TravelCostApp/screens/SplitSummaryScreen.tsx
+++ b/TravelCostApp/screens/SplitSummaryScreen.tsx
@@ -21,7 +21,7 @@ import {
 } from "react-native";
 import Toast from "react-native-toast-message";
 import ErrorOverlay from "../components/UI/ErrorOverlay";
-import FlatButton from "../components/UI/FlatButton";
+import ActionRowStack from "../components/UI/ActionRowStack";
 import MiniSyncIndicator from "../components/UI/MiniSyncIndicator";
 import { GlobalStyles } from "../constants/styles";
 import { TripContext } from "../store/trip-context";
@@ -32,7 +32,6 @@ import {
 } from "../util/split";
 import PropTypes from "prop-types";
 import { UserContext } from "../store/user-context";
-import GradientButton from "../components/UI/GradientButton";
 import { ExpensesContext } from "../store/expenses-context";
 import {
   ExpenseData,
@@ -320,75 +319,72 @@ const SplitSummaryScreen = ({ navigation }) => {
 
   const ButtonContainerJSX = (
     <View style={isPortrait && styles.buttonContainer}>
-      {!showSimplify && (
-        <FlatButton
-          textStyle={styles.buttonText}
-          onPress={async () => {
-            if (showSimplify) {
-              trackEvent(VexoEvents.SPLIT_SUMMARY_BACK_PRESSED);
-              navigation.goBack();
-            } else {
-              getOpenSplits();
-              setShowSimplify(true);
-              setTitleText(titleTextOriginal);
-            }
-          }}
-        >
-          {i18n.t("back")}
-        </FlatButton>
-      )}
-      {showSimplify && !noSimpleSplits && (
-        <View style={styles.actionWithHelper}>
-          <GradientButton
-            buttonStyle={styles.button}
-            style={styles.button}
-            onPress={handleSimpflifySplits}
-          >
-            {i18n.t("simplifySplits")}
-          </GradientButton>
-          <Text style={styles.buttonHelperText}>
-            {i18n.t("balanceSimplificationHelper")}
-          </Text>
-        </View>
-      )}
-      {hasOpenSplits && !isTripSettled && (
-        <View style={styles.actionWithHelper}>
-          <GradientButton
-            style={styles.button}
-            colors={GlobalStyles.gradientColors}
-            darkText
-            buttonStyle={{
-              backgroundColor: GlobalStyles.colors.errorGrayed,
-            }}
-            onPress={async () => {
-              Alert.alert(
-                i18n.t("settleSplits"),
-                i18n.t("sureSettleSplitsFullMessage"),
-                [
-                  {
-                    text: i18n.t("cancel"),
-                    style: "cancel",
+      <ActionRowStack
+        showChevron={false}
+        actions={[
+          ...(showSimplify && !noSimpleSplits
+            ? [
+                {
+                  testID: "split-summary-simplify",
+                  tier: "primary" as const,
+                  label: i18n.t("simplifySplits"),
+                  hint: i18n.t("balanceSimplificationHelper"),
+                  icon: "git-merge-outline",
+                  onPress: handleSimpflifySplits,
+                },
+              ]
+            : []),
+          ...(hasOpenSplits && !isTripSettled
+            ? [
+                {
+                  testID: "split-summary-settle",
+                  tier: "primary" as const,
+                  label: i18n.t("settleSplits"),
+                  hint: i18n.t("settlementHelper"),
+                  icon: "checkmark-done-outline",
+                  onPress: async () => {
+                    Alert.alert(
+                      i18n.t("settleSplits"),
+                      i18n.t("sureSettleSplitsFullMessage"),
+                      [
+                        { text: i18n.t("cancel"), style: "cancel" },
+                        {
+                          text: i18n.t("confirmSettle"),
+                          onPress: async () => {
+                            trackEvent(VexoEvents.SETTLE_ALL_PRESSED, {
+                              splitsCount: splits?.length || 0,
+                            });
+                            await settleSplitsHandler();
+                          },
+                        },
+                      ]
+                    );
                   },
-                  {
-                    text: i18n.t("confirmSettle"),
-                    onPress: async () => {
-                      trackEvent(VexoEvents.SETTLE_ALL_PRESSED, {
-                        splitsCount: splits?.length || 0,
-                      });
-                      await settleSplitsHandler();
-                    },
+                },
+              ]
+            : []),
+          ...(!showSimplify
+            ? [
+                {
+                  testID: "split-summary-back",
+                  tier: "secondary" as const,
+                  label: i18n.t("back"),
+                  icon: "arrow-back-outline",
+                  onPress: async () => {
+                    if (showSimplify) {
+                      trackEvent(VexoEvents.SPLIT_SUMMARY_BACK_PRESSED);
+                      navigation.goBack();
+                    } else {
+                      getOpenSplits();
+                      setShowSimplify(true);
+                      setTitleText(titleTextOriginal);
+                    }
                   },
-                ]
-              );
-            }}
-          >
-            {i18n.t("settleSplits")}
-          </GradientButton>
-          <Text style={styles.buttonHelperText}>
-            {i18n.t("settlementHelper")}
-          </Text>
-        </View>
-      )}
+                },
+              ]
+            : []),
+        ]}
+      />
     </View>
   );
 

--- a/TravelCostApp/screens/TripSummaryScreen.tsx
+++ b/TravelCostApp/screens/TripSummaryScreen.tsx
@@ -17,7 +17,8 @@ import { Checkbox } from "react-native-paper";
 import { daysBetween, isToday } from "../util/date";
 import { GlobalStyles } from "../constants/styles";
 import { shadowRegressionStyles } from "../styles/shadow-regression-styles";
-import FlatButton from "../components/UI/FlatButton";
+import ActionRow from "../components/UI/ActionRow";
+import ActionRowStack from "../components/UI/ActionRowStack";
 
 import { i18n } from "../i18n/i18n";
 
@@ -44,7 +45,6 @@ import { getTripData } from "../util/trip";
 import * as Progress from "react-native-progress";
 import Animated, { FadeInUp } from "react-native-reanimated";
 import ExpenseCountryFlag from "../components/ExpensesOutput/ExpenseCountryFlag";
-import GradientButton from "../components/UI/GradientButton";
 import { constantScale, dynamicScale, scale } from "../util/scalingUtil";
 import { Platform } from "react-native";
 import { safelyParseJSON } from "../util/jsonParse";
@@ -588,7 +588,12 @@ const TripSummaryScreen = ({ navigation }) => {
         )}
       </Pressable>
       <View style={styles.buttonContainer}>
-        <GradientButton
+        <ActionRow
+          testID="trip-summary-summary"
+          tier="gradient"
+          label={i18n.t("summary")}
+          hint={i18n.t("summaryHint")}
+          icon="document-text-outline"
           onPress={() => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
             setShowSummary(!showSummary);
@@ -596,27 +601,17 @@ const TripSummaryScreen = ({ navigation }) => {
               summarizeHandler();
             }
           }}
-          buttonStyle={styles.fullWidthButtonStyle}
-          colors={GlobalStyles.gradientColorsButton}
-          darkText
-        >
-          {i18n.t("summary")}
-        </GradientButton>
-        <View style={styles.halfWidthButtonContainer}>
-          <View style={styles.halfWidthButton}>
-            <FlatButton
-              onPress={() => {
-                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                navigation.pop();
-              }}
-              textStyle={{}}
-            >
-              {i18n.t("back")}
-            </FlatButton>
-          </View>
-          <View style={styles.halfWidthButton}>
-            <FlatButton
-              onPress={() => {
+          showChevron={false}
+        />
+        <ActionRowStack
+          showChevron={false}
+          actions={[
+            {
+              testID: "trip-summary-charts",
+              tier: "secondary",
+              label: i18n.t("charts"),
+              icon: "pie-chart-outline",
+              onPress: () => {
                 Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                 navigation.navigate("FilteredPieCharts", {
                   expenses: toExpenseNavigationDtos(allExpensesList),
@@ -624,21 +619,20 @@ const TripSummaryScreen = ({ navigation }) => {
                     "expensesTab"
                   )}`,
                 });
-              }}
-              textStyle={{}}
-            >
-              {i18n.t("charts")}
-            </FlatButton>
-          </View>
-        </View>
-        {/* {tripSummary && (
-          <GradientButton
-            style={styles.gradientButtonStyle}
-            onPress={exportHandler}
-          >
-            Export to PDF
-          </GradientButton>
-        )} */}
+              },
+            },
+            {
+              testID: "trip-summary-back",
+              tier: "secondary",
+              label: i18n.t("back"),
+              icon: "arrow-back-outline",
+              onPress: () => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                navigation.pop();
+              },
+            },
+          ]}
+        />
       </View>
     </ScrollView>
   );
@@ -729,19 +723,6 @@ const styles = StyleSheet.create({
     margin: dynamicScale(20, false, 0.5),
     paddingHorizontal: dynamicScale(16, false, 0.5),
   },
-  fullWidthButtonStyle: {
-    width: "100%",
-    marginBottom: dynamicScale(24, false, 0.5),
-  },
-  halfWidthButtonContainer: {
-    flexDirection: "row",
-    width: "100%",
-    justifyContent: "space-between",
-    paddingHorizontal: dynamicScale(16, false, 0.5),
-  },
-  halfWidthButton: {
-    flex: 1,
-  },
   summaryTextBig: {
     fontSize: dynamicScale(16, false, 0.5),
     fontWeight: "600",
@@ -794,29 +775,6 @@ const styles = StyleSheet.create({
     fontWeight: "400",
     color: GlobalStyles.colors.textColor,
     opacity: 0.8,
-  },
-  gradientButtonStyle: {
-    justifyContent: "center",
-    alignItems: "center",
-    marginHorizontal: 0, // Override GradientButton's default margin
-  },
-  buttonContent: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    paddingTop: dynamicScale(2, true),
-    marginBottom: dynamicScale(-2, true),
-  },
-  buttonIcon: {
-    width: dynamicScale(18, false, 0.5),
-    height: dynamicScale(18, false, 0.5),
-    marginRight: dynamicScale(6, false, 0.5),
-  },
-  buttonText: {
-    fontSize: dynamicScale(16, false, 0.5),
-    fontWeight: "300",
-    fontStyle: "italic",
-    color: GlobalStyles.colors.textColor,
   },
   tripItemText: {
     fontSize: dynamicScale(14, false, 0.5),

--- a/TravelCostApp/styles/action-row-tokens.ts
+++ b/TravelCostApp/styles/action-row-tokens.ts
@@ -1,0 +1,49 @@
+import { Platform } from "react-native";
+
+import { GlobalStyles } from "../constants/styles";
+import { dynamicScale } from "../util/scalingUtil";
+
+/**
+ * Locked ActionRow design tokens (variant C — accent strip).
+ * Do not tweak per screen; change here only after design review.
+ */
+export const ActionRowTokens = {
+  surface: "#FFFFFF",
+  borderColor: GlobalStyles.colors.gray300,
+  borderWidth: 1,
+  borderRadius: 16,
+  padding: dynamicScale(14),
+  marginBottom: dynamicScale(10, true),
+  accentStripWidth: dynamicScale(5),
+  primaryTint: GlobalStyles.colors.primary50,
+  iconSize: dynamicScale(20, false, 0.5),
+  imageIconSize: dynamicScale(20, false, 0.5),
+  labelFontSize: dynamicScale(16, false, 0.5),
+  hintFontSize: dynamicScale(12, false, 0.5),
+  chevronFontSize: dynamicScale(22, false, 0.5),
+  gradients: {
+    primary: GlobalStyles.gradientPrimaryButton,
+    promotional: GlobalStyles.gradientColorsButton,
+  },
+  press: GlobalStyles.pressedActionRow,
+  shadow: Platform.select({
+    ios: {
+      shadowColor: "#002A22",
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.16,
+      shadowRadius: 3,
+    },
+    android: {
+      elevation: 3,
+    },
+  }),
+} as const;
+
+/** Shell style co-locating background, border, and shadow for ActionRow. */
+export const actionRowCardShell = {
+  backgroundColor: ActionRowTokens.surface,
+  borderRadius: ActionRowTokens.borderRadius,
+  borderWidth: ActionRowTokens.borderWidth,
+  borderColor: ActionRowTokens.borderColor,
+  ...ActionRowTokens.shadow,
+};

--- a/TravelCostApp/styles/profile-toolbar-tokens.ts
+++ b/TravelCostApp/styles/profile-toolbar-tokens.ts
@@ -1,0 +1,16 @@
+import { dynamicScale } from "../util/scalingUtil";
+
+/** Compact profile top bar: icon row height is iconSize + small vertical padding only. */
+export const ProfileToolbarTokens = {
+  iconSize: dynamicScale(24, false, 0.5),
+  paddingVertical: dynamicScale(4, true),
+  paddingHorizontal: dynamicScale(8, false, 0.5),
+  iconHitPadding: dynamicScale(4, false, 0.5),
+  contentHeight:
+    dynamicScale(24, false, 0.5) + 2 * dynamicScale(4, false, 0.5),
+  /** Painted toolbar strip below the safe area (icon row + bottom padding). */
+  chromeHeight:
+    dynamicScale(24, false, 0.5) +
+    2 * dynamicScale(4, false, 0.5) +
+    dynamicScale(4, true),
+} as const;

--- a/TravelCostApp/styles/shadow-regression-styles.ts
+++ b/TravelCostApp/styles/shadow-regression-styles.ts
@@ -1,6 +1,7 @@
 import { Platform, StyleSheet } from "react-native";
 
 import { GlobalStyles } from "../constants/styles";
+import { actionRowCardShell } from "./action-row-tokens";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
 
 export const periodHeaderLabelFontSize = dynamicScale(28, false, 0.5);
@@ -113,6 +114,7 @@ export const shadowRegressionStyles = StyleSheet.create({
     backgroundColor: GlobalStyles.colors.backgroundColorLight,
     ...GlobalStyles.wideStrongShadow,
   },
+  actionRowCard: actionRowCardShell,
   tripTravellerChip: {
     backgroundColor: GlobalStyles.colors.backgroundColor,
     ...GlobalStyles.strongShadow,

--- a/TravelCostApp/util/action-row-label.ts
+++ b/TravelCostApp/util/action-row-label.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+/** Derives an ActionRow label from legacy Button children (plain text). */
+export function actionRowLabelFromChildren(children: React.ReactNode): string {
+  if (typeof children === "string" || typeof children === "number") {
+    return String(children);
+  }
+  if (Array.isArray(children)) {
+    return children.map(actionRowLabelFromChildren).join("");
+  }
+  if (React.isValidElement(children)) {
+    return actionRowLabelFromChildren(children.props.children);
+  }
+  return "";
+}

--- a/TravelCostApp/util/expense-form-local-price-hint.ts
+++ b/TravelCostApp/util/expense-form-local-price-hint.ts
@@ -1,0 +1,30 @@
+import { i18n } from "../i18n/i18n";
+
+type ExpenseFormLocalPriceHintParams = {
+  product: string;
+  country: string;
+  price?: string;
+  currency?: string;
+};
+
+/** Contextual ActionRow hint for the expense form "Get local price" row. */
+export function expenseFormLocalPriceHint({
+  product,
+  country,
+  price,
+  currency,
+}: ExpenseFormLocalPriceHintParams): string {
+  const trimmedProduct = product.trim();
+  if (price && price !== "" && !Number.isNaN(Number(price))) {
+    return i18n.t("getLocalPriceExpenseDealHint", {
+      price,
+      currency: currency ?? "",
+      product: trimmedProduct,
+      country,
+    });
+  }
+  return i18n.t("getLocalPriceExpenseHint", {
+    product: trimmedProduct,
+    country,
+  });
+}


### PR DESCRIPTION
## Summary
- Add `ActionRow` / `ActionRowStack` with shared design tokens, accessibility hints, and haptic feedback for primary, secondary, and gradient action tiers.
- Migrate screens and components (forms, modals, profile toolbar, trip summary, split summary, etc.) from ad-hoc `GradientButton` / `FlatButton` usage to the shared action-row pattern.
- Add regression tests including a legacy-import guard to prevent new direct `GradientButton` / `FlatButton` imports outside allowed paths.

## Test plan
- [ ] Run `pnpm test` in `TravelCostApp/`
- [ ] Spot-check profile toolbar, trip summary, and split summary action rows (primary/secondary/gradient tiers)
- [ ] Verify modal footers and form submit/cancel rows still trigger correctly
- [ ] Confirm accessibility hints render for action rows with optional hint text