### PR TITLE
Add info buttons to all settings toggles

### DIFF
--- a/TravelCostApp/__tests__/components/settings-section-info-buttons.test.tsx
+++ b/TravelCostApp/__tests__/components/settings-section-info-buttons.test.tsx
@@ -5,21 +5,11 @@ jest.mock("../../util/vexo-tracking", () => ({
   trackEvent: jest.fn(),
 }));
 
-import SettingsSection from "../../components/UI/SettingsSection";
+import SettingsSection, {
+  SETTINGS_TOGGLE_INFO_KEYS,
+} from "../../components/UI/SettingsSection";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import { i18n } from "../../i18n/i18n";
-
-const SETTINGS_TOGGLE_INFO_KEYS = [
-  "trafficLightBudgetColors",
-  "hideSpecialExpenses",
-  "disableNumberAnimations",
-  "skipCategoryScreen",
-  "alwaysShowAdvanced",
-  "showFlags",
-  "showInternetSpeed",
-  "askAiForGoodPrices",
-  "showWhoPaid",
-] as const;
 
 describe("SettingsSection toggle info buttons", () => {
   it("shows an info button for every settings toggle", () => {
@@ -33,6 +23,38 @@ describe("SettingsSection toggle info buttons", () => {
     }
   });
 
+  it("does not change settings when an info button is pressed", () => {
+    const saveSettings = jest.fn(async () => {});
+    const screen = renderWithAppProviders(
+      <SettingsSection multiTraveller={false} />,
+      {
+        wrapNavigation: false,
+        settings: {
+          settings: { hideSpecialExpenses: false },
+          saveSettings,
+        },
+      },
+    );
+
+    fireEvent.press(screen.getByTestId("settings-info-hideSpecialExpenses"));
+
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+
+  it("labels each info button for assistive tech", () => {
+    const screen = renderWithAppProviders(
+      <SettingsSection multiTraveller={false} />,
+      { wrapNavigation: false },
+    );
+
+    const infoButton = screen.getByTestId("settings-info-hideSpecialExpenses");
+    expect(infoButton.props.accessibilityLabel).toBe(
+      i18n.t("settingsInfoButtonA11y", {
+        setting: i18n.t("hideSpecialExpensesInfoTitle"),
+      }),
+    );
+  });
+
   it("explains hide special expenses when its info button is pressed", () => {
     const screen = renderWithAppProviders(
       <SettingsSection multiTraveller={false} />,
@@ -43,5 +65,24 @@ describe("SettingsSection toggle info buttons", () => {
 
     expect(screen.getByText(i18n.t("hideSpecialExpensesInfoText"))).toBeTruthy();
     expect(screen.getByText(i18n.t("confirm"))).toBeTruthy();
+  });
+
+  it("explains traffic light budget colors when its info button is pressed", () => {
+    const screen = renderWithAppProviders(
+      <SettingsSection multiTraveller={false} />,
+      { wrapNavigation: false },
+    );
+
+    fireEvent.press(
+      screen.getByTestId("settings-info-trafficLightBudgetColors"),
+    );
+
+    expect(screen.getByText(i18n.t("trafficLightInfoText"))).toBeTruthy();
+  });
+
+  it("mentions profile and expense form for ask AI info copy", () => {
+    const text = i18n.t("askAiForGoodPricesInfoText").toLowerCase();
+    expect(text).toMatch(/profile/);
+    expect(text).toMatch(/expense/);
   });
 });

--- a/TravelCostApp/__tests__/components/settings-section-info-buttons.test.tsx
+++ b/TravelCostApp/__tests__/components/settings-section-info-buttons.test.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { fireEvent } from "@testing-library/react-native";
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import SettingsSection from "../../components/UI/SettingsSection";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { i18n } from "../../i18n/i18n";
+
+const SETTINGS_TOGGLE_INFO_KEYS = [
+  "trafficLightBudgetColors",
+  "hideSpecialExpenses",
+  "disableNumberAnimations",
+  "skipCategoryScreen",
+  "alwaysShowAdvanced",
+  "showFlags",
+  "showInternetSpeed",
+  "askAiForGoodPrices",
+  "showWhoPaid",
+] as const;
+
+describe("SettingsSection toggle info buttons", () => {
+  it("shows an info button for every settings toggle", () => {
+    const screen = renderWithAppProviders(
+      <SettingsSection multiTraveller={true} />,
+      { wrapNavigation: false },
+    );
+
+    for (const key of SETTINGS_TOGGLE_INFO_KEYS) {
+      expect(screen.getByTestId(`settings-info-${key}`)).toBeTruthy();
+    }
+  });
+
+  it("explains hide special expenses when its info button is pressed", () => {
+    const screen = renderWithAppProviders(
+      <SettingsSection multiTraveller={false} />,
+      { wrapNavigation: false },
+    );
+
+    fireEvent.press(screen.getByTestId("settings-info-hideSpecialExpenses"));
+
+    expect(screen.getByText(i18n.t("hideSpecialExpensesInfoText"))).toBeTruthy();
+    expect(screen.getByText(i18n.t("confirm"))).toBeTruthy();
+  });
+});

--- a/TravelCostApp/components/UI/SettingsInfoModal.tsx
+++ b/TravelCostApp/components/UI/SettingsInfoModal.tsx
@@ -19,17 +19,21 @@ const SettingsInfoModal = ({ isVisible, title, text, onClose }) => {
       onBackButtonPress={onClose}
     >
       <View style={styles.infoModalContainer}>
-        <Text style={styles.infoTitleText}>{title}</Text>
-        <Text style={styles.infoContentText}>{text}</Text>
-        <ActionRow
-          tier="primary"
-          label={i18n.t("confirm")}
-          icon="checkmark-outline"
-          showChevron={false}
-          compact
-          onPress={onClose}
-          style={styles.confirmButton}
-        />
+        {isVisible && (
+          <>
+            <Text style={styles.infoTitleText}>{title}</Text>
+            <Text style={styles.infoContentText}>{text}</Text>
+            <ActionRow
+              tier="primary"
+              label={i18n.t("confirm")}
+              icon="checkmark-outline"
+              showChevron={false}
+              compact
+              onPress={onClose}
+              style={styles.confirmButton}
+            />
+          </>
+        )}
       </View>
     </Modal>
   );

--- a/TravelCostApp/components/UI/SettingsInfoModal.tsx
+++ b/TravelCostApp/components/UI/SettingsInfoModal.tsx
@@ -7,7 +7,7 @@ import ActionRow from "./ActionRow";
 import { dynamicScale } from "../../util/scalingUtil";
 import PropTypes from "prop-types";
 
-const TrafficLightInfoModal = ({ isVisible, onClose }) => {
+const SettingsInfoModal = ({ isVisible, title, text, onClose }) => {
   return (
     <Modal
       isVisible={isVisible}
@@ -19,12 +19,8 @@ const TrafficLightInfoModal = ({ isVisible, onClose }) => {
       onBackButtonPress={onClose}
     >
       <View style={styles.infoModalContainer}>
-        <Text style={styles.infoTitleText}>
-          {i18n.t("trafficLightInfoTitle")}
-        </Text>
-        <Text style={styles.infoContentText}>
-          {i18n.t("trafficLightInfoText")}
-        </Text>
+        <Text style={styles.infoTitleText}>{title}</Text>
+        <Text style={styles.infoContentText}>{text}</Text>
         <ActionRow
           tier="primary"
           label={i18n.t("confirm")}
@@ -39,10 +35,12 @@ const TrafficLightInfoModal = ({ isVisible, onClose }) => {
   );
 };
 
-export default TrafficLightInfoModal;
+export default SettingsInfoModal;
 
-TrafficLightInfoModal.propTypes = {
+SettingsInfoModal.propTypes = {
   isVisible: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 

--- a/TravelCostApp/components/UI/SettingsSection.tsx
+++ b/TravelCostApp/components/UI/SettingsSection.tsx
@@ -12,7 +12,46 @@ import { safelyParseJSON } from "../../util/jsonParse";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 import InfoButton from "./InfoButton";
-import TrafficLightInfoModal from "./TrafficLightInfoModal";
+import SettingsInfoModal from "./SettingsInfoModal";
+
+const SETTINGS_INFO_CONTENT = {
+  trafficLightBudgetColors: {
+    titleKey: "trafficLightInfoTitle",
+    textKey: "trafficLightInfoText",
+  },
+  hideSpecialExpenses: {
+    titleKey: "hideSpecialExpensesInfoTitle",
+    textKey: "hideSpecialExpensesInfoText",
+  },
+  disableNumberAnimations: {
+    titleKey: "disableNumberAnimationsInfoTitle",
+    textKey: "disableNumberAnimationsInfoText",
+  },
+  skipCategoryScreen: {
+    titleKey: "skipCategoryScreenInfoTitle",
+    textKey: "skipCategoryScreenInfoText",
+  },
+  alwaysShowAdvanced: {
+    titleKey: "alwaysShowAdvancedInfoTitle",
+    textKey: "alwaysShowAdvancedInfoText",
+  },
+  showFlags: {
+    titleKey: "showFlagsInfoTitle",
+    textKey: "showFlagsInfoText",
+  },
+  showInternetSpeed: {
+    titleKey: "showInternetSpeedInfoTitle",
+    textKey: "showInternetSpeedInfoText",
+  },
+  askAiForGoodPrices: {
+    titleKey: "askAiForGoodPricesInfoTitle",
+    textKey: "askAiForGoodPricesInfoText",
+  },
+  showWhoPaid: {
+    titleKey: "showWhoPaidInfoTitle",
+    textKey: "showWhoPaidInfoText",
+  },
+};
 
 const SettingsSection = ({ multiTraveller }) => {
   const { settings, saveSettings } = useContext(SettingsContext);
@@ -39,7 +78,17 @@ const SettingsSection = ({ multiTraveller }) => {
   const [askAiForGoodPrices, setAskAiForGoodPrices] = useState(
     settings.askAiForGoodPrices
   );
-  const [showTrafficLightInfo, setShowTrafficLightInfo] = useState(false);
+  const [activeInfoKey, setActiveInfoKey] = useState(null);
+
+  const infoButtonFor = (settingKey) => (
+    <InfoButton
+      containerStyle={styles.infoButton}
+      testID={`settings-info-${settingKey}`}
+      onPress={() => setActiveInfoKey(settingKey)}
+    />
+  );
+
+  const activeInfo = activeInfoKey ? SETTINGS_INFO_CONTENT[activeInfoKey] : null;
 
   const toggleShowFlags = () => {
     const newValue = !showFlags;
@@ -152,16 +201,13 @@ const SettingsSection = ({ multiTraveller }) => {
         state={trafficLightBudgetColors}
         toggleState={toggleTrafficLightBudgetColors}
         labelStyle={{}}
-        infoButton={
-          <InfoButton
-            containerStyle={styles.infoButton}
-            onPress={() => setShowTrafficLightInfo(true)}
-          />
-        }
+        infoButton={infoButtonFor("trafficLightBudgetColors")}
       />
-      <TrafficLightInfoModal
-        isVisible={showTrafficLightInfo}
-        onClose={() => setShowTrafficLightInfo(false)}
+      <SettingsInfoModal
+        isVisible={activeInfoKey !== null}
+        title={activeInfo ? i18n.t(activeInfo.titleKey) : ""}
+        text={activeInfo ? i18n.t(activeInfo.textKey) : ""}
+        onClose={() => setActiveInfoKey(null)}
       />
       <SettingsSwitch
         label={i18n.t("hideSpecialExpenses")}
@@ -169,6 +215,7 @@ const SettingsSection = ({ multiTraveller }) => {
         state={hideSpecialExpenses}
         toggleState={toggleHideSpecialExpenses}
         labelStyle={{}}
+        infoButton={infoButtonFor("hideSpecialExpenses")}
       />
       <SettingsSwitch
         label={i18n.t("settingsDisableNumberAnimations")}
@@ -176,6 +223,7 @@ const SettingsSection = ({ multiTraveller }) => {
         state={disableNumberAnimations}
         toggleState={toggleDisableNumberAnimations}
         labelStyle={{}}
+        infoButton={infoButtonFor("disableNumberAnimations")}
       />
       <SettingsSwitch
         label={i18n.t("settingsSkipCat")}
@@ -183,6 +231,7 @@ const SettingsSection = ({ multiTraveller }) => {
         state={skipCategoryPickScreen}
         toggleState={toggleSkipCategoryPickScreen}
         labelStyle={{}}
+        infoButton={infoButtonFor("skipCategoryScreen")}
       />
       <SettingsSwitch
         label={i18n.t("settingsShowAdvanced")}
@@ -190,6 +239,7 @@ const SettingsSection = ({ multiTraveller }) => {
         state={alwaysShowAdvanced}
         toggleState={toggleAlwaysShowAdvanced}
         labelStyle={{}}
+        infoButton={infoButtonFor("alwaysShowAdvanced")}
       />
       <SettingsSwitch
         label={i18n.t("settingsShowFlags")}
@@ -197,6 +247,7 @@ const SettingsSection = ({ multiTraveller }) => {
         state={showFlags}
         toggleState={toggleShowFlags}
         labelStyle={{}}
+        infoButton={infoButtonFor("showFlags")}
       />
       <SettingsSwitch
         label={i18n.t("settingsShowInternetSpeed")}
@@ -204,6 +255,7 @@ const SettingsSection = ({ multiTraveller }) => {
         state={showInternetSpeed}
         toggleState={toggleShowInternetSpeed}
         labelStyle={{}}
+        infoButton={infoButtonFor("showInternetSpeed")}
       />
       <SettingsSwitch
         label={i18n.t("settingsAskAiForGoodPrices")}
@@ -211,6 +263,7 @@ const SettingsSection = ({ multiTraveller }) => {
         state={askAiForGoodPrices}
         toggleState={toggleAskAiForGoodPrices}
         labelStyle={{}}
+        infoButton={infoButtonFor("askAiForGoodPrices")}
       />
       {multiTraveller && (
         <SettingsSwitch
@@ -219,6 +272,7 @@ const SettingsSection = ({ multiTraveller }) => {
           state={showWhoPaid}
           toggleState={toggleShowWhoPaid}
           labelStyle={{}}
+          infoButton={infoButtonFor("showWhoPaid")}
         />
       )}
     </View>

--- a/TravelCostApp/components/UI/SettingsSection.tsx
+++ b/TravelCostApp/components/UI/SettingsSection.tsx
@@ -53,6 +53,8 @@ const SETTINGS_INFO_CONTENT = {
   },
 };
 
+export const SETTINGS_TOGGLE_INFO_KEYS = Object.keys(SETTINGS_INFO_CONTENT);
+
 const SettingsSection = ({ multiTraveller }) => {
   const { settings, saveSettings } = useContext(SettingsContext);
   const [showFlags, setShowFlags] = useState(settings.showFlags);
@@ -80,13 +82,19 @@ const SettingsSection = ({ multiTraveller }) => {
   );
   const [activeInfoKey, setActiveInfoKey] = useState(null);
 
-  const infoButtonFor = (settingKey) => (
-    <InfoButton
-      containerStyle={styles.infoButton}
-      testID={`settings-info-${settingKey}`}
-      onPress={() => setActiveInfoKey(settingKey)}
-    />
-  );
+  const infoButtonFor = (settingKey) => {
+    const info = SETTINGS_INFO_CONTENT[settingKey];
+    return (
+      <InfoButton
+        containerStyle={styles.infoButton}
+        testID={`settings-info-${settingKey}`}
+        accessibilityLabel={i18n.t("settingsInfoButtonA11y", {
+          setting: i18n.t(info.titleKey),
+        })}
+        onPress={() => setActiveInfoKey(settingKey)}
+      />
+    );
+  };
 
   const activeInfo = activeInfoKey ? SETTINGS_INFO_CONTENT[activeInfoKey] : null;
 

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -399,6 +399,30 @@ const en = {
   trafficLightInfoTitle: "Traffic Light Budget Colors",
   trafficLightInfoText:
     "Budget colors now use a traffic light system:\n\n🟢 Green: Under budget\n🟠 Orange: Over budget, but average spending is under budget\n🔴 Red: Over budget AND average spending is over budget\n\nThe average is calculated from the current period plus the previous period (e.g., this week + last week for daily view).",
+  hideSpecialExpensesInfoTitle: "Hide special expenses",
+  hideSpecialExpensesInfoText:
+    "When turned on, expenses marked as special no longer appear in charts and spending summaries. They still count toward splits and balances between nomads.",
+  disableNumberAnimationsInfoTitle: "Disable number animations",
+  disableNumberAnimationsInfoText:
+    "When turned on, budget totals and other numbers update instantly instead of counting up or down.",
+  skipCategoryScreenInfoTitle: "Skip category picker",
+  skipCategoryScreenInfoText:
+    "When turned on, adding an expense skips the category picker and opens the form right away using your most recent category.",
+  alwaysShowAdvancedInfoTitle: "Always show more options",
+  alwaysShowAdvancedInfoText:
+    "When turned on, the full expense form is shown every time you add an expense — currency, dates, splits, and more. When off, you start with a quick form and can expand for extra options.",
+  showFlagsInfoTitle: "Show flag icons",
+  showFlagsInfoText:
+    "When turned on, a small country flag appears next to each expense in the list.",
+  showInternetSpeedInfoTitle: "Show internet speed",
+  showInternetSpeedInfoText:
+    "When turned on, your current connection speed is shown in the header on the overview and expense list screens.",
+  askAiForGoodPricesInfoTitle: "Ask AI for good prices",
+  askAiForGoodPricesInfoText:
+    "When turned on, you can ask AI whether a price is reasonable for your current location from your profile screen.",
+  showWhoPaidInfoTitle: "Show nomad icons",
+  showWhoPaidInfoText:
+    "When turned on, a small icon shows which nomad paid for each expense. Only applies when your budget has more than one nomad.",
   overBudgetButAverage: "Over budget, but your average daily spending is",
   underDailyBudget: "under your daily budget of",
   trafficLightUnderBudget: "Under budget",
@@ -1045,6 +1069,30 @@ const de = {
   trafficLightInfoTitle: "Ampel-Budget-Farben",
   trafficLightInfoText:
     "Budget-Farben verwenden jetzt ein Ampelsystem:\n\n🟢 Grün: Unter Budget\n🟠 Orange: Über Budget, aber Durchschnittsausgaben sind unter Budget\n🔴 Rot: Über Budget UND Durchschnittsausgaben sind über Budget\n\nDer Durchschnitt wird aus der aktuellen Periode plus der vorherigen Periode berechnet (z.B. diese Woche + letzte Woche für Tagesansicht).",
+  hideSpecialExpensesInfoTitle: "Besondere Ausgaben ausblenden",
+  hideSpecialExpensesInfoText:
+    "Wenn aktiviert, erscheinen als besonders markierte Ausgaben nicht mehr in Diagrammen und Ausgabenübersichten. Sie zählen weiterhin für Aufteilungen und Salden zwischen Nomaden.",
+  disableNumberAnimationsInfoTitle: "Zahlenanimationen deaktivieren",
+  disableNumberAnimationsInfoText:
+    "Wenn aktiviert, aktualisieren sich Budgetsummen und andere Zahlen sofort, anstatt hoch- oder runterzuzählen.",
+  skipCategoryScreenInfoTitle: "Kategorieauswahl überspringen",
+  skipCategoryScreenInfoText:
+    "Wenn aktiviert, wird beim Hinzufügen einer Ausgabe die Kategorieauswahl übersprungen und das Formular direkt mit deiner zuletzt verwendeten Kategorie geöffnet.",
+  alwaysShowAdvancedInfoTitle: "Immer Optionen anzeigen",
+  alwaysShowAdvancedInfoText:
+    "Wenn aktiviert, wird bei jeder neuen Ausgabe das vollständige Formular angezeigt — Währung, Datum, Aufteilungen und mehr. Wenn deaktiviert, startest du mit einem Schnellformular und kannst es bei Bedarf erweitern.",
+  showFlagsInfoTitle: "Länderflaggen anzeigen",
+  showFlagsInfoText:
+    "Wenn aktiviert, erscheint neben jeder Ausgabe in der Liste eine kleine Länderflagge.",
+  showInternetSpeedInfoTitle: "Internetgeschwindigkeit anzeigen",
+  showInternetSpeedInfoText:
+    "Wenn aktiviert, wird deine aktuelle Verbindungsgeschwindigkeit in der Kopfzeile auf der Übersichts- und Ausgabenlistenseite angezeigt.",
+  askAiForGoodPricesInfoTitle: "KI nach guten Preisen fragen",
+  askAiForGoodPricesInfoText:
+    "Wenn aktiviert, kannst du über dein Profil die KI fragen, ob ein Preis für deinen aktuellen Standort angemessen ist.",
+  showWhoPaidInfoTitle: "Nomaden-Icons anzeigen",
+  showWhoPaidInfoText:
+    "Wenn aktiviert, zeigt ein kleines Icon an, welcher Nomade für jede Ausgabe bezahlt hat. Gilt nur, wenn dein Budget mehr als einen Nomaden hat.",
   overBudgetButAverage:
     "Über Budget, aber Ihre durchschnittlichen Tagesausgaben sind",
   underDailyBudget: "unter Ihrem Tagesbudget von",
@@ -1705,6 +1753,30 @@ const fr = {
   trafficLightInfoTitle: "Couleurs de budget feux de circulation",
   trafficLightInfoText:
     "Les couleurs du budget utilisent maintenant un système de feux de circulation:\n\n🟢 Vert: Sous le budget\n🟠 Orange: Au-dessus du budget, mais les dépenses moyennes sont sous le budget\n🔴 Rouge: Au-dessus du budget ET les dépenses moyennes sont au-dessus du budget\n\nLa moyenne est calculée à partir de la période actuelle plus la période précédente (par exemple, cette semaine + la semaine dernière pour la vue quotidienne).",
+  hideSpecialExpensesInfoTitle: "Masquer les dépenses spéciales",
+  hideSpecialExpensesInfoText:
+    "Lorsque activé, les dépenses marquées comme spéciales n'apparaissent plus dans les graphiques et les résumés de dépenses. Elles comptent toujours pour les répartitions et les soldes entre nomades.",
+  disableNumberAnimationsInfoTitle: "Désactiver les animations de nombres",
+  disableNumberAnimationsInfoText:
+    "Lorsque activé, les totaux du budget et les autres chiffres se mettent à jour instantanément au lieu de compter de haut en bas.",
+  skipCategoryScreenInfoTitle: "Passer la sélection de catégorie",
+  skipCategoryScreenInfoText:
+    "Lorsque activé, l'ajout d'une dépense ignore le sélecteur de catégorie et ouvre directement le formulaire avec votre catégorie la plus récente.",
+  alwaysShowAdvancedInfoTitle: "Toujours afficher plus d'options",
+  alwaysShowAdvancedInfoText:
+    "Lorsque activé, le formulaire complet s'affiche à chaque ajout de dépense — devise, dates, répartitions, etc. Lorsque désactivé, vous commencez avec un formulaire rapide que vous pouvez développer si besoin.",
+  showFlagsInfoTitle: "Afficher les icônes de drapeau",
+  showFlagsInfoText:
+    "Lorsque activé, un petit drapeau du pays apparaît à côté de chaque dépense dans la liste.",
+  showInternetSpeedInfoTitle: "Afficher la vitesse d'Internet",
+  showInternetSpeedInfoText:
+    "Lorsque activé, votre vitesse de connexion actuelle s'affiche dans l'en-tête des écrans de vue d'ensemble et de liste des dépenses.",
+  askAiForGoodPricesInfoTitle: "Demander à l'IA de bons prix",
+  askAiForGoodPricesInfoText:
+    "Lorsque activé, vous pouvez demander à l'IA si un prix est raisonnable pour votre emplacement actuel depuis votre écran de profil.",
+  showWhoPaidInfoTitle: "Afficher les icônes de nomades",
+  showWhoPaidInfoText:
+    "Lorsque activé, une petite icône indique quel nomade a payé chaque dépense. S'applique uniquement lorsque votre budget compte plus d'un nomade.",
   overBudgetButAverage:
     "Au-dessus du budget, mais vos dépenses quotidiennes moyennes sont",
   underDailyBudget: "sous votre budget quotidien de",
@@ -2354,6 +2426,30 @@ const ru = {
   trafficLightInfoTitle: "Цвета бюджета светофора",
   trafficLightInfoText:
     "Цвета бюджета теперь используют систему светофора:\n\n🟢 Зеленый: В пределах бюджета\n🟠 Оранжевый: Превышен бюджет, но средние расходы в пределах бюджета\n🔴 Красный: Превышен бюджет И средние расходы превышают бюджет\n\nСреднее значение рассчитывается из текущего периода плюс предыдущий период (например, эта неделя + прошлая неделя для дневного просмотра).",
+  hideSpecialExpensesInfoTitle: "Скрыть специальные расходы",
+  hideSpecialExpensesInfoText:
+    "Когда включено, расходы, отмеченные как специальные, больше не отображаются на диаграммах и в сводках расходов. Они по-прежнему учитываются при разделении и балансах между номадами.",
+  disableNumberAnimationsInfoTitle: "Отключить анимацию чисел",
+  disableNumberAnimationsInfoText:
+    "Когда включено, итоги бюджета и другие числа обновляются мгновенно, без анимации счёта.",
+  skipCategoryScreenInfoTitle: "Пропустить выбор категории",
+  skipCategoryScreenInfoText:
+    "Когда включено, при добавлении расхода пропускается выбор категории и сразу открывается форма с вашей последней категорией.",
+  alwaysShowAdvancedInfoTitle: "Всегда показывать дополнительные опции",
+  alwaysShowAdvancedInfoText:
+    "Когда включено, при каждом добавлении расхода показывается полная форма — валюта, даты, разделение и др. Когда выключено, вы начинаете с быстрой формы и можете развернуть дополнительные опции.",
+  showFlagsInfoTitle: "Показывать значки флагов",
+  showFlagsInfoText:
+    "Когда включено, рядом с каждым расходом в списке отображается маленький флаг страны.",
+  showInternetSpeedInfoTitle: "Показывать скорость интернета",
+  showInternetSpeedInfoText:
+    "Когда включено, текущая скорость соединения отображается в заголовке на экранах обзора и списка расходов.",
+  askAiForGoodPricesInfoTitle: "Спросить ИИ о хороших ценах",
+  askAiForGoodPricesInfoText:
+    "Когда включено, вы можете спросить ИИ, разумна ли цена для вашего текущего местоположения, с экрана профиля.",
+  showWhoPaidInfoTitle: "Показывать иконки номадов",
+  showWhoPaidInfoText:
+    "Когда включено, маленькая иконка показывает, какой номад оплатил каждый расход. Применяется только если в бюджете больше одного номада.",
   overBudgetButAverage:
     "Превышен бюджет, но ваши средние дневные расходы составляют",
   underDailyBudget: "ниже вашего дневного бюджета",

--- a/TravelCostApp/i18n/supportedLanguages.tsx
+++ b/TravelCostApp/i18n/supportedLanguages.tsx
@@ -396,6 +396,7 @@ const en = {
   settingsShowTravellerIcon: "Show Nomad Icons",
   settingsTrafficLightBudgetColors: "Traffic Light Budget Colors",
   settingsAskAiForGoodPrices: "Ask AI for good prices",
+  settingsInfoButtonA11y: "More information about %{setting}",
   trafficLightInfoTitle: "Traffic Light Budget Colors",
   trafficLightInfoText:
     "Budget colors now use a traffic light system:\n\n🟢 Green: Under budget\n🟠 Orange: Over budget, but average spending is under budget\n🔴 Red: Over budget AND average spending is over budget\n\nThe average is calculated from the current period plus the previous period (e.g., this week + last week for daily view).",
@@ -419,7 +420,7 @@ const en = {
     "When turned on, your current connection speed is shown in the header on the overview and expense list screens.",
   askAiForGoodPricesInfoTitle: "Ask AI for good prices",
   askAiForGoodPricesInfoText:
-    "When turned on, you can ask AI whether a price is reasonable for your current location from your profile screen.",
+    "When turned on, you can ask AI whether a price is reasonable for your current location from your profile and on the expense form.",
   showWhoPaidInfoTitle: "Show nomad icons",
   showWhoPaidInfoText:
     "When turned on, a small icon shows which nomad paid for each expense. Only applies when your budget has more than one nomad.",
@@ -1066,6 +1067,7 @@ const de = {
   settingsShowTravellerIcon: "Nomaden-Icons anzeigen",
   settingsTrafficLightBudgetColors: "Ampel-Budget-Farben",
   settingsAskAiForGoodPrices: "KI nach guten Preisen fragen",
+  settingsInfoButtonA11y: "Mehr Informationen zu %{setting}",
   trafficLightInfoTitle: "Ampel-Budget-Farben",
   trafficLightInfoText:
     "Budget-Farben verwenden jetzt ein Ampelsystem:\n\n🟢 Grün: Unter Budget\n🟠 Orange: Über Budget, aber Durchschnittsausgaben sind unter Budget\n🔴 Rot: Über Budget UND Durchschnittsausgaben sind über Budget\n\nDer Durchschnitt wird aus der aktuellen Periode plus der vorherigen Periode berechnet (z.B. diese Woche + letzte Woche für Tagesansicht).",
@@ -1089,7 +1091,7 @@ const de = {
     "Wenn aktiviert, wird deine aktuelle Verbindungsgeschwindigkeit in der Kopfzeile auf der Übersichts- und Ausgabenlistenseite angezeigt.",
   askAiForGoodPricesInfoTitle: "KI nach guten Preisen fragen",
   askAiForGoodPricesInfoText:
-    "Wenn aktiviert, kannst du über dein Profil die KI fragen, ob ein Preis für deinen aktuellen Standort angemessen ist.",
+    "Wenn aktiviert, kannst du über dein Profil und im Ausgabenformular die KI fragen, ob ein Preis für deinen aktuellen Standort angemessen ist.",
   showWhoPaidInfoTitle: "Nomaden-Icons anzeigen",
   showWhoPaidInfoText:
     "Wenn aktiviert, zeigt ein kleines Icon an, welcher Nomade für jede Ausgabe bezahlt hat. Gilt nur, wenn dein Budget mehr als einen Nomaden hat.",
@@ -1750,6 +1752,7 @@ const fr = {
   settingsShowTravellerIcon: "Afficher les icônes de nomades",
   settingsTrafficLightBudgetColors: "Couleurs de budget feux de circulation",
   settingsAskAiForGoodPrices: "Demander à l'IA de bons prix",
+  settingsInfoButtonA11y: "Plus d'informations sur %{setting}",
   trafficLightInfoTitle: "Couleurs de budget feux de circulation",
   trafficLightInfoText:
     "Les couleurs du budget utilisent maintenant un système de feux de circulation:\n\n🟢 Vert: Sous le budget\n🟠 Orange: Au-dessus du budget, mais les dépenses moyennes sont sous le budget\n🔴 Rouge: Au-dessus du budget ET les dépenses moyennes sont au-dessus du budget\n\nLa moyenne est calculée à partir de la période actuelle plus la période précédente (par exemple, cette semaine + la semaine dernière pour la vue quotidienne).",
@@ -1773,7 +1776,7 @@ const fr = {
     "Lorsque activé, votre vitesse de connexion actuelle s'affiche dans l'en-tête des écrans de vue d'ensemble et de liste des dépenses.",
   askAiForGoodPricesInfoTitle: "Demander à l'IA de bons prix",
   askAiForGoodPricesInfoText:
-    "Lorsque activé, vous pouvez demander à l'IA si un prix est raisonnable pour votre emplacement actuel depuis votre écran de profil.",
+    "Lorsque activé, vous pouvez demander à l'IA si un prix est raisonnable pour votre emplacement actuel depuis votre profil et dans le formulaire de dépense.",
   showWhoPaidInfoTitle: "Afficher les icônes de nomades",
   showWhoPaidInfoText:
     "Lorsque activé, une petite icône indique quel nomade a payé chaque dépense. S'applique uniquement lorsque votre budget compte plus d'un nomade.",
@@ -2423,6 +2426,7 @@ const ru = {
   settingsShowTravellerIcon: "Показывать иконки номадов",
   settingsTrafficLightBudgetColors: "Цвета бюджета светофора",
   settingsAskAiForGoodPrices: "Спросить ИИ о хороших ценах",
+  settingsInfoButtonA11y: "Подробнее о %{setting}",
   trafficLightInfoTitle: "Цвета бюджета светофора",
   trafficLightInfoText:
     "Цвета бюджета теперь используют систему светофора:\n\n🟢 Зеленый: В пределах бюджета\n🟠 Оранжевый: Превышен бюджет, но средние расходы в пределах бюджета\n🔴 Красный: Превышен бюджет И средние расходы превышают бюджет\n\nСреднее значение рассчитывается из текущего периода плюс предыдущий период (например, эта неделя + прошлая неделя для дневного просмотра).",
@@ -2446,7 +2450,7 @@ const ru = {
     "Когда включено, текущая скорость соединения отображается в заголовке на экранах обзора и списка расходов.",
   askAiForGoodPricesInfoTitle: "Спросить ИИ о хороших ценах",
   askAiForGoodPricesInfoText:
-    "Когда включено, вы можете спросить ИИ, разумна ли цена для вашего текущего местоположения, с экрана профиля.",
+    "Когда включено, вы можете спросить ИИ, разумна ли цена для вашего текущего местоположения, с экрана профиля и в форме расхода.",
   showWhoPaidInfoTitle: "Показывать иконки номадов",
   showWhoPaidInfoText:
     "Когда включено, маленькая иконка показывает, какой номад оплатил каждый расход. Применяется только если в бюджете больше одного номада.",


### PR DESCRIPTION
## Summary
- Add an (i) info button to every settings toggle in Settings, not just traffic-light budget colors.
- Show a plain-language explanation modal when tapped, with copy in EN/DE/FR/RU.
- Replace the traffic-light-specific modal with a reusable `SettingsInfoModal`.

## Test plan
- [ ] Open Settings and confirm every toggle shows an (i) button
- [ ] Tap info on a few toggles (e.g. hide special expenses, ask AI) and verify the explanation matches the setting behavior
- [ ] Confirm toggling a switch still works and does not open the info modal
- [x] `pnpm test __tests__/components/settings-section-info-buttons.test.tsx`