### PR TITLE
Include day span and sum in ranged local-price deal prompts

### DIFF
--- a/TravelCostApp/__tests__/util/expense-form-local-price-hint.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-local-price-hint.test.ts
@@ -88,6 +88,20 @@ describe("expenseFormLocalPriceHint", () => {
       })
     ).toBe('Is 80 EUR a good deal for "hotel" in Spain?');
   });
+
+  it("omits day span when ranged mode is not chosen yet", () => {
+    expect(
+      expenseFormLocalPriceHint({
+        product: "hotel",
+        country: "Spain",
+        price: "240",
+        currency: "EUR",
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.null,
+        alreadyDividedAmountByDays: false,
+      })
+    ).toBe('Is 240 EUR a good deal for "hotel" in Spain?');
+  });
 });
 
 describe("localPriceDealAmountPhrase", () => {
@@ -101,5 +115,17 @@ describe("localPriceDealAmountPhrase", () => {
         alreadyDividedAmountByDays: false,
       })
     ).toBe("80 EUR over 3 days (sum 240 EUR)");
+  });
+
+  it("uses plain amount when ranged mode is not chosen yet", () => {
+    expect(
+      localPriceDealAmountPhrase({
+        price: "240",
+        currency: "EUR",
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.null,
+        alreadyDividedAmountByDays: false,
+      })
+    ).toBe("240 EUR");
   });
 });

--- a/TravelCostApp/__tests__/util/expense-form-local-price-hint.test.ts
+++ b/TravelCostApp/__tests__/util/expense-form-local-price-hint.test.ts
@@ -1,4 +1,5 @@
-import { expenseFormLocalPriceHint } from "../../util/expense-form-local-price-hint";
+import { expenseFormLocalPriceHint, localPriceDealAmountPhrase } from "../../util/expense-form-local-price-hint";
+import { DuplicateOption } from "../../util/expense";
 import { i18n } from "../../i18n/i18n";
 
 describe("expenseFormLocalPriceHint", () => {
@@ -24,5 +25,81 @@ describe("expenseFormLocalPriceHint", () => {
         currency: "EUR",
       })
     ).toBe('Is 25 EUR a good deal for "Coworking" in Portugal?');
+  });
+
+  it("includes per-day amount, day count, and sum for a ranged duplicate", () => {
+    expect(
+      expenseFormLocalPriceHint({
+        product: "hotel",
+        country: "Spain",
+        price: "80",
+        currency: "EUR",
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.duplicate,
+        alreadyDividedAmountByDays: false,
+      })
+    ).toBe(
+      'Is 80 EUR over 3 days (sum 240 EUR) a good deal for "hotel" in Spain?'
+    );
+  });
+
+  it("uses per-day amount when ranged-split field still holds the total", () => {
+    expect(
+      expenseFormLocalPriceHint({
+        product: "hotel",
+        country: "Spain",
+        price: "240",
+        currency: "EUR",
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.split,
+        alreadyDividedAmountByDays: false,
+      })
+    ).toBe(
+      'Is 80 EUR over 3 days (sum 240 EUR) a good deal for "hotel" in Spain?'
+    );
+  });
+
+  it("keeps per-day amount when editing an already-divided ranged split", () => {
+    expect(
+      expenseFormLocalPriceHint({
+        product: "hotel",
+        country: "Spain",
+        price: "80",
+        currency: "EUR",
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.split,
+        alreadyDividedAmountByDays: true,
+      })
+    ).toBe(
+      'Is 80 EUR over 3 days (sum 240 EUR) a good deal for "hotel" in Spain?'
+    );
+  });
+
+  it("omits day span when the expense is a single day", () => {
+    expect(
+      expenseFormLocalPriceHint({
+        product: "hotel",
+        country: "Spain",
+        price: "80",
+        currency: "EUR",
+        inclusiveDayCount: 1,
+        duplOrSplit: DuplicateOption.duplicate,
+        alreadyDividedAmountByDays: false,
+      })
+    ).toBe('Is 80 EUR a good deal for "hotel" in Spain?');
+  });
+});
+
+describe("localPriceDealAmountPhrase", () => {
+  it("formats per-day amount with day count and sum for GPT prompts", () => {
+    expect(
+      localPriceDealAmountPhrase({
+        price: "80",
+        currency: "EUR",
+        inclusiveDayCount: 3,
+        duplOrSplit: DuplicateOption.duplicate,
+        alreadyDividedAmountByDays: false,
+      })
+    ).toBe("80 EUR over 3 days (sum 240 EUR)");
   });
 });

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -1193,6 +1193,9 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       currency: inputs.currency.value,
       country: inputs.country.value,
       product: inputs.description.value,
