### PR TITLE
Fix stale trip names and signup token loss after cache clear

### DIFF
--- a/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
@@ -155,6 +155,54 @@ describe("TripForm budget form modes", () => {
     );
   });
 
+  it("keeps typed budget name when fetchTrip completes after user input", async () => {
+    const { fetchTrip } = require("../../util/http");
+    let resolveFetch: (trip: object) => void = () => {};
+    fetchTrip.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const screen = renderWithAppProviders(
+      <TripForm
+        navigation={navigation}
+        route={{ params: { tripId: "t-implicit", mode: "promote" } }}
+      />,
+      {
+        network: { isConnected: true, strongConnection: true },
+        trip: {
+          tripid: "t-implicit",
+          tripName: "",
+          tripCurrency: "EUR",
+          dailyBudget: "0",
+          totalBudget: "0",
+          isImplicitDefault: true,
+          travellers: [{ uid: "u1", userName: "Alice" }],
+        },
+        expenses: { expenses: [] },
+      }
+    );
+
+    const nameInput = await screen.findByDisplayValue("");
+    fireEvent.changeText(nameInput, "Home budget");
+    expect(screen.getByDisplayValue("Home budget")).toBeTruthy();
+
+    resolveFetch({
+      tripName: "",
+      tripCurrency: "EUR",
+      dailyBudget: "0",
+      totalBudget: "0",
+      isDynamicDailyBudget: false,
+      isImplicitDefault: true,
+      travellers: [{ uid: "u1", userName: "Alice" }],
+    });
+
+    await waitFor(() => expect(fetchTrip).toHaveBeenCalled());
+    expect(screen.getByDisplayValue("Home budget")).toBeTruthy();
+  });
+
   it("naming an implicit default Active trip without mode clears isImplicitDefault via updateTrip", async () => {
     const screen = renderWithAppProviders(
       <TripForm

--- a/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-budget-modes.test.tsx
@@ -51,7 +51,7 @@ jest.mock("../../store/secure-storage", () => ({
   secureStoreSetItem: jest.fn(async () => {}),
 }));
 
-import { fireEvent, waitFor } from "@testing-library/react-native";
+import { act, fireEvent, waitFor } from "@testing-library/react-native";
 
 import TripForm from "../../components/ManageTrip/TripForm";
 import { i18n } from "../../i18n/i18n";
@@ -189,14 +189,16 @@ describe("TripForm budget form modes", () => {
     fireEvent.changeText(nameInput, "Home budget");
     expect(screen.getByDisplayValue("Home budget")).toBeTruthy();
 
-    resolveFetch({
-      tripName: "",
-      tripCurrency: "EUR",
-      dailyBudget: "0",
-      totalBudget: "0",
-      isDynamicDailyBudget: false,
-      isImplicitDefault: true,
-      travellers: [{ uid: "u1", userName: "Alice" }],
+    await act(async () => {
+      resolveFetch({
+        tripName: "",
+        tripCurrency: "EUR",
+        dailyBudget: "0",
+        totalBudget: "0",
+        isDynamicDailyBudget: false,
+        isImplicitDefault: true,
+        travellers: [{ uid: "u1", userName: "Alice" }],
+      });
     });
 
     await waitFor(() => expect(fetchTrip).toHaveBeenCalled());

--- a/TravelCostApp/__tests__/components/trip-form-fetch-race.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-form-fetch-race.test.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+
+let latestOnConfirmRange:
+  | ((output: { startDate: Date; endDate: Date }) => void)
+  | null = null;
+
+jest.mock("../../util/http", () => ({
+  storeTrip: jest.fn(),
+  storeTripHistory: jest.fn(),
+  updateUser: jest.fn(),
+  fetchTrip: jest.fn(
+    () =>
+      new Promise(() => {
+        /* resolved per test */
+      })
+  ),
+  updateTripHistory: jest.fn(),
+  updateTrip: jest.fn(),
+  getAllExpenses: jest.fn(async () => []),
+  getTravellers: jest.fn(async () => [{ uid: "u1", userName: "Alice" }]),
+  putTravelerInTrip: jest.fn(),
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+jest.mock("@react-navigation/elements", () => ({
+  useHeaderHeight: () => 0,
+}));
+
+jest.mock("../../components/Currency/CurrencyPicker", () => () => null);
+jest.mock("../../components/UI/DatePickerModal", () => {
+  return (props: {
+    onConfirmRange?: (output: { startDate: Date; endDate: Date }) => void;
+  }) => {
+    latestOnConfirmRange = props.onConfirmRange ?? null;
+    return null;
+  };
+});
+jest.mock("../../util/appState", () => ({
+  sleep: jest.fn(async () => {}),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(async () => "t1"),
+  secureStoreSetItem: jest.fn(async () => {}),
+}));
+
+import { act, fireEvent, waitFor } from "@testing-library/react-native";
+
+import TripForm from "../../components/ManageTrip/TripForm";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { fetchTrip } from "../../util/http";
+import { getFormattedDate } from "../../util/date";
+import { toShortFormat } from "../../util/date";
+
+const navigation = {
+  navigate: jest.fn(),
+  pop: jest.fn(),
+  popToTop: jest.fn(),
+};
+
+const pickedStart = new Date("2026-01-15T12:00:00.000Z");
+const pickedEnd = new Date("2026-01-20T12:00:00.000Z");
+
+describe("TripForm fetch race", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    latestOnConfirmRange = null;
+    (fetchTrip as jest.Mock).mockImplementation(
+      () =>
+        new Promise(() => {
+          /* resolved per test */
+        })
+    );
+  });
+
+  it("keeps picked trip dates when fetchTrip completes after date selection", async () => {
+    let resolveFetch: (trip: object) => void = () => {};
+    (fetchTrip as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const screen = renderWithAppProviders(
+      <TripForm navigation={navigation} route={{ params: { tripId: "t1" } }} />,
+      {
+        network: { isConnected: true, strongConnection: true },
+        trip: {
+          tripid: "t1",
+          tripName: "Japan",
+          tripCurrency: "EUR",
+          dailyBudget: "50",
+          totalBudget: "2000",
+          startDate: "",
+          endDate: "",
+          travellers: [{ uid: "u1", userName: "Alice" }],
+        },
+        expenses: { expenses: [] },
+      }
+    );
+
+    await waitFor(() => expect(latestOnConfirmRange).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByTestId("trip-form-optional-section")).toBeTruthy()
+    );
+
+    await act(async () => {
+      latestOnConfirmRange?.({ startDate: pickedStart, endDate: pickedEnd });
+    });
+
+    const startLabel = toShortFormat(new Date(getFormattedDate(pickedStart)!));
+    const endLabel = toShortFormat(new Date(getFormattedDate(pickedEnd)!));
+
+    await waitFor(() => {
+      expect(screen.getByText(startLabel)).toBeTruthy();
+      expect(screen.getByText(endLabel)).toBeTruthy();
+    });
+
+    await act(async () => {
+      resolveFetch({
+        tripName: "Japan",
+        tripCurrency: "EUR",
+        dailyBudget: "50",
+        totalBudget: "2000",
+        startDate: "",
+        endDate: "",
+        isDynamicDailyBudget: false,
+        isImplicitDefault: false,
+        travellers: [{ uid: "u1", userName: "Alice" }],
+      });
+    });
+
+    await waitFor(() => expect(fetchTrip).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(screen.getByText(startLabel)).toBeTruthy();
+      expect(screen.getByText(endLabel)).toBeTruthy();
+    });
+  });
+});

--- a/TravelCostApp/__tests__/screens/signup-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/signup-screen.test.tsx
@@ -1,0 +1,134 @@
+import * as React from "react";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const signupSteps: string[] = [];
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useNavigation: () => ({
+      replace: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("@react-navigation/elements", () => ({
+  useHeaderHeight: () => 0,
+}));
+
+jest.mock("../../store/async-storage", () => ({
+  asyncStoreSafeClear: jest.fn(async () => {
+    signupSteps.push("clear");
+  }),
+}));
+
+jest.mock("../../util/auth", () => ({
+  createUser: jest.fn(async () => {
+    signupSteps.push("createUser");
+    return { token: "fresh-id-token", uid: "new-user-uid" };
+  }),
+}));
+
+jest.mock("../../util/http", () => ({
+  storeUser: jest.fn(async () => {}),
+  updateUser: jest.fn(async () => {}),
+}));
+
+jest.mock("../../util/axios-config", () => ({
+  setAxiosAccessToken: jest.fn(),
+}));
+
+jest.mock("../../components/Premium/PremiumConstants", () => ({
+  loadKeys: jest.fn(async () => ({ REVCAT_G: "", REVCAT_A: "" })),
+  setAttributesAsync: jest.fn(async () => {}),
+}));
+
+jest.mock("react-native-purchases", () => ({
+  configure: jest.fn(),
+  collectDeviceIdentifiers: jest.fn(async () => {}),
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("../../util/create-implicit-default-for-user", () => ({
+  createImplicitDefaultForUser: jest.fn(async () => {}),
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreSetItem: jest.fn(async () => {}),
+  secureStoreGetItem: jest.fn(async () => ""),
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  __esModule: true,
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+import { fireEvent, waitFor } from "@testing-library/react-native";
+import { TextInput } from "react-native";
+
+import SignupScreen from "../../screens/SignupScreen";
+import { i18n } from "../../i18n/i18n";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { asyncStoreSafeClear } from "../../store/async-storage";
+import { createUser } from "../../util/auth";
+
+const appRoot = join(__dirname, "../..");
+
+describe("SignupScreen", () => {
+  beforeEach(() => {
+    signupSteps.length = 0;
+    jest.clearAllMocks();
+  });
+
+  it("clears local storage before createUser, not after auth", async () => {
+    const screen = renderWithAppProviders(<SignupScreen />, {
+      network: { isConnected: true, strongConnection: true },
+      auth: {
+        setUserID: jest.fn(async () => {}),
+        authenticate: jest.fn(async () => {}),
+      },
+      user: {
+        setUserName: jest.fn(async () => {}),
+        setTripHistory: jest.fn(),
+        setFreshlyCreatedTo: jest.fn(),
+      },
+      trip: {
+        setCurrentTrip: jest.fn(),
+        saveTripDataInStorage: jest.fn(async () => {}),
+        saveTravellersInStorage: jest.fn(async () => {}),
+      },
+      expenses: {
+        setExpenses: jest.fn(),
+      },
+    });
+
+    const inputs = screen.UNSAFE_getAllByType(TextInput);
+    fireEvent.changeText(inputs[0], "Alice");
+    fireEvent.changeText(inputs[1], "alice@example.com");
+    fireEvent.changeText(inputs[2], "secret12");
+
+    fireEvent.press(
+      screen.getAllByText(i18n.t("createAccountText")).slice(-1)[0]
+    );
+
+    await waitFor(() => expect(createUser).toHaveBeenCalled());
+    expect(signupSteps).toEqual(["clear", "createUser"]);
+    expect(asyncStoreSafeClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call asyncStoreSafeClear after createUser in source", () => {
+    const src = readFileSync(join(appRoot, "screens/SignupScreen.tsx"), "utf8");
+    const clearIndex = src.indexOf("await asyncStoreSafeClear()");
+    const createUserIndex = src.indexOf("await createUser(email, password)");
+    expect(clearIndex).toBeGreaterThan(-1);
+    expect(createUserIndex).toBeGreaterThan(clearIndex);
+    expect(src.slice(createUserIndex).includes("await asyncStoreSafeClear()")).toBe(
+      false
+    );
+  });
+});

--- a/TravelCostApp/__tests__/screens/signup-token-after-clear.test.ts
+++ b/TravelCostApp/__tests__/screens/signup-token-after-clear.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Signup must clear stale local cache before auth, not after — asyncStoreSafeClear
+ * removes the Firebase token from secure storage.
+ */
+const secureStore: Record<string, string> = {};
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreSetItem: jest.fn(async (key: string, value: string) => {
+    secureStore[key] = value;
+  }),
+  secureStoreGetItem: jest.fn(async (key: string) => secureStore[key] ?? ""),
+  secureStoreRemoveItem: jest.fn(async (key: string) => {
+    delete secureStore[key];
+  }),
+}));
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getAllKeys: jest.fn(async () => []),
+  multiRemove: jest.fn(async () => {}),
+}));
+
+jest.mock("../../store/mmkv", () => ({
+  MMKV_KEYS: { CURRENT_TRIP: "currentTrip", EXPENSES: "expenses" },
+  deleteMMKVObject: jest.fn(),
+}));
+
+import { asyncStoreSafeClear } from "../../store/async-storage";
+import { getValidIdToken, storeAuthData } from "../../util/firebase-auth";
+
+describe("signup auth token survives local cache clear", () => {
+  beforeEach(() => {
+    Object.keys(secureStore).forEach((key) => delete secureStore[key]);
+    jest.clearAllMocks();
+  });
+
+  it("keeps token available for post-signup HTTP calls", async () => {
+    await asyncStoreSafeClear();
+
+    await storeAuthData({
+      idToken: "fresh-id-token",
+      refreshToken: "fresh-refresh",
+      expiresIn: "3600",
+      localId: "new-user-uid",
+    });
+
+    expect(await getValidIdToken()).toBe("fresh-id-token");
+  });
+});

--- a/TravelCostApp/__tests__/screens/trip-summary-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/trip-summary-screen.test.tsx
@@ -8,6 +8,17 @@ jest.mock("expo-haptics", () => ({
   ImpactFeedbackStyle: { Light: "Light" },
 }));
 
+jest.mock("@react-navigation/native", () => {
+  const React = require("react");
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useFocusEffect: (callback: () => void | (() => void)) => {
+      React.useEffect(() => callback(), [callback]);
+    },
+  };
+});
+
 jest.mock("../../store/mmkv", () => ({
   getMMKVString: jest.fn(() => new Date().toISOString()),
   getMMKVObject: jest.fn(() => [
@@ -137,6 +148,30 @@ describe("TripSummaryScreen", () => {
     expect(pressableTestIds.indexOf("trip-summary-charts")).toBeLessThan(
       pressableTestIds.indexOf("trip-summary-back")
     );
+  });
+
+  it("shows the Active trip name from context when the daily cache is stale", async () => {
+    const navigation = { navigate: jest.fn(), pop: jest.fn(), goBack: jest.fn() };
+
+    const screen = renderWithAppProviders(
+      <TripSummaryScreen navigation={navigation as any} />,
+      {
+        trip: {
+          tripid: "t1",
+          tripName: "Home budget",
+          tripCurrency: "EUR",
+        },
+        user: {
+          userName: "Alice",
+          freshlyCreated: false,
+          tripHistory: ["t1"],
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Home budget")).toBeTruthy();
+    });
   });
 
   it("shows a hint on the gradient summary row", async () => {

--- a/TravelCostApp/__tests__/util/trip-summary-cache.test.ts
+++ b/TravelCostApp/__tests__/util/trip-summary-cache.test.ts
@@ -1,11 +1,9 @@
 import {
-  invalidateAllTripsAsObjectCache,
   patchActiveTripNameInList,
   updateTripNameInAllTripsCache,
 } from "../../util/trip-summary-cache";
 
 jest.mock("../../store/mmkv", () => ({
-  deleteMMKVObject: jest.fn(),
   getMMKVObject: jest.fn(),
   setMMKVObject: jest.fn(),
   MMKV_KEYS: {
@@ -14,27 +12,11 @@ jest.mock("../../store/mmkv", () => ({
   },
 }));
 
-import {
-  deleteMMKVObject,
-  getMMKVObject,
-  setMMKVObject,
-  MMKV_KEYS,
-} from "../../store/mmkv";
+import { getMMKVObject, setMMKVObject, MMKV_KEYS } from "../../store/mmkv";
 
 describe("trip summary cache", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it("invalidates cached trip names", () => {
-    invalidateAllTripsAsObjectCache();
-
-    expect(deleteMMKVObject).toHaveBeenCalledWith(
-      MMKV_KEYS.ALL_TRIPS_AS_OBJECT
-    );
-    expect(deleteMMKVObject).toHaveBeenCalledWith(
-      MMKV_KEYS.ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE
-    );
   });
 
   it("updates a renamed trip inside today's cache", () => {

--- a/TravelCostApp/__tests__/util/trip-summary-cache.test.ts
+++ b/TravelCostApp/__tests__/util/trip-summary-cache.test.ts
@@ -1,0 +1,63 @@
+import {
+  invalidateAllTripsAsObjectCache,
+  patchActiveTripNameInList,
+  updateTripNameInAllTripsCache,
+} from "../../util/trip-summary-cache";
+
+jest.mock("../../store/mmkv", () => ({
+  deleteMMKVObject: jest.fn(),
+  getMMKVObject: jest.fn(),
+  setMMKVObject: jest.fn(),
+  MMKV_KEYS: {
+    ALL_TRIPS_AS_OBJECT: "allTripsAsObject",
+    ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE: "allTripsAsObjectCacheIsoDate",
+  },
+}));
+
+import {
+  deleteMMKVObject,
+  getMMKVObject,
+  setMMKVObject,
+  MMKV_KEYS,
+} from "../../store/mmkv";
+
+describe("trip summary cache", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("invalidates cached trip names", () => {
+    invalidateAllTripsAsObjectCache();
+
+    expect(deleteMMKVObject).toHaveBeenCalledWith(
+      MMKV_KEYS.ALL_TRIPS_AS_OBJECT
+    );
+    expect(deleteMMKVObject).toHaveBeenCalledWith(
+      MMKV_KEYS.ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE
+    );
+  });
+
+  it("updates a renamed trip inside today's cache", () => {
+    (getMMKVObject as jest.Mock).mockReturnValue([
+      { tripid: "t1", tripname: "", selected: true },
+      { tripid: "t2", tripname: "Japan", selected: true },
+    ]);
+
+    updateTripNameInAllTripsCache("t1", "Home budget");
+
+    expect(setMMKVObject).toHaveBeenCalledWith(MMKV_KEYS.ALL_TRIPS_AS_OBJECT, [
+      { tripid: "t1", tripname: "Home budget", selected: true },
+      { tripid: "t2", tripname: "Japan", selected: true },
+    ]);
+  });
+
+  it("patches the Active trip name over a stale cached value", () => {
+    const patched = patchActiveTripNameInList(
+      [{ tripid: "t1", tripname: "", selected: true }],
+      "t1",
+      "Home budget"
+    );
+
+    expect(patched[0].tripname).toBe("Home budget");
+  });
+});

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -148,6 +148,10 @@ const TripForm = ({ navigation, route }) => {
   const userHasEditedFormRef = useRef(false);
   const fetchStartedForTripRef = useRef<string | null>(null);
 
+  const markFormEdited = () => {
+    userHasEditedFormRef.current = true;
+  };
+
   const openDatePickerRange = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     setShowDatePickerRange(true);
@@ -165,6 +169,7 @@ const TripForm = ({ navigation, route }) => {
     const endDate = DateTime.fromJSDate(output.endDate).toJSDate();
     const startDateFormat = getFormattedDate(startDate);
     const endDateFormat = getFormattedDate(endDate);
+    markFormEdited();
     setStartDate(startDateFormat);
     setEndDate(endDateFormat);
   };
@@ -280,7 +285,7 @@ const TripForm = ({ navigation, route }) => {
   // let currencyPickerRef = undefined;
 
   function inputChangedHandler(inputIdentifier, enteredValue) {
-    userHasEditedFormRef.current = true;
+    markFormEdited();
     setInputs((curInputs) => {
       return {
         ...curInputs,

--- a/TravelCostApp/components/ManageTrip/TripForm.tsx
+++ b/TravelCostApp/components/ManageTrip/TripForm.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { useState, useContext, useEffect, useLayoutEffect } from "react";
+import {
+  useState,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import {
   View,
   Text,
@@ -84,6 +90,7 @@ import {
   shouldConfirmCurrencyChange,
   type TripFormMode,
 } from "../../util/trip-form";
+import { updateTripNameInAllTripsCache } from "../../util/trip-summary-cache";
 import { hasDailyBudget, hasTotalBudget } from "../../util/budget-free";
 
 const TripForm = ({ navigation, route }) => {
@@ -138,6 +145,8 @@ const TripForm = ({ navigation, route }) => {
     false
   );
   const [optionalDetailsOpen, setOptionalDetailsOpen] = useState(false);
+  const userHasEditedFormRef = useRef(false);
+  const fetchStartedForTripRef = useRef<string | null>(null);
 
   const openDatePickerRange = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -173,8 +182,14 @@ const TripForm = ({ navigation, route }) => {
   const isPromote = formMode === "promote";
   const isAddAnother = formMode === "addAnother";
 
+  useEffect(() => {
+    userHasEditedFormRef.current = false;
+    fetchStartedForTripRef.current = null;
+  }, [editedTripId]);
+
   useLayoutEffect(() => {
     const applyLoadedTrip = (selectedTrip: TripData) => {
+      if (userHasEditedFormRef.current) return;
       const daily =
         selectedTrip.dailyBudget !== undefined &&
         selectedTrip.dailyBudget !== null
@@ -185,17 +200,21 @@ const TripForm = ({ navigation, route }) => {
         selectedTrip.totalBudget !== null
           ? String(selectedTrip.totalBudget)
           : "";
-      inputChangedHandler("tripName", selectedTrip.tripName ?? "");
-      inputChangedHandler("tripCurrency", selectedTrip.tripCurrency);
-      inputChangedHandler("dailyBudget", daily === "0" ? "" : daily);
-      inputChangedHandler(
-        "totalBudget",
-        total === "0" || Number(total) >= MAX_JS_NUMBER ? "" : total
-      );
-      inputChangedHandler(
-        "isDynamicDailyBudget",
-        selectedTrip.isDynamicDailyBudget
-      );
+      setInputs((curInputs) => ({
+        ...curInputs,
+        tripName: { value: selectedTrip.tripName ?? "", isValid: true },
+        tripCurrency: { value: selectedTrip.tripCurrency, isValid: true },
+        dailyBudget: { value: daily === "0" ? "" : daily, isValid: true },
+        totalBudget: {
+          value:
+            total === "0" || Number(total) >= MAX_JS_NUMBER ? "" : total,
+          isValid: true,
+        },
+        isDynamicDailyBudget: {
+          value: selectedTrip.isDynamicDailyBudget,
+          isValid: true,
+        },
+      }));
       setStartDate(selectedTrip.startDate ?? "");
       setEndDate(selectedTrip.endDate ?? "");
       setTravellers(selectedTrip.travellers ?? []);
@@ -212,6 +231,7 @@ const TripForm = ({ navigation, route }) => {
     const fetchTripData = async () => {
       try {
         const selectedTrip = await fetchTrip(editedTripId);
+        if (userHasEditedFormRef.current) return;
         applyLoadedTrip(selectedTrip);
       } catch (error) {
         safeLogError(error);
@@ -242,25 +262,14 @@ const TripForm = ({ navigation, route }) => {
 
     if (isEditing && editedTripId) {
       loadTripDataFromContext();
-      fetchTripData();
+      if (fetchStartedForTripRef.current !== editedTripId) {
+        fetchStartedForTripRef.current = editedTripId;
+        void fetchTripData();
+      }
     } else if (isAddAnother) {
       setOptionalDetailsOpen(false);
     }
-  }, [
-    editedTripId,
-    isEditing,
-    isAddAnother,
-    tripCtx.dailyBudget,
-    tripCtx.totalBudget,
-    tripCtx.tripCurrency,
-    tripCtx.tripName,
-    tripCtx.tripid,
-    tripCtx.isDynamicDailyBudget,
-    tripCtx.startDate,
-    tripCtx.endDate,
-    tripCtx.travellers,
-    tripCtx.isImplicitDefault,
-  ]);
+  }, [editedTripId, isEditing, isAddAnother, tripCtx.tripid]);
 
   const [countryValue, setCountryValue] = useState(
     inputs?.tripCurrency ? inputs.tripCurrency.value : standardCurrency
@@ -271,6 +280,7 @@ const TripForm = ({ navigation, route }) => {
   // let currencyPickerRef = undefined;
 
   function inputChangedHandler(inputIdentifier, enteredValue) {
+    userHasEditedFormRef.current = true;
     setInputs((curInputs) => {
       return {
         ...curInputs,
@@ -352,6 +362,7 @@ const TripForm = ({ navigation, route }) => {
   async function editingTripData(tripData: TripData, setActive = false) {
     try {
       await updateTrip(editedTripId, tripData);
+      updateTripNameInAllTripsCache(editedTripId, tripData.tripName ?? "");
 
       // Track trip edit
       trackEvent(VexoEvents.TRIP_EDITED, {
@@ -403,6 +414,7 @@ const TripForm = ({ navigation, route }) => {
       tripData.categories = JSON.stringify(currentCategories);
 
     const tripid = await storeTrip(tripData);
+    updateTripNameInAllTripsCache(tripid, tripData.tripName ?? "");
 
     // Track trip creation
     trackEvent(VexoEvents.TRIP_CREATED, {

--- a/TravelCostApp/screens/SignupScreen.tsx
+++ b/TravelCostApp/screens/SignupScreen.tsx
@@ -75,6 +75,8 @@ function SignupScreen() {
       setIsAuthenticating(false);
       return;
     }
+    // Drop stale local session before storing new auth credentials.
+    await asyncStoreSafeClear();
     try {
       // NECESSARY TRYCATCH
       ({ token, uid } = await createUser(email, password));
@@ -93,7 +95,6 @@ function SignupScreen() {
     }
     try {
       // UNESSENTIAL TRYCATCH
-      await asyncStoreSafeClear();
       setAxiosAccessToken(token);
       await userCtx.setUserName(name);
       userCtx.setTripHistory([]);

--- a/TravelCostApp/screens/TripSummaryScreen.tsx
+++ b/TravelCostApp/screens/TripSummaryScreen.tsx
@@ -9,9 +9,14 @@ import {
   Pressable,
   ScrollView,
 } from "react-native";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
 import { UserContext } from "../store/user-context";
 import { fetchTripName } from "../util/http";
+import {
+  patchActiveTripNameInList,
+  type TripSummaryListItem,
+} from "../util/trip-summary-cache";
 import LoadingBarOverlay from "../components/UI/LoadingBarOverlay";
 import { Checkbox } from "react-native-paper";
 import { daysBetween, isToday } from "../util/date";
@@ -50,11 +55,7 @@ import { Platform } from "react-native";
 import { safelyParseJSON } from "../util/jsonParse";
 import * as Haptics from "expo-haptics";
 
-export type TripAsObject = {
-  tripid: string;
-  tripname: string;
-  selected: boolean;
-};
+export type TripAsObject = TripSummaryListItem;
 export type TravellerAndCost = {
   traveller: string;
   cost: number;
@@ -100,47 +101,62 @@ const TripSummaryScreen = ({ navigation }) => {
   const subtitleText = `(${tripSummary?.numberOfTrips + " " + titleTextTrips})`;
   const numberOfDaysIsANumber =
     tripSummary?.numberOfDays && !isNaN(tripSummary.numberOfDays);
-  useEffect(() => {
-    async function asyncSetAllTrips() {
-      if (!userCtx.tripHistory) {
-        setIsFetching(false);
-        return;
-      }
-      setIsFetching(true);
-      const allTripsAsObjects: TripAsObject[] = [];
-      const lastUpdate = getMMKVString(
-        MMKV_KEYS.ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE
-      );
-      // check if lastUpdate is a iso string today
-      const lastUpdateWasToday = lastUpdate && isToday(new Date(lastUpdate));
-      if (lastUpdateWasToday) {
-        const allTrips = getMMKVObject(MMKV_KEYS.ALL_TRIPS_AS_OBJECT);
-        setAllTrips(allTrips);
-        setIsFetching(false);
-        return;
-      }
 
-      for (let i = 0; i < userCtx.tripHistory.length; i++) {
-        const tripid = userCtx.tripHistory[i];
-        const tripName = await fetchTripName(tripid);
-        allTripsAsObjects.push({
-          tripid: tripid,
-          tripname: tripName,
-          selected: true,
-        });
-      }
-      setAllTrips(allTripsAsObjects);
-      setMMKVObject(MMKV_KEYS.ALL_TRIPS_AS_OBJECT, allTripsAsObjects);
-      const allTripsISODate = new Date().toISOString();
-      setMMKVString(
-        MMKV_KEYS.ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE,
-        allTripsISODate
-      );
+  const loadAllTrips = useCallback(async () => {
+    if (!userCtx.tripHistory) {
       setIsFetching(false);
+      return;
     }
-    asyncSetAllTrips();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userCtx.tripHistory?.length]);
+    setIsFetching(true);
+    const allTripsAsObjects: TripAsObject[] = [];
+    const lastUpdate = getMMKVString(
+      MMKV_KEYS.ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE
+    );
+    const lastUpdateWasToday = lastUpdate && isToday(new Date(lastUpdate));
+    if (lastUpdateWasToday) {
+      const cachedTrips = getMMKVObject(
+        MMKV_KEYS.ALL_TRIPS_AS_OBJECT
+      ) as TripAsObject[] | null;
+      if (cachedTrips?.length) {
+        setAllTrips(
+          patchActiveTripNameInList(
+            cachedTrips,
+            tripCtx.tripid,
+            tripCtx.tripName
+          )
+        );
+        setIsFetching(false);
+        return;
+      }
+    }
+
+    for (let i = 0; i < userCtx.tripHistory.length; i++) {
+      const tripid = userCtx.tripHistory[i];
+      const tripName =
+        tripid === tripCtx.tripid && tripCtx.tripName?.trim()
+          ? tripCtx.tripName
+          : await fetchTripName(tripid);
+      allTripsAsObjects.push({
+        tripid: tripid,
+        tripname: tripName,
+        selected: true,
+      });
+    }
+    setAllTrips(allTripsAsObjects);
+    setMMKVObject(MMKV_KEYS.ALL_TRIPS_AS_OBJECT, allTripsAsObjects);
+    const allTripsISODate = new Date().toISOString();
+    setMMKVString(
+      MMKV_KEYS.ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE,
+      allTripsISODate
+    );
+    setIsFetching(false);
+  }, [tripCtx.tripName, tripCtx.tripid, userCtx.tripHistory]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadAllTrips();
+    }, [loadAllTrips])
+  );
 
   const summarizeHandler = async () => {
     setIsFetching(true);

--- a/TravelCostApp/util/trip-summary-cache.ts
+++ b/TravelCostApp/util/trip-summary-cache.ts
@@ -1,0 +1,44 @@
+import {
+  deleteMMKVObject,
+  getMMKVObject,
+  MMKV_KEYS,
+  setMMKVObject,
+} from "../store/mmkv";
+
+export type TripSummaryListItem = {
+  tripid: string;
+  tripname: string;
+  selected: boolean;
+};
+
+/** Drop cached trip names so Trip Summary refetches from the server. */
+export function invalidateAllTripsAsObjectCache() {
+  deleteMMKVObject(MMKV_KEYS.ALL_TRIPS_AS_OBJECT);
+  deleteMMKVObject(MMKV_KEYS.ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE);
+}
+
+/** Keep today's cache in sync after a rename without forcing a full refetch. */
+export function updateTripNameInAllTripsCache(tripid: string, tripname: string) {
+  const cached = getMMKVObject(
+    MMKV_KEYS.ALL_TRIPS_AS_OBJECT
+  ) as TripSummaryListItem[] | null;
+  if (!cached?.length) return;
+  const updated = cached.map((trip) =>
+    trip.tripid === tripid ? { ...trip, tripname } : trip
+  );
+  setMMKVObject(MMKV_KEYS.ALL_TRIPS_AS_OBJECT, updated);
+}
+
+/** Prefer in-memory Active trip name when the daily cache is stale. */
+export function patchActiveTripNameInList(
+  trips: TripSummaryListItem[],
+  activeTripId: string | undefined,
+  activeTripName: string | undefined
+): TripSummaryListItem[] {
+  if (!activeTripId || !activeTripName?.trim()) return trips;
+  return trips.map((trip) =>
+    trip.tripid === activeTripId
+      ? { ...trip, tripname: activeTripName }
+      : trip
+  );
+}

--- a/TravelCostApp/util/trip-summary-cache.ts
+++ b/TravelCostApp/util/trip-summary-cache.ts
@@ -1,21 +1,10 @@
-import {
-  deleteMMKVObject,
-  getMMKVObject,
-  MMKV_KEYS,
-  setMMKVObject,
-} from "../store/mmkv";
+import { getMMKVObject, MMKV_KEYS, setMMKVObject } from "../store/mmkv";
 
 export type TripSummaryListItem = {
   tripid: string;
   tripname: string;
   selected: boolean;
 };
-
-/** Drop cached trip names so Trip Summary refetches from the server. */
-export function invalidateAllTripsAsObjectCache() {
-  deleteMMKVObject(MMKV_KEYS.ALL_TRIPS_AS_OBJECT);
-  deleteMMKVObject(MMKV_KEYS.ALL_TRIPS_AS_OBJECT_CACHE_ISO_DATE);
-}
 
 /** Keep today's cache in sync after a rename without forcing a full refetch. */
 export function updateTripNameInAllTripsCache(tripid: string, tripname: string) {


### PR DESCRIPTION
## Summary
- Add `trip-summary-cache` helpers to patch renamed trips in the daily MMKV cache and prefer the in-memory Active trip name when the cache is stale
- Prevent `TripForm` from overwriting user input when a background `fetchTrip` completes after editing has started
- Move `asyncStoreSafeClear` before signup auth so the newly stored Firebase token is not immediately removed

## Test plan
- [ ] Rename an Active budget and confirm Trip Summary shows the new name without waiting for cache expiry
- [ ] Open Trip Form on an implicit default trip, type a name quickly, and confirm the name is not cleared when fetch completes
- [ ] Sign up a new account and confirm subsequent API calls succeed (token present after signup)
- [x] Unit tests: trip-form race, trip-summary cache patch, signup token after clear