### PR TITLE
Hide Ask AI buttons behind Settings toggle

### DIFF
--- a/TravelCostApp/__tests__/components/form-action-row-footers.test.tsx
+++ b/TravelCostApp/__tests__/components/form-action-row-footers.test.tsx
@@ -237,6 +237,43 @@ describe("form ActionRow footers", () => {
       expect(rowShowsChevron(screen, "expense-form-cancel")).toBe(false);
     });
 
+    it("hides local price row when Ask AI for good prices is off", () => {
+      const screen = renderWithAppProviders(
+        <ExpenseForm
+          onCancel={jest.fn()}
+          onSubmit={jest.fn(async () => {})}
+          submitButtonLabel={i18n.t("update")}
+          isEditing
+          defaultValues={makeExpense({
+            amount: 0,
+            description: "Coffee",
+            country: "Germany",
+            currency: "EUR",
+            whoPaid: "Alice",
+            splitList: [{ userName: "Alice", amount: 0 }],
+          })}
+          pickedCat="food"
+          navigation={navigation as any}
+          editedExpenseId="e1"
+          newCat={false}
+          iconName="food"
+          dateISO=""
+        />,
+        {
+          trip: {
+            tripid: "t1",
+            tripCurrency: "EUR",
+            travellers: [{ uid: "u1", userName: "Alice" }],
+            fetchAndSetTravellers: jest.fn(async () => {}),
+          },
+          user: { userName: "Alice", lastCurrency: "EUR", lastCountry: "DE" },
+          settings: { settings: { askAiForGoodPrices: false } },
+        }
+      );
+
+      expect(screen.queryByTestId("expense-form-get-local-price")).toBeNull();
+    });
+
     it("shows contextual local price hint when product and country are set", () => {
       const screen = renderWithAppProviders(
         <ExpenseForm
@@ -267,6 +304,7 @@ describe("form ActionRow footers", () => {
             fetchAndSetTravellers: jest.fn(async () => {}),
           },
           user: { userName: "Alice", lastCurrency: "EUR", lastCountry: "DE" },
+          settings: { settings: { askAiForGoodPrices: true } },
         }
       );
 

--- a/TravelCostApp/__tests__/components/get-local-price-button.test.tsx
+++ b/TravelCostApp/__tests__/components/get-local-price-button.test.tsx
@@ -23,10 +23,40 @@ describe("GetLocalPriceButton", () => {
     jest.mocked(Alert.alert).mockRestore();
   });
 
+  it("is hidden when Ask AI for good prices is off", () => {
+    const screen = renderWithAppProviders(
+      <GetLocalPriceButton navigation={navigation as any} />,
+      {
+        wrapNavigation: false,
+        network: { isConnected: true },
+        settings: { settings: { askAiForGoodPrices: false } },
+      },
+    );
+
+    expect(screen.queryByTestId("profile-get-local-price")).toBeNull();
+  });
+
+  it("is visible when Ask AI for good prices is on", () => {
+    const screen = renderWithAppProviders(
+      <GetLocalPriceButton navigation={navigation as any} />,
+      {
+        wrapNavigation: false,
+        network: { isConnected: true },
+        settings: { settings: { askAiForGoodPrices: true } },
+      },
+    );
+
+    expect(screen.getByTestId("profile-get-local-price")).toBeTruthy();
+  });
+
   it("shows no chevron on the profile trigger row that opens a modal", () => {
     const screen = renderWithAppProviders(
       <GetLocalPriceButton navigation={navigation as any} />,
-      { wrapNavigation: false, network: { isConnected: true } },
+      {
+        wrapNavigation: false,
+        network: { isConnected: true },
+        settings: { settings: { askAiForGoodPrices: true } },
+      },
     );
 
     expect(
@@ -39,7 +69,11 @@ describe("GetLocalPriceButton", () => {
   it("shows hint text on the profile Local Price row", () => {
     const screen = renderWithAppProviders(
       <GetLocalPriceButton navigation={navigation as any} />,
-      { wrapNavigation: false, network: { isConnected: true } },
+      {
+        wrapNavigation: false,
+        network: { isConnected: true },
+        settings: { settings: { askAiForGoodPrices: true } },
+      },
     );
 
     expect(
@@ -50,7 +84,11 @@ describe("GetLocalPriceButton", () => {
   it("hides chevrons on modal footer rows", () => {
     const screen = renderWithAppProviders(
       <GetLocalPriceButton navigation={navigation as any} />,
-      { wrapNavigation: false, network: { isConnected: true } },
+      {
+        wrapNavigation: false,
+        network: { isConnected: true },
+        settings: { settings: { askAiForGoodPrices: true } },
+      },
     );
 
     fireEvent.press(screen.getByTestId("profile-get-local-price"));

--- a/TravelCostApp/__tests__/components/settings-section-ask-ai.test.tsx
+++ b/TravelCostApp/__tests__/components/settings-section-ask-ai.test.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { fireEvent } from "@testing-library/react-native";
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import SettingsSection from "../../components/UI/SettingsSection";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+describe("SettingsSection ask AI setting", () => {
+  it("shows Ask AI for good prices switch when the setting is off", () => {
+    const screen = renderWithAppProviders(
+      <SettingsSection multiTraveller={false} />,
+      {
+        wrapNavigation: false,
+        settings: {
+          settings: { askAiForGoodPrices: false },
+          saveSettings: jest.fn(async () => {}),
+        },
+      },
+    );
+
+    expect(screen.getByText("Ask AI for good prices")).toBeTruthy();
+  });
+
+  it("persists Ask AI for good prices when toggled on", () => {
+    const saveSettings = jest.fn(async () => {});
+    const screen = renderWithAppProviders(
+      <SettingsSection multiTraveller={false} />,
+      {
+        wrapNavigation: false,
+        settings: {
+          settings: {
+            askAiForGoodPrices: false,
+            showFlags: true,
+            showWhoPaid: true,
+            alwaysShowAdvanced: false,
+            skipCategoryScreen: false,
+            showInternetSpeed: false,
+            hideSpecialExpenses: false,
+            disableNumberAnimations: false,
+            trafficLightBudgetColors: true,
+          },
+          saveSettings,
+        },
+      },
+    );
+
+    fireEvent.press(screen.getByText("Ask AI for good prices"));
+
+    expect(saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ askAiForGoodPrices: true }),
+    );
+  });
+});

--- a/TravelCostApp/__tests__/components/settings-section-ask-ai.test.tsx
+++ b/TravelCostApp/__tests__/components/settings-section-ask-ai.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { fireEvent } from "@testing-library/react-native";
+import { fireEvent, within } from "@testing-library/react-native";
 
 jest.mock("../../util/vexo-tracking", () => ({
   trackEvent: jest.fn(),
@@ -7,6 +7,21 @@ jest.mock("../../util/vexo-tracking", () => ({
 
 import SettingsSection from "../../components/UI/SettingsSection";
 import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function switchForLabel(
+  screen: ReturnType<typeof renderWithAppProviders>,
+  label: string,
+) {
+  let node: { parent?: unknown } | null = screen.getByText(label);
+  while (node) {
+    try {
+      return within(node as object).getByRole("switch");
+    } catch {
+      node = (node.parent as { parent?: unknown } | null) ?? null;
+    }
+  }
+  throw new Error(`No switch found for label: ${label}`);
+}
 
 describe("SettingsSection ask AI setting", () => {
   it("shows Ask AI for good prices switch when the setting is off", () => {
@@ -22,6 +37,9 @@ describe("SettingsSection ask AI setting", () => {
     );
 
     expect(screen.getByText("Ask AI for good prices")).toBeTruthy();
+    expect(switchForLabel(screen, "Ask AI for good prices").props.value).toBe(
+      false,
+    );
   });
 
   it("persists Ask AI for good prices when toggled on", () => {

--- a/TravelCostApp/__tests__/fixtures/app-providers.tsx
+++ b/TravelCostApp/__tests__/fixtures/app-providers.tsx
@@ -66,6 +66,7 @@ const defaultSettings = {
     showInternetSpeed: false,
     disableNumberAnimations: true,
     trafficLightBudgetColors: false,
+    askAiForGoodPrices: false,
   },
 };
 
@@ -79,11 +80,13 @@ export function AppProviders({
   const trip = { ...defaultTrip, ...overrides.trip };
   const user = { ...defaultUser, ...overrides.user };
   const expenses = { ...defaultExpenses, ...overrides.expenses };
-  const settings = {
+  const settingsContextValue = {
     settings: {
       ...defaultSettings.settings,
       ...(overrides.settings?.settings as object | undefined),
     },
+    saveSettings:
+      overrides.settings?.saveSettings ?? jest.fn(async () => {}),
   };
   const network = {
     isConnected: false,
@@ -116,7 +119,7 @@ export function AppProviders({
           <ExpensesContext.Provider value={expenses as any}>
             <UserContext.Provider value={user as any}>
               <NetworkContext.Provider value={network as any}>
-                <SettingsContext.Provider value={settings as any}>
+                <SettingsContext.Provider value={settingsContextValue as any}>
                   <OrientationContext.Provider value={orientation as any}>
                     {children}
                   </OrientationContext.Provider>

--- a/TravelCostApp/__tests__/screens/profile-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/profile-screen.test.tsx
@@ -495,6 +495,7 @@ describe("Profile screen", () => {
         expenses: { setExpenses: jest.fn() },
         user: profileUserOverrides(),
         network: { isConnected: true, strongConnection: true },
+        settings: { settings: { askAiForGoodPrices: true } },
       },
     );
 
@@ -525,6 +526,7 @@ describe("Profile screen", () => {
         expenses: { setExpenses: jest.fn() },
         user: profileUserOverrides(),
         network: { isConnected: true, strongConnection: true },
+        settings: { settings: { askAiForGoodPrices: true } },
       },
     );
 

--- a/TravelCostApp/__tests__/screens/profile-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/profile-screen.test.tsx
@@ -485,6 +485,22 @@ describe("Profile screen", () => {
     expect(screen.getByTestId("profile-scroll-header")).toBeTruthy();
   });
 
+  it("hides Local Price when Ask AI for good prices is off", () => {
+    const navigation = { navigate: jest.fn() };
+    const screen = renderWithAppProviders(
+      <ProfileScreen navigation={navigation as any} />,
+      {
+        auth: { uid: "u1", logout: jest.fn() },
+        trip: { setCurrentTrip: jest.fn(async () => {}) },
+        expenses: { setExpenses: jest.fn() },
+        user: profileUserOverrides(),
+        network: { isConnected: true, strongConnection: true },
+      },
+    );
+
+    expect(screen.queryByTestId("profile-get-local-price")).toBeNull();
+  });
+
   it("shows chevrons only on budget navigation rows, not modal actions", () => {
     const navigation = { navigate: jest.fn() };
     const screen = renderWithAppProviders(

--- a/TravelCostApp/__tests__/store/settings-context.test.tsx
+++ b/TravelCostApp/__tests__/store/settings-context.test.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { useContext, useEffect } from "react";
+import { render, waitFor } from "@testing-library/react-native";
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreGetItem: jest.fn(),
+  secureStoreSetItem: jest.fn(),
+}));
+
+import { secureStoreGetItem } from "../../store/secure-storage";
+import {
+  SettingsContext,
+  SettingsProvider,
+} from "../../store/settings-context";
+
+describe("SettingsProvider", () => {
+  it("fills missing askAiForGoodPrices from defaults when loading stored settings", async () => {
+    jest.mocked(secureStoreGetItem).mockResolvedValue(
+      JSON.stringify({
+        showFlags: false,
+        showWhoPaid: true,
+        alwaysShowAdvanced: true,
+        skipCategoryScreen: false,
+        showInternetSpeed: true,
+        hideSpecialExpenses: false,
+        disableNumberAnimations: true,
+        trafficLightBudgetColors: false,
+      }),
+    );
+
+    let loadedSettings: ReturnType<
+      typeof useContext<typeof SettingsContext>
+    >["settings"] | undefined;
+
+    function Probe() {
+      const { settings } = useContext(SettingsContext);
+      useEffect(() => {
+        loadedSettings = settings;
+      }, [settings]);
+      return null;
+    }
+
+    render(
+      <SettingsProvider>
+        <Probe />
+      </SettingsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(loadedSettings?.showFlags).toBe(false);
+    });
+    expect(loadedSettings?.askAiForGoodPrices).toBe(false);
+    expect(loadedSettings?.alwaysShowAdvanced).toBe(true);
+  });
+});

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -2059,6 +2059,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
           </Animated.View>
           {/* Get Local Price Button Section */}
           {!hideAdvanced &&
+            settings.askAiForGoodPrices &&
             inputs.description.value &&
             inputs.currency.value &&
             inputs.country.value && (

--- a/TravelCostApp/components/Settings/GetLocalPriceButton.tsx
+++ b/TravelCostApp/components/Settings/GetLocalPriceButton.tsx
@@ -12,6 +12,7 @@ import {
 import { UserContext } from "../../store/user-context";
 import { TripContext } from "../../store/trip-context";
 import { NetworkContext } from "../../store/network-context";
+import { SettingsContext } from "../../store/settings-context";
 import { GlobalStyles } from "../../constants/styles";
 import { dynamicScale } from "../../util/scalingUtil";
 import ActionRow from "../UI/ActionRow";
@@ -26,6 +27,7 @@ const GetLocalPriceButton = ({ navigation, style }) => {
   const userCtx = useContext(UserContext);
   const tripCtx = useContext(TripContext);
   const netCtx = useContext(NetworkContext);
+  const { settings } = useContext(SettingsContext);
   const isConnected = netCtx.isConnected;
 
   const [showLocalPriceModal, setShowLocalPriceModal] = useState(false);
@@ -65,6 +67,10 @@ const GetLocalPriceButton = ({ navigation, style }) => {
     setShowLocalPriceModal(false);
     setProductInput("");
   };
+
+  if (!settings.askAiForGoodPrices) {
+    return null;
+  }
 
   return (
     <>

--- a/TravelCostApp/components/UI/SettingsSection.tsx
+++ b/TravelCostApp/components/UI/SettingsSection.tsx
@@ -36,6 +36,9 @@ const SettingsSection = ({ multiTraveller }) => {
   const [trafficLightBudgetColors, setTrafficLightBudgetColors] = useState(
     settings.trafficLightBudgetColors
   );
+  const [askAiForGoodPrices, setAskAiForGoodPrices] = useState(
+    settings.askAiForGoodPrices
+  );
   const [showTrafficLightInfo, setShowTrafficLightInfo] = useState(false);
 
   const toggleShowFlags = () => {
@@ -126,6 +129,18 @@ const SettingsSection = ({ multiTraveller }) => {
       enabled: newValue,
     });
   };
+  const toggleAskAiForGoodPrices = () => {
+    const newValue = !askAiForGoodPrices;
+    const newSettings = {
+      ...settings,
+      askAiForGoodPrices: newValue,
+    };
+    setAskAiForGoodPrices(newValue);
+    saveSettings(newSettings);
+    trackEvent(VexoEvents.ASK_AI_FOR_GOOD_PRICES_TOGGLE_CHANGED, {
+      enabled: newValue,
+    });
+  };
   return (
     <View>
       {/* <View style={styles.switchContainer}>
@@ -188,6 +203,13 @@ const SettingsSection = ({ multiTraveller }) => {
         style={styles.switchContainer}
         state={showInternetSpeed}
         toggleState={toggleShowInternetSpeed}
+        labelStyle={{}}
+      />
+      <SettingsSwitch
+        label={i18n.t("settingsAskAiForGoodPrices")}
+        style={styles.switchContainer}
+        state={askAiForGoodPrices}
+        toggleState={toggleAskAiForGoodPrices}
         labelStyle={{}}
       />
       {multiTraveller && (

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -395,6 +395,7 @@ const en = {
   settingsDisableNumberAnimations: "Disable Number Animations",
   settingsShowTravellerIcon: "Show Nomad Icons",
   settingsTrafficLightBudgetColors: "Traffic Light Budget Colors",
+  settingsAskAiForGoodPrices: "Ask AI for good prices",
   trafficLightInfoTitle: "Traffic Light Budget Colors",
   trafficLightInfoText:
     "Budget colors now use a traffic light system:\n\n🟢 Green: Under budget\n🟠 Orange: Over budget, but average spending is under budget\n🔴 Red: Over budget AND average spending is over budget\n\nThe average is calculated from the current period plus the previous period (e.g., this week + last week for daily view).",
@@ -1040,6 +1041,7 @@ const de = {
   settingsDisableNumberAnimations: "Zahlenanimationen deaktivieren",
   settingsShowTravellerIcon: "Nomaden-Icons anzeigen",
   settingsTrafficLightBudgetColors: "Ampel-Budget-Farben",
+  settingsAskAiForGoodPrices: "KI nach guten Preisen fragen",
   trafficLightInfoTitle: "Ampel-Budget-Farben",
   trafficLightInfoText:
     "Budget-Farben verwenden jetzt ein Ampelsystem:\n\n🟢 Grün: Unter Budget\n🟠 Orange: Über Budget, aber Durchschnittsausgaben sind unter Budget\n🔴 Rot: Über Budget UND Durchschnittsausgaben sind über Budget\n\nDer Durchschnitt wird aus der aktuellen Periode plus der vorherigen Periode berechnet (z.B. diese Woche + letzte Woche für Tagesansicht).",
@@ -1699,6 +1701,7 @@ const fr = {
   settingsDisableNumberAnimations: "Désactiver les animations de nombres",
   settingsShowTravellerIcon: "Afficher les icônes de nomades",
   settingsTrafficLightBudgetColors: "Couleurs de budget feux de circulation",
+  settingsAskAiForGoodPrices: "Demander à l'IA de bons prix",
   trafficLightInfoTitle: "Couleurs de budget feux de circulation",
   trafficLightInfoText:
     "Les couleurs du budget utilisent maintenant un système de feux de circulation:\n\n🟢 Vert: Sous le budget\n🟠 Orange: Au-dessus du budget, mais les dépenses moyennes sont sous le budget\n🔴 Rouge: Au-dessus du budget ET les dépenses moyennes sont au-dessus du budget\n\nLa moyenne est calculée à partir de la période actuelle plus la période précédente (par exemple, cette semaine + la semaine dernière pour la vue quotidienne).",
@@ -2347,6 +2350,7 @@ const ru = {
   settingsDisableNumberAnimations: "Отключить анимацию чисел",
   settingsShowTravellerIcon: "Показывать иконки номадов",
   settingsTrafficLightBudgetColors: "Цвета бюджета светофора",
+  settingsAskAiForGoodPrices: "Спросить ИИ о хороших ценах",
   trafficLightInfoTitle: "Цвета бюджета светофора",
   trafficLightInfoText:
     "Цвета бюджета теперь используют систему светофора:\n\n🟢 Зеленый: В пределах бюджета\n🟠 Оранжевый: Превышен бюджет, но средние расходы в пределах бюджета\n🔴 Красный: Превышен бюджет И средние расходы превышают бюджет\n\nСреднее значение рассчитывается из текущего периода плюс предыдущий период (например, эта неделя + прошлая неделя для дневного просмотра).",

--- a/TravelCostApp/store/settings-context.tsx
+++ b/TravelCostApp/store/settings-context.tsx
@@ -14,6 +14,7 @@ export interface Settings {
   hideSpecialExpenses: boolean;
   disableNumberAnimations: boolean;
   trafficLightBudgetColors: boolean;
+  askAiForGoodPrices: boolean;
 }
 
 export type SettingsContextType = {
@@ -30,6 +31,7 @@ const defaultSettings: Settings = {
   hideSpecialExpenses: false,
   disableNumberAnimations: false,
   trafficLightBudgetColors: true,
+  askAiForGoodPrices: false,
 };
 
 export const SettingsContext = createContext<SettingsContextType>({

--- a/TravelCostApp/store/settings-context.tsx
+++ b/TravelCostApp/store/settings-context.tsx
@@ -53,7 +53,8 @@ export const SettingsProvider = ({
       const settingsString = await secureStoreGetItem("settings");
       if (settingsString) {
         const loadedSettings: Settings = safelyParseJSON(settingsString);
-        loadedSettings && setSettings(loadedSettings);
+        loadedSettings &&
+          setSettings({ ...defaultSettings, ...loadedSettings });
       } else setSettings(defaultSettings);
     };
     loadSettingsAsync();

--- a/TravelCostApp/util/vexo-constants.ts
+++ b/TravelCostApp/util/vexo-constants.ts
@@ -79,6 +79,8 @@ export const VexoEvents = {
     "disable_number_animations_toggle_changed",
   TRAFFIC_LIGHT_BUDGET_COLORS_TOGGLE_CHANGED:
     "traffic_light_budget_colors_toggle_changed",
+  ASK_AI_FOR_GOOD_PRICES_TOGGLE_CHANGED:
+    "ask_ai_for_good_prices_toggle_changed",
   RESET_APP_INTRODUCTION_PRESSED: "reset_app_introduction_pressed",
   VISIT_FOOD_FOR_NOMADS_PRESSED: "visit_food_for_nomads_pressed",
   FEEDBACK_BUTTON_PRESSED: "feedback_button_pressed",


### PR DESCRIPTION
## Summary
- Add an **Ask AI for good prices** setting (default off) in Settings.
- Hide Profile and expense-form Local Price entry points until the user enables the toggle.
- Cover the behavior with component tests for the settings switch, profile button, and expense form row.

## Test plan
- [ ] Open Settings and confirm **Ask AI for good prices** is off by default
- [ ] Verify Profile and expense form show no Local Price / Ask AI rows while off
- [ ] Enable the toggle and confirm both entry points appear
- [ ] Relaunch the app and confirm the setting persists
- [x] `pnpm test __tests__/components/settings-section-ask-ai.test.tsx __tests__/components/get-local-price-button.test.tsx __tests__/components/form-action-row-footers.test.tsx -t "local price|ask AI"`