+      inclusiveDayCount: daysBeween || 1,
+      duplOrSplit,
+      alreadyDividedAmountByDays,
     });
   };
 
@@ -1203,12 +1206,18 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
         country: inputs.country.value,
         price: amountValue,
         currency: inputs.currency.value,
+        inclusiveDayCount: daysBeween || 1,
+        duplOrSplit,
+        alreadyDividedAmountByDays,
       }),
     [
       inputs.description.value,
       inputs.country.value,
       inputs.currency.value,
       amountValue,
+      daysBeween,
+      duplOrSplit,
+      alreadyDividedAmountByDays,
     ]
   );
 

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -2275,7 +2275,7 @@ const ru = {
   getLocalPriceExpenseDealHint:
     'Хорошая ли сделка — %{price} %{currency} за «%{product}» в %{country}?',
   getLocalPriceExpenseDealHintRanged:
-    'Хорошая ли сделка — %{price} %{currency} за %{days} дн. (сумма %{sum} %{currency}) за «%{product}» в %{country}?',
+    'Хорошая ли сделка — %{price} %{currency} за %{days} дн. (сумма %{sum} %{currency}) для «%{product}» в %{country}?',
   gettingLocalPrice: "Получение информации о местных ценах...",
   day: "День",
   week: "Неделя",

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -323,6 +323,8 @@ const en = {
     'Get local price for "%{product}" in %{country}',
   getLocalPriceExpenseDealHint:
     'Is %{price} %{currency} a good deal for "%{product}" in %{country}?',
+  getLocalPriceExpenseDealHintRanged:
+    'Is %{price} %{currency} over %{days} days (sum %{sum} %{currency}) a good deal for "%{product}" in %{country}?',
   gettingLocalPrice: "Getting local price information...",
   day: "Day",
   week: "Week",
@@ -963,6 +965,8 @@ const de = {
     'Lokalen Preis für „%{product}“ in %{country} ermitteln',
   getLocalPriceExpenseDealHint:
     'Ist %{price} %{currency} ein gutes Angebot für „%{product}“ in %{country}?',
+  getLocalPriceExpenseDealHintRanged:
+    'Ist %{price} %{currency} über %{days} Tage (Summe %{sum} %{currency}) ein gutes Angebot für „%{product}“ in %{country}?',
   gettingLocalPrice: "Lokale Preisinformationen werden abgerufen...",
   day: "Tag",
   week: "Woche",
@@ -1622,6 +1626,8 @@ const fr = {
     'Obtenir le prix local pour « %{product} » en %{country}',
   getLocalPriceExpenseDealHint:
     'Est-ce que %{price} %{currency} est une bonne affaire pour « %{product} » en %{country} ?',
+  getLocalPriceExpenseDealHintRanged:
+    'Est-ce que %{price} %{currency} sur %{days} jours (somme %{sum} %{currency}) est une bonne affaire pour « %{product} » en %{country} ?',
   gettingLocalPrice: "Obtention des informations sur les prix locaux...",
   day: "Jour",
   week: "Semaine",
@@ -2268,6 +2274,8 @@ const ru = {
     'Узнать местную цену для «%{product}» в %{country}',
   getLocalPriceExpenseDealHint:
     'Хорошая ли сделка — %{price} %{currency} за «%{product}» в %{country}?',
+  getLocalPriceExpenseDealHintRanged:
+    'Хорошая ли сделка — %{price} %{currency} за %{days} дн. (сумма %{sum} %{currency}) за «%{product}» в %{country}?',
   gettingLocalPrice: "Получение информации о местных ценах...",
   day: "День",
   week: "Неделя",

--- a/TravelCostApp/screens/ChatGPTDealScreen.tsx
+++ b/TravelCostApp/screens/ChatGPTDealScreen.tsx
@@ -20,6 +20,7 @@ import {
   GPT_getGoodDeal,
   GPT_getPrice,
 } from "../util/chatGPTrequest";
+import { expenseFormLocalPriceHint } from "../util/expense-form-local-price-hint";
 import { GlobalStyles } from "../constants/styles";
 import { Image } from "react-native";
 import InfoButton from "../components/UI/InfoButton";
@@ -30,7 +31,15 @@ import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
 
 const GPTDealScreen = ({ route, navigation }) => {
-  const { price, currency, country, product } = route.params;
+  const {
+    price,
+    currency,
+    country,
+    product,
+    inclusiveDayCount = 1,
+    duplOrSplit = 0,
+    alreadyDividedAmountByDays = false,
+  } = route.params;
 
   const markdownStyles: MarkdownProps["style"] = {
     body: {
@@ -166,6 +175,9 @@ const GPTDealScreen = ({ route, navigation }) => {
           price: price,
           currency: currency,
           country: country,
+          inclusiveDayCount,
+          duplOrSplit,
+          alreadyDividedAmountByDays,
         };
 
         const response = await getChatGPT_Response(goodDeal, setLoadingPhase);
@@ -203,7 +215,16 @@ const GPTDealScreen = ({ route, navigation }) => {
       return;
     }
     getGPT_Response();
-  }, [country, currency, price, product, answer]);
+  }, [
+    country,
+    currency,
+    price,
+    product,
+    answer,
+    inclusiveDayCount,
+    duplOrSplit,
+    alreadyDividedAmountByDays,
+  ]);
 
   const startStreaming = (content) => {
     // Split content into chapters/sections by double newlines
@@ -243,6 +264,9 @@ const GPTDealScreen = ({ route, navigation }) => {
         price: price,
         currency: currency,
         country: country,
+        inclusiveDayCount,
+        duplOrSplit,
+        alreadyDividedAmountByDays,
       };
 
       const response = await getChatGPT_Response(goodDeal, setLoadingPhase);
@@ -291,9 +315,15 @@ const GPTDealScreen = ({ route, navigation }) => {
             <View style={styles.userBubbleContainer}>
               <View style={[styles.userBubble, GlobalStyles.shadowGlowPrimary]}>
                 <Text style={styles.userBubbleText}>
-                  {price && price !== "" && !isNaN(Number(price))
-                    ? `Is ${price} ${currency} a good deal for "${product.trim()}" in ${country}?`
-                    : `Get local price for "${product.trim()}" in ${country}`}
+                  {expenseFormLocalPriceHint({
+                    product,
+                    country,
+                    price,
+                    currency,
+                    inclusiveDayCount,
+                    duplOrSplit,
+                    alreadyDividedAmountByDays,
+                  })}
                 </Text>
               </View>
             </View>

--- a/TravelCostApp/util/chatGPTrequest.ts
+++ b/TravelCostApp/util/chatGPTrequest.ts
@@ -8,6 +8,7 @@ const languageName = languageObj?.name;
 import axios from "axios";
 import { Keys, loadKeys } from "../components/Premium/PremiumConstants";
 import safeLogError from "./error";
+import { localPriceDealAmountPhrase } from "./expense-form-local-price-hint";
 
 // Function to get current date in a readable format
 function getCurrentDateString(): string {
@@ -139,6 +140,9 @@ export interface GPT_getGoodDeal extends GPT_RequestBody {
   price: string;
   currency: string;
   country: string;
+  inclusiveDayCount?: number;
+  duplOrSplit?: number;
+  alreadyDividedAmountByDays?: boolean;
 }
 export interface GPT_getPrice extends GPT_RequestBody {
   requestType: GPT_RequestType.getPrice;
@@ -169,7 +173,10 @@ async function chatGPTcontentGoodDealPost(
   price: string,
   currency: string,
   country: string,
-  onLoadingPhaseChange?: (phase: string) => void
+  onLoadingPhaseChange?: (phase: string) => void,
+  inclusiveDayCount = 1,
+  duplOrSplit = 0,
+  alreadyDividedAmountByDays = false
 ): Promise<string> {
   const currentDate = getCurrentDateString();
   const { seasonalInfo, pricingInfo } = await performComprehensiveWebSearch(
@@ -179,7 +186,15 @@ async function chatGPTcontentGoodDealPost(
     onLoadingPhaseChange
   );
 
-  return `Analyze this local price: Is ${price} ${currency} a good deal for the product "${product}" in ${country}?
+  const amountPhrase = localPriceDealAmountPhrase({
+    price,
+    currency,
+    inclusiveDayCount,
+    duplOrSplit,
+    alreadyDividedAmountByDays,
+  });
+
+  return `Analyze this local price: Is ${amountPhrase} a good deal for the product "${product}" in ${country}?
 
 **Current Seasonal Context:** ${seasonalInfo}
 
@@ -197,11 +212,11 @@ IF "${product}" is not recognized as a typical product or service:
 - Provide a brief, witty response commenting humorously on the unusual item.
 
 IF "${product}" is recognized:
-**Price Analysis:** Based on the current market data above, compare ${price} ${currency} to current local market prices for "${product}" in ${country}.
+**Price Analysis:** Based on the current market data above, compare ${amountPhrase} to current local market prices for "${product}" in ${country}.
 \n\n
 
 **Seasonal Impact:** Explain how the current season in ${country} affects pricing for this type of product.
-\n Explain whether this influences the value of ${price} ${currency}.
+\n Explain whether this influences the value of ${amountPhrase}.
 \n\n
 
 **Actionable Advice:** Recommend next steps or purchasing tips based on the comprehensive analysis (e.g., good deal, worth waiting for discounts, overpriced). Consider both current market prices and seasonal timing in your recommendations.
@@ -263,7 +278,10 @@ async function getGPT_Content(
         (requestBody as GPT_getGoodDeal).price,
         (requestBody as GPT_getGoodDeal).currency,
         (requestBody as GPT_getGoodDeal).country,
-        onLoadingPhaseChange
+        onLoadingPhaseChange,
+        (requestBody as GPT_getGoodDeal).inclusiveDayCount,
+        (requestBody as GPT_getGoodDeal).duplOrSplit,
+        (requestBody as GPT_getGoodDeal).alreadyDividedAmountByDays
       );
     case GPT_RequestType.getKeywords:
       return chatGPTcontentKeywords(

--- a/TravelCostApp/util/expense-form-local-price-hint.ts
+++ b/TravelCostApp/util/expense-form-local-price-hint.ts
@@ -1,11 +1,85 @@
 import { i18n } from "../i18n/i18n";
+import { DuplicateOption } from "./expense";
+import {
+  divideAmountForRangedSplit,
+  multiplyAmountForRangedDuplicate,
+} from "./expense-form-range";
 
 type ExpenseFormLocalPriceHintParams = {
   product: string;
   country: string;
   price?: string;
   currency?: string;
+  inclusiveDayCount?: number;
+  duplOrSplit?: DuplicateOption | number;
+  alreadyDividedAmountByDays?: boolean;
 };
+
+function formatDealAmount(amount: number): string {
+  return Number.isInteger(amount) ? String(amount) : amount.toFixed(2);
+}
+
+/** Per-day rate and span total for a ranged local-price deal prompt. */
+export function resolveLocalPriceDealPerDayAndSum(input: {
+  amount: number;
+  inclusiveDayCount: number;
+  duplOrSplit?: DuplicateOption | number;
+  alreadyDividedAmountByDays?: boolean;
+}): { perDay: number; sum: number } | null {
+  if (input.inclusiveDayCount <= 1) return null;
+
+  const isUndividedSplit =
+    Number(input.duplOrSplit) === DuplicateOption.split &&
+    !input.alreadyDividedAmountByDays;
+
+  if (isUndividedSplit) {
+    return {
+      perDay: Number(
+        divideAmountForRangedSplit(
+          input.amount,
+          input.inclusiveDayCount
+        ).toFixed(2)
+      ),
+      sum: input.amount,
+    };
+  }
+
+  return {
+    perDay: input.amount,
+    sum: multiplyAmountForRangedDuplicate(
+      input.amount,
+      input.inclusiveDayCount
+    ),
+  };
+}
+
+type LocalPriceDealAmountPhraseParams = {
+  price: string;
+  currency: string;
+  inclusiveDayCount?: number;
+  duplOrSplit?: DuplicateOption | number;
+  alreadyDividedAmountByDays?: boolean;
+};
+
+/** English amount clause for GPT prompts (and shared math with the UI hint). */
+export function localPriceDealAmountPhrase({
+  price,
+  currency,
+  inclusiveDayCount = 1,
+  duplOrSplit = DuplicateOption.null,
+  alreadyDividedAmountByDays = false,
+}: LocalPriceDealAmountPhraseParams): string {
+  const ranged = resolveLocalPriceDealPerDayAndSum({
+    amount: Number(price),
+    inclusiveDayCount,
+    duplOrSplit,
+    alreadyDividedAmountByDays,
+  });
+  if (ranged) {
+    return `${formatDealAmount(ranged.perDay)} ${currency} over ${inclusiveDayCount} days (sum ${formatDealAmount(ranged.sum)} ${currency})`;
+  }
+  return `${price} ${currency}`;
+}
 
 /** Contextual ActionRow hint for the expense form "Get local price" row. */
 export function expenseFormLocalPriceHint({
@@ -13,12 +87,32 @@ export function expenseFormLocalPriceHint({
   country,
   price,
   currency,
+  inclusiveDayCount = 1,
+  duplOrSplit = DuplicateOption.null,
+  alreadyDividedAmountByDays = false,
 }: ExpenseFormLocalPriceHintParams): string {
   const trimmedProduct = product.trim();
   if (price && price !== "" && !Number.isNaN(Number(price))) {
+    const currencyLabel = currency ?? "";
+    const ranged = resolveLocalPriceDealPerDayAndSum({
+      amount: Number(price),
+      inclusiveDayCount,
+      duplOrSplit,
+      alreadyDividedAmountByDays,
+    });
+    if (ranged) {
+      return i18n.t("getLocalPriceExpenseDealHintRanged", {
+        price: formatDealAmount(ranged.perDay),
+        currency: currencyLabel,
+        days: inclusiveDayCount,
+        sum: formatDealAmount(ranged.sum),
+        product: trimmedProduct,
+        country,
+      });
+    }
     return i18n.t("getLocalPriceExpenseDealHint", {
       price,
-      currency: currency ?? "",
+      currency: currencyLabel,
       product: trimmedProduct,
       country,
     });

--- a/TravelCostApp/util/expense-form-local-price-hint.ts
+++ b/TravelCostApp/util/expense-form-local-price-hint.ts
@@ -28,9 +28,16 @@ export function resolveLocalPriceDealPerDayAndSum(input: {
 }): { perDay: number; sum: number } | null {
   if (input.inclusiveDayCount <= 1) return null;
 
+  const mode = Number(input.duplOrSplit ?? DuplicateOption.null);
+  if (
+    mode !== DuplicateOption.duplicate &&
+    mode !== DuplicateOption.split
+  ) {
+    return null;
+  }
+
   const isUndividedSplit =
-    Number(input.duplOrSplit) === DuplicateOption.split &&
-    !input.alreadyDividedAmountByDays;
+    mode === DuplicateOption.split && !input.alreadyDividedAmountByDays;
 
   if (isUndividedSplit) {
     return {


### PR DESCRIPTION
## Summary
- Ranged expense “good deal” prompts now include per-day amount, day count, and span sum (e.g. `80 EUR over 3 days (sum 240 EUR)`).
- Adjusts for ranged split vs duplicate so the prompt always states the per-day rate and total sum.
- Updates ActionRow hint, GPTDeal chat bubble, and GPT request content (EN/DE/FR/RU).

## Test plan
- [ ] Add a ranged duplicate hotel (80/day × 3 days) → Get local price hint and GPT bubble show per-day + days + sum
- [ ] Add a ranged split with total still in the amount field → same phrase uses derived per-day
- [ ] Edit already-divided ranged split → per-day kept, sum = per-day × days
- [ ] Single-day expense → hint unchanged (no day span)
- [ ] `pnpm test -- __tests__/util/expense-form-local-price-hint.test.ts`