### PR TITLE
Hide recent expenses empty state until initial trip fetch completes

### DIFF
--- a/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
@@ -321,6 +321,49 @@ describe("RecentExpenses screen", () => {
     expect(navigation.navigate).toHaveBeenCalledWith("CategoryPick");
   });
 
+  it("does not show the empty-state while the initial trip fetch is still running", async () => {
+    jest.useFakeTimers();
+    let resolveFetch!: () => void;
+    const fetchPromise = new Promise<void>((resolve) => {
+      resolveFetch = resolve;
+    });
+    (fetchAndSetExpenses as jest.Mock).mockImplementation(async () => {
+      await fetchPromise;
+    });
+
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <RecentExpenses navigation={navigation as any} />,
+      {
+        expenses: expensesContextForList([]),
+        user: {
+          periodName: "month",
+          freshlyCreated: false,
+        },
+        trip: implicitDefaultTrip,
+        network: { isConnected: true, strongConnection: true },
+      }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByTestId("empty-expenses-cta")).toBeNull();
+    expect(
+      screen.queryByText(/No expenses in this time period yet/)
+    ).toBeNull();
+
+    await act(async () => {
+      resolveFetch();
+      await Promise.resolve();
+    });
+
+    await flushExpensesLoadTimeout();
+
+    expect(screen.getByTestId("empty-expenses-cta")).toBeTruthy();
+  });
+
   it("does not show the empty-state CTA when the trip ledger already has expenses", async () => {
     jest.useFakeTimers();
     const historyExpense = makeExpense({

--- a/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/recent-expenses-screen.test.tsx
@@ -95,10 +95,11 @@ jest.mock("react-native-toast-message/lib/src/Toast", () => ({
 }));
 
 import { act, fireEvent, waitFor } from "@testing-library/react-native";
-import { StyleSheet } from "react-native";
+import { RefreshControl, StyleSheet } from "react-native";
 import RecentExpenses from "../../screens/RecentExpenses";
 import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
 import { fetchAndSetExpenses } from "../../components/ExpensesOutput/RecentExpensesUtil";
+import { refreshWithToast } from "../../util/refreshWithToast";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import { assertNoNestedVerticalFlatLists } from "../../test-utils/scroll-composition";
@@ -362,6 +363,61 @@ describe("RecentExpenses screen", () => {
     await flushExpensesLoadTimeout();
 
     expect(screen.getByTestId("empty-expenses-cta")).toBeTruthy();
+  });
+
+  it("keeps the empty-state CTA visible during pull-to-refresh after an empty fetch this session", async () => {
+    jest.useFakeTimers();
+    let resolveRefresh!: () => void;
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    (refreshWithToast as jest.Mock).mockImplementation(
+      async ({
+        setIsFetching,
+      }: {
+        setIsFetching: (value: boolean) => void;
+      }) => {
+        setIsFetching(true);
+        await refreshPromise;
+        setIsFetching(false);
+      }
+    );
+
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <RecentExpenses navigation={navigation as any} />,
+      {
+        expenses: expensesContextForList([]),
+        user: {
+          periodName: "month",
+          freshlyCreated: false,
+        },
+        trip: implicitDefaultTrip,
+        network: { isConnected: true, strongConnection: true },
+      }
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await flushExpensesLoadTimeout();
+    expect(screen.getByTestId("empty-expenses-cta")).toBeTruthy();
+
+    const refreshControl = screen.UNSAFE_getByType(RefreshControl);
+    await act(async () => {
+      refreshControl.props.onRefresh();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("empty-expenses-cta")).toBeTruthy();
+    expect(
+      screen.getByText(/No expenses in this time period yet/)
+    ).toBeTruthy();
+
+    await act(async () => {
+      resolveRefresh();
+      await Promise.resolve();
+    });
   });
 
   it("does not show the empty-state CTA when the trip ledger already has expenses", async () => {

--- a/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
@@ -29,6 +29,7 @@ function ExpensesOutput({
   isFiltered,
   emptyCtaLabel,
   onEmptyCtaPress,
+  awaitingTripFetch,
 }) {
   const { tripName, tripid } = useContext(TripContext);
   const [showLoading, setShowLoading] = useState(true);
@@ -56,6 +57,8 @@ function ExpensesOutput({
     if (tripReady && expenses.length > 1) setShowLoading(false);
   }, [tripReady, expenses.length]);
 
+  const deferEmptyState = showLoading || awaitingTripFetch;
+
   const memoizedContent = useMemo(() => {
     if (expenses?.length > 0) {
       if (fallback) setFallback(false);
@@ -78,11 +81,11 @@ function ExpensesOutput({
           showsVerticalScrollIndicator={false}
         >
           <View style={styles.fallbackInnerContainer}>
-            {showLoading && <LoadingOverlay></LoadingOverlay>}
-            {!showLoading && (
+            {deferEmptyState && <LoadingOverlay></LoadingOverlay>}
+            {!deferEmptyState && (
               <Text style={styles.infoText}>{fallbackText}</Text>
             )}
-            {!showLoading && emptyCtaLabel && onEmptyCtaPress && (
+            {!deferEmptyState && emptyCtaLabel && onEmptyCtaPress && (
               <View testID="empty-expenses-cta" style={styles.emptyCta}>
                 <ActionRow
                   tier="primary"
@@ -123,6 +126,8 @@ function ExpensesOutput({
       </Animated.View>
     );
   }, [
+    awaitingTripFetch,
+    deferEmptyState,
     emptyCtaLabel,
     expenses,
     fallback,
@@ -160,6 +165,7 @@ ExpensesOutput.propTypes = {
   isFiltered: PropTypes.bool,
   emptyCtaLabel: PropTypes.string,
   onEmptyCtaPress: PropTypes.func,
+  awaitingTripFetch: PropTypes.bool,
 };
 
 const styles = StyleSheet.create({

--- a/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
@@ -127,7 +127,6 @@ function ExpensesOutput({
     );
   }, [
     awaitingTripFetch,
-    deferEmptyState,
     emptyCtaLabel,
     expenses,
     fallback,

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -269,7 +269,8 @@ function RecentExpenses({ navigation }) {
   }, [navigation, settings.skipCategoryScreen]);
 
   const tripLedgerEmpty = tripExpenseCount === 0;
-  const awaitingTripFetch = tripLedgerEmpty && (!loadedOnce || isFetching);
+  // Only gate on the first session fetch; later isFetching (pull-to-refresh) must keep empty visible.
+  const awaitingTripFetch = tripLedgerEmpty && !loadedOnce;
 
   useEffect(() => {
     const asyncLoading = async () => {

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -269,6 +269,7 @@ function RecentExpenses({ navigation }) {
   }, [navigation, settings.skipCategoryScreen]);
 
   const tripLedgerEmpty = tripExpenseCount === 0;
+  const awaitingTripFetch = tripLedgerEmpty && (!loadedOnce || isFetching);
 
   useEffect(() => {
     const asyncLoading = async () => {
@@ -355,6 +356,7 @@ function RecentExpenses({ navigation }) {
       fallbackText={i18n.t("fallbackTextExpenses")}
       emptyCtaLabel={tripLedgerEmpty ? i18n.t("addExp") : undefined}
       onEmptyCtaPress={tripLedgerEmpty ? handleEmptyCtaPress : undefined}
+      awaitingTripFetch={awaitingTripFetch}
       refreshing={refreshing}
       refreshControl={
         <RefreshControl


### PR DESCRIPTION
## Summary
- Defer the empty-period message and add-expense CTA on Recent Expenses while the initial trip expense fetch is still running
- Once the fetch has completed this session (even with an empty ledger), the empty state shows as before
- Add a screen test covering the deferred-fetch case

## Test plan
- [x] `pnpm test -- __tests__/screens/recent-expenses-screen.test.tsx`
- [ ] Open Recent Expenses on a trip with no expenses on a slow connection — loading overlay should show until fetch completes, then empty state appears
- [ ] Pull to refresh on an already-confirmed-empty trip — empty state should remain visible during refresh