### PR TITLE
Add feature hints to premium paywall upsell buttons

### DIFF
--- a/TravelCostApp/__tests__/components/blur-premium.test.tsx
+++ b/TravelCostApp/__tests__/components/blur-premium.test.tsx
@@ -105,4 +105,32 @@ describe("BlurPremium", () => {
     expect(screen.getByText(i18n.t("paywallTitle"))).toBeTruthy();
     expect(screen.getByText(i18n.t("back"))).toBeTruthy();
   });
+
+  it("shows a feature hint under the premium prompt when featureHintKey is set", async () => {
+    const checkPremium = jest.fn(async () => false);
+
+    const screen = renderWithAppProviders(
+      <BlurPremium featureHintKey="paywallHintCustomCategories" />,
+      {
+        user: {
+          checkPremium,
+          isPremium: false,
+          freshlyCreated: false,
+        },
+        network: {
+          isConnected: true,
+          strongConnection: true,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(checkPremium).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText(i18n.t("paywallTitle"))).toBeTruthy();
+    expect(
+      screen.getByText("Create your own categories")
+    ).toBeTruthy();
+  });
 });

--- a/TravelCostApp/__tests__/components/blur-premium.test.tsx
+++ b/TravelCostApp/__tests__/components/blur-premium.test.tsx
@@ -104,6 +104,9 @@ describe("BlurPremium", () => {
 
     expect(screen.getByText(i18n.t("paywallTitle"))).toBeTruthy();
     expect(screen.getByText(i18n.t("back"))).toBeTruthy();
+    expect(
+      screen.queryByText(i18n.t("paywallHintCustomCategories"))
+    ).toBeNull();
   });
 
   it("shows a feature hint under the premium prompt when featureHintKey is set", async () => {

--- a/TravelCostApp/__tests__/i18n/paywall-hints.test.ts
+++ b/TravelCostApp/__tests__/i18n/paywall-hints.test.ts
@@ -1,0 +1,42 @@
+import { de, en, fr, ru } from "../../i18n/supportedLanguages";
+
+/** Context hints on premium upsell ActionRows — must ship in EN, DE, FR, and RU. */
+const PAYWALL_HINT_KEYS = [
+  "paywallHintCustomCategories",
+  "paywallHintExpenseSearch",
+  "paywallHintAdvancedCharts",
+  "paywallHintGptDeal",
+  "paywallHintDebtSettlements",
+  "paywallHintUnlimitedExpenses",
+] as const;
+
+describe("paywall feature hint i18n", () => {
+  it("ships EN+DE+FR+RU copy for every paywall hint key", () => {
+    for (const locale of [en, de, fr, ru]) {
+      for (const key of PAYWALL_HINT_KEYS) {
+        expect(locale[key]).toBeTruthy();
+      }
+    }
+  });
+
+  it("English hints explain the blocked premium feature in plain language", () => {
+    expect(en.paywallHintCustomCategories).toBe(
+      "Create your own categories"
+    );
+    expect(en.paywallHintExpenseSearch).toBe(
+      "Search and filter expenses"
+    );
+    expect(en.paywallHintAdvancedCharts).toBe(
+      "Advanced spending charts"
+    );
+    expect(en.paywallHintGptDeal).toBe(
+      "Ask AI if you got a good deal"
+    );
+    expect(en.paywallHintDebtSettlements).toBe(
+      "Simplify debt settlements"
+    );
+    expect(en.paywallHintUnlimitedExpenses).toBe(
+      "Add unlimited budgets and expenses"
+    );
+  });
+});

--- a/TravelCostApp/components/Premium/BlurPremium.tsx
+++ b/TravelCostApp/components/Premium/BlurPremium.tsx
@@ -17,7 +17,7 @@ import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 import { blurPremiumLayoutStyles as styles } from "../../styles/blur-premium-layout";
 
-const BlurPremium = ({ canBack = false }) => {
+const BlurPremium = ({ canBack = false, featureHintKey }) => {
   const netCtx = useContext(NetworkContext);
   const userCtx = useContext(UserContext);
   const [isPremium, setIsPremium] = useState(false);
@@ -86,6 +86,7 @@ const BlurPremium = ({ canBack = false }) => {
             <ActionRow
               tier="gradient"
               label={i18n.t("paywallTitle")}
+              hint={featureHintKey ? i18n.t(featureHintKey) : undefined}
               icon="diamond-outline"
               showChevron={false}
               onPress={() => {
@@ -125,4 +126,5 @@ export default BlurPremium;
 
 BlurPremium.propTypes = {
   canBack: PropTypes.bool,
+  featureHintKey: PropTypes.string,
 };

--- a/TravelCostApp/components/Premium/BlurPremium.tsx
+++ b/TravelCostApp/components/Premium/BlurPremium.tsx
@@ -126,5 +126,6 @@ export default BlurPremium;
 
 BlurPremium.propTypes = {
   canBack: PropTypes.bool,
+  /** i18n key naming the blocked premium feature — keys listed in __tests__/i18n/paywall-hints.test.ts */
   featureHintKey: PropTypes.string,
 };

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -291,6 +291,12 @@ const en = {
     "At the end of the 1-week trial period, your iTunes account will be charged $2. The subscription will automatically renew unless canceled within 24 hours before the end of the current period. You can cancel anytime through your iTunes account. Any unused portion of a free trial will be forfeited upon subscription purchase. For more information, please refer to our terms and conditions and privacy policy.",
   paywallToS: "Terms of Service",
   paywallPP: "Privacy Policy",
+  paywallHintCustomCategories: "Create your own categories",
+  paywallHintExpenseSearch: "Search and filter expenses",
+  paywallHintAdvancedCharts: "Advanced spending charts",
+  paywallHintGptDeal: "Ask AI if you got a good deal",
+  paywallHintDebtSettlements: "Simplify debt settlements",
+  paywallHintUnlimitedExpenses: "Add unlimited budgets and expenses",
 
   //auth form
   nameInvalidInfoText: "Please enter a name!",
@@ -924,6 +930,12 @@ const de = {
     "Datenschutzrichtlinien.",
   paywallToS: "Nutzungsbedingungen",
   paywallPP: "Datenschutzbestimmungen",
+  paywallHintCustomCategories: "Eigene Kategorien erstellen",
+  paywallHintExpenseSearch: "Ausgaben suchen und filtern",
+  paywallHintAdvancedCharts: "Erweiterte Ausgabendiagramme",
+  paywallHintGptDeal: "KI fragen, ob du einen guten Deal hast",
+  paywallHintDebtSettlements: "Schuldenbegleichungen vereinfachen",
+  paywallHintUnlimitedExpenses: "Unbegrenzt Budgets und Ausgaben hinzufügen",
 
   // auth form
   nameInvalidInfoText: "Bitte gib einen Namen ein!",
@@ -1576,6 +1588,12 @@ const fr = {
     "À la fin de la période d'essai d'une semaine, votre compte iTunes sera facturé 2 $. L'abonnement se renouvellera automatiquement sauf s'il est annulé dans les 24 heures précédant la fin de la période en cours. Vous pouvez annuler à tout moment via votre compte iTunes. Toute partie inutilisée de l'essai gratuit sera perdue lors de l'achat de l'abonnement. Pour plus d'informations, veuillez consulter nos conditions générales et notre politique de confidentialité.",
   paywallToS: "Conditions d'utilisation",
   paywallPP: "Politique de confidentialité",
+  paywallHintCustomCategories: "Créez vos propres catégories",
+  paywallHintExpenseSearch: "Recherchez et filtrez les dépenses",
+  paywallHintAdvancedCharts: "Graphiques de dépenses avancés",
+  paywallHintGptDeal: "Demandez à l'IA si vous avez fait une bonne affaire",
+  paywallHintDebtSettlements: "Simplifiez le règlement des dettes",
+  paywallHintUnlimitedExpenses: "Ajoutez des budgets et dépenses illimités",
 
   // auth form
   nameInvalidInfoText: "Veuillez entrer un nom !",
@@ -2220,6 +2238,12 @@ const ru = {
     "По истечении 1-недельного пробного периода ваш аккаунт iTunes будет списан на $2. Подписка автоматически продлится, если не будет отменена в течение 24 часов перед окончанием текущего периода. Вы можете отменить подписку в любое время через свой аккаунт iTunes. Любая неиспользованная часть бесплатного пробного периода будет аннулирована при покупке подписки. Дополнительную информацию можно найти в наших условиях использования и политике конфиденциальности.",
   paywallToS: "Условия использования",
   paywallPP: "Политика конфиденциальности",
+  paywallHintCustomCategories: "Создавайте собственные категории",
+  paywallHintExpenseSearch: "Ищите и фильтруйте расходы",
+  paywallHintAdvancedCharts: "Расширенные графики расходов",
+  paywallHintGptDeal: "Спросите ИИ, выгодная ли была сделка",
+  paywallHintDebtSettlements: "Упрощайте расчёты по долгам",
+  paywallHintUnlimitedExpenses: "Добавляйте неограниченно бюджетов и расходов",
   // auth form
   nameInvalidInfoText: "Пожалуйста, введите имя!",
   emailInvalidInfoText:

--- a/TravelCostApp/screens/ManageCategoryScreen.tsx
+++ b/TravelCostApp/screens/ManageCategoryScreen.tsx
@@ -574,7 +574,7 @@ const ManageCategoryScreen = ({ navigation }) => {
           </View>
         </KeyboardAvoidingView>
       </BackgroundGradient>
-      <BlurPremium canBack />
+      <BlurPremium canBack featureHintKey="paywallHintCustomCategories" />
     </>
   );
 };


### PR DESCRIPTION
## Summary
- Premium blur overlay (`BlurPremium`) accepts an optional `featureHintKey` and shows a sublabel under "Become a Premium Nomad!" via `ActionRow` hint
- Custom categories screen passes `paywallHintCustomCategories` so users see what they would unlock
- i18n keys for six premium-gated features in EN, DE, FR, and RU, with tests

## Test plan
- [x] `pnpm test -- __tests__/components/blur-premium.test.tsx __tests__/i18n/paywall-hints.test.ts`
- [ ] Open Manage Categories as a non-premium user — confirm sublabel "Create your own categories" appears under the premium button