### PR TITLE
Responsive layout foundation for tablet/macOS (#387)

### DIFF
--- a/TravelCostApp/App.tsx
+++ b/TravelCostApp/App.tsx
@@ -95,12 +95,14 @@ import TripSummaryScreen from "./screens/TripSummaryScreen";
 import { versionCheck } from "./util/version";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import ChangelogScreen from "./screens/ChangelogScreen";
+import LayoutHarnessScreen from "./screens/LayoutHarnessScreen";
 import { Badge } from "react-native-paper";
 import { ExpenseData } from "./util/expense";
 
 import safeLogError from "./util/error";
 import { constantScale, dynamicScale } from "./util/scalingUtil";
 import OrientationContextProvider from "./store/orientation-context";
+import LayoutContextProvider from "./store/layout-context";
 import {
   initializeVexo,
   identifyUser,
@@ -322,6 +324,17 @@ function AuthenticatedStack() {
               presentation: "modal",
             }}
           />
+          {__DEV__ ? (
+            <Stack.Screen
+              name="LayoutHarness"
+              component={LayoutHarnessScreen}
+              options={{
+                headerShown: true,
+                title: "Layout harness",
+                presentation: "modal",
+              }}
+            />
+          ) : null}
 
           <Stack.Screen
             name="Changelog"
@@ -862,13 +875,15 @@ export default function App() {
                   <UserContextProvider>
                     <SettingsProvider>
                       <NetworkProvider>
-                        <OrientationContextProvider>
-                          <GestureHandlerRootView style={{ flex: 1 }}>
-                            <Root />
+                        <LayoutContextProvider>
+                          <OrientationContextProvider>
+                            <GestureHandlerRootView style={{ flex: 1 }}>
+                              <Root />
 
-                            <ToastComponent />
-                          </GestureHandlerRootView>
-                        </OrientationContextProvider>
+                              <ToastComponent />
+                            </GestureHandlerRootView>
+                          </OrientationContextProvider>
+                        </LayoutContextProvider>
                       </NetworkProvider>
                     </SettingsProvider>
                   </UserContextProvider>

--- a/TravelCostApp/__tests__/components/content-frame.test.tsx
+++ b/TravelCostApp/__tests__/components/content-frame.test.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { StyleSheet } from "react-native";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import ContentFrame from "../../components/layout/ContentFrame";
+import { layoutFor } from "../../util/layout";
+
+describe("ContentFrame", () => {
+  it("centers content with an 800px max width and layout spacing padding", () => {
+    const layout = layoutFor({ width: 1024, height: 768 });
+    const screen = renderWithAppProviders(
+      <ContentFrame testID="content-frame" layout={layout}>
+        <></>
+      </ContentFrame>,
+      { wrapNavigation: false }
+    );
+
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("content-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.maxWidth).toBe(800);
+    expect(frameStyle.alignSelf).toBe("center");
+    expect(frameStyle.width).toBe("100%");
+    expect(frameStyle.paddingHorizontal).toBe(layout.space(3));
+  });
+});

--- a/TravelCostApp/__tests__/components/modal-frame.test.tsx
+++ b/TravelCostApp/__tests__/components/modal-frame.test.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { StyleSheet } from "react-native";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import ModalFrame from "../../components/layout/ModalFrame";
+import { layoutFor } from "../../util/layout";
+
+describe("ModalFrame", () => {
+  it("uses full width on narrow viewports", () => {
+    const layout = layoutFor({ width: 390, height: 844 });
+    const screen = renderWithAppProviders(
+      <ModalFrame testID="modal-frame" layout={layout}>
+        <></>
+      </ModalFrame>,
+      { wrapNavigation: false }
+    );
+
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("modal-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.width).toBe("100%");
+    expect(frameStyle.alignSelf).toBeUndefined();
+  });
+
+  it("centers modal content with a max width once the modal breakpoint is wide", () => {
+    const layout = layoutFor({ width: 700, height: 900 });
+    const screen = renderWithAppProviders(
+      <ModalFrame testID="modal-frame" layout={layout}>
+        <></>
+      </ModalFrame>,
+      { wrapNavigation: false }
+    );
+
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("modal-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.width).toBe("100%");
+    expect(frameStyle.maxWidth).toBe(600);
+    expect(frameStyle.alignSelf).toBe("center");
+  });
+});

--- a/TravelCostApp/__tests__/components/responsive-grid.test.tsx
+++ b/TravelCostApp/__tests__/components/responsive-grid.test.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { StyleSheet, Text } from "react-native";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import ResponsiveGrid from "../../components/layout/ResponsiveGrid";
+import { layoutFor } from "../../util/layout";
+
+describe("ResponsiveGrid", () => {
+  it("lays out children in two columns with column-first flow on wide breakpoints", () => {
+    const layout = layoutFor({ width: 1024, height: 768 });
+    const screen = renderWithAppProviders(
+      <ResponsiveGrid
+        testID="responsive-grid"
+        layout={layout}
+        items={[
+          { key: "one", render: () => <Text>One</Text> },
+          { key: "two", render: () => <Text>Two</Text> },
+          { key: "three", render: () => <Text>Three</Text> },
+          { key: "four", render: () => <Text>Four</Text> },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const gridStyle = StyleSheet.flatten(
+      screen.getByTestId("responsive-grid").props.style
+    ) as Record<string, unknown>;
+
+    expect(gridStyle.flexDirection).toBe("row");
+    expect(gridStyle.flexWrap).toBe("wrap");
+    expect(screen.getAllByTestId("responsive-grid-column")).toHaveLength(2);
+    expect(screen.getByText("One")).toBeTruthy();
+    expect(screen.getByText("Three")).toBeTruthy();
+  });
+});

--- a/TravelCostApp/__tests__/components/responsive-grid.test.tsx
+++ b/TravelCostApp/__tests__/components/responsive-grid.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { StyleSheet, Text } from "react-native";
+import { within } from "@testing-library/react-native";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import ResponsiveGrid from "../../components/layout/ResponsiveGrid";
 import { layoutFor } from "../../util/layout";
@@ -12,10 +13,13 @@ describe("ResponsiveGrid", () => {
         testID="responsive-grid"
         layout={layout}
         items={[
-          { key: "one", render: () => <Text>One</Text> },
-          { key: "two", render: () => <Text>Two</Text> },
-          { key: "three", render: () => <Text>Three</Text> },
-          { key: "four", render: () => <Text>Four</Text> },
+          { key: "one", render: () => <Text testID="grid-item-one">One</Text> },
+          { key: "two", render: () => <Text testID="grid-item-two">Two</Text> },
+          {
+            key: "three",
+            render: () => <Text testID="grid-item-three">Three</Text>,
+          },
+          { key: "four", render: () => <Text testID="grid-item-four">Four</Text> },
         ]}
       />,
       { wrapNavigation: false }
@@ -27,8 +31,28 @@ describe("ResponsiveGrid", () => {
 
     expect(gridStyle.flexDirection).toBe("row");
     expect(gridStyle.flexWrap).toBe("wrap");
+
+    const [leftColumn, rightColumn] = screen.getAllByTestId("responsive-grid-column");
+    expect(within(leftColumn).getByTestId("grid-item-one")).toBeTruthy();
+    expect(within(leftColumn).getByTestId("grid-item-three")).toBeTruthy();
+    expect(within(rightColumn).getByTestId("grid-item-two")).toBeTruthy();
+    expect(within(rightColumn).getByTestId("grid-item-four")).toBeTruthy();
+  });
+
+  it("uses two columns from the modal breakpoint upward", () => {
+    const layout = layoutFor({ width: 700, height: 900 });
+    const screen = renderWithAppProviders(
+      <ResponsiveGrid
+        testID="responsive-grid"
+        layout={layout}
+        items={[
+          { key: "one", render: () => <Text testID="grid-item-one">One</Text> },
+          { key: "two", render: () => <Text testID="grid-item-two">Two</Text> },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
     expect(screen.getAllByTestId("responsive-grid-column")).toHaveLength(2);
-    expect(screen.getByText("One")).toBeTruthy();
-    expect(screen.getByText("Three")).toBeTruthy();
   });
 });

--- a/TravelCostApp/__tests__/screens/recent-expenses-tablet-layout.test.tsx
+++ b/TravelCostApp/__tests__/screens/recent-expenses-tablet-layout.test.tsx
@@ -1,0 +1,139 @@
+import * as React from "react";
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return { ...actual, useScrollToTop: jest.fn() };
+});
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("react-native-dropdown-picker", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return function MockDropDownPicker(props: {
+    containerStyle?: object;
+    style?: object;
+  }) {
+    return (
+      <View
+        testID="mock-dropdown-picker"
+        style={[props.containerStyle, props.style]}
+      />
+    );
+  };
+});
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+  identifyUser: jest.fn(async () => {}),
+  initializeVexo: jest.fn(async () => true),
+  VexoUserContext: {},
+}));
+
+jest.mock("react-native-toast-message/lib/src/Toast", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+}));
+
+jest.mock("../../components/UI/ToastComponent", () => ({
+  showBanner: jest.fn(),
+}));
+
+jest.mock("../../util/currencyExchange", () => ({
+  getRate: jest.fn(async () => 1),
+}));
+
+jest.mock("../../components/ExpensesOutput/ExpensesOverview", () => {
+  const React = require("react");
+  return {
+    MemoizedExpensesOverview: () => null,
+  };
+});
+jest.mock("../../components/ExpensesOutput/ExpensesOutput", () => ({
+  MemoizedExpensesOutput: () => null,
+}));
+jest.mock("../../components/ManageExpense/AddExpenseButton", () => () => null);
+jest.mock("../../components/UI/MiniSyncIndicator", () => () => null);
+jest.mock("../../components/ExpensesOutput/RecentExpensesUtil", () => ({
+  fetchAndSetExpenses: jest.fn(async () => {}),
+}));
+jest.mock("../../util/http", () => ({
+  fetchTravelerIsTouched: jest.fn(async () => true),
+}));
+jest.mock("../../util/refreshWithToast", () => ({
+  refreshWithToast: jest.fn(async () => {}),
+}));
+
+import { Dimensions, StyleSheet } from "react-native";
+
+import RecentExpenses from "../../screens/RecentExpenses";
+import LayoutContextProvider from "../../store/layout-context";
+import OrientationContextProvider from "../../store/orientation-context";
+import { makeExpense } from "../fixtures/expense";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+const monthExpenses = [
+  makeExpense({ id: "e1", calcAmount: 75, amount: 75 }),
+];
+
+function flattenScreenContainer(screen: { getByTestId: (id: string) => any }) {
+  return StyleSheet.flatten(
+    screen.getByTestId("recent-expenses-screen").props.style
+  ) as Record<string, unknown>;
+}
+
+function renderRecentExpensesWithLayout(width: number, height: number) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 3,
+    fontScale: 1,
+  });
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <OrientationContextProvider>
+        <RecentExpenses navigation={{ navigate: jest.fn() } as any} />
+      </OrientationContextProvider>
+    </LayoutContextProvider>,
+    {
+      wrapNavigation: false,
+      expenses: {
+        expenses: monthExpenses,
+        getRecentExpenses: () => monthExpenses,
+      },
+      user: {
+        periodName: "month",
+      },
+    }
+  );
+}
+
+describe("RecentExpenses tablet layout adapter", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not apply tablet padding on phone portrait widths", () => {
+    const screen = renderRecentExpensesWithLayout(390, 844);
+    const container = flattenScreenContainer(screen);
+
+    expect(container.paddingTop).toBeUndefined();
+  });
+
+  it("applies tablet padding when the layout profile is no longer narrow", () => {
+    const portrait = flattenScreenContainer(renderRecentExpensesWithLayout(390, 844));
+    const landscape = flattenScreenContainer(renderRecentExpensesWithLayout(844, 390));
+
+    expect(portrait.paddingTop).toBeUndefined();
+    expect(landscape.paddingTop).toBeGreaterThan(0);
+  });
+});

--- a/TravelCostApp/__tests__/store/layout-context.test.tsx
+++ b/TravelCostApp/__tests__/store/layout-context.test.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { Dimensions, Text } from "react-native";
+import { act, render } from "@testing-library/react-native";
+
+import LayoutContextProvider, {
+  useLayoutProfile,
+} from "../../store/layout-context";
+
+function BreakpointProbe() {
+  const layout = useLayoutProfile();
+  return <Text testID="layout-breakpoint">{layout.breakpoint}</Text>;
+}
+
+describe("LayoutContextProvider", () => {
+  const dimensionListeners: Array<(event: { window: { width: number; height: number } }) => void> = [];
+
+  beforeEach(() => {
+    dimensionListeners.length = 0;
+    jest.spyOn(Dimensions, "get").mockReturnValue({
+      width: 390,
+      height: 844,
+      scale: 3,
+      fontScale: 1,
+    });
+    jest.spyOn(Dimensions, "addEventListener").mockImplementation((_event, listener) => {
+      dimensionListeners.push(listener as typeof dimensionListeners[number]);
+      return { remove: jest.fn() };
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("recomputes the layout profile when window dimensions change", () => {
+    const screen = render(
+      <LayoutContextProvider>
+        <BreakpointProbe />
+      </LayoutContextProvider>
+    );
+
+    expect(screen.getByTestId("layout-breakpoint")).toHaveTextContent("narrow");
+
+    act(() => {
+      jest.spyOn(Dimensions, "get").mockReturnValue({
+        width: 1024,
+        height: 768,
+        scale: 2,
+        fontScale: 2,
+      });
+      dimensionListeners.forEach((listener) =>
+        listener({ window: { width: 1024, height: 768 } })
+      );
+    });
+
+    expect(screen.getByTestId("layout-breakpoint")).toHaveTextContent("wide");
+  });
+});

--- a/TravelCostApp/__tests__/store/orientation-context.test.tsx
+++ b/TravelCostApp/__tests__/store/orientation-context.test.tsx
@@ -45,4 +45,48 @@ describe("OrientationContext adapter", () => {
       "PORTRAIT:tablet:portrait"
     );
   });
+
+  it("keeps phone portrait on the narrow layout profile", () => {
+    jest.spyOn(Dimensions, "get").mockReturnValue({
+      width: 390,
+      height: 844,
+      scale: 3,
+      fontScale: 1,
+    });
+
+    const screen = renderWithAppProviders(
+      <LayoutContextProvider>
+        <OrientationContextProvider>
+          <Probe />
+        </OrientationContextProvider>
+      </LayoutContextProvider>,
+      { wrapNavigation: false }
+    );
+
+    expect(screen.getByTestId("orientation-probe")).toHaveTextContent(
+      "PORTRAIT:phone:portrait"
+    );
+  });
+
+  it("treats landscape phone widths at or above 600px as tablet layout", () => {
+    jest.spyOn(Dimensions, "get").mockReturnValue({
+      width: 844,
+      height: 390,
+      scale: 3,
+      fontScale: 1,
+    });
+
+    const screen = renderWithAppProviders(
+      <LayoutContextProvider>
+        <OrientationContextProvider>
+          <Probe />
+        </OrientationContextProvider>
+      </LayoutContextProvider>,
+      { wrapNavigation: false }
+    );
+
+    expect(screen.getByTestId("orientation-probe")).toHaveTextContent(
+      "LANDSCAPE:tablet:landscape"
+    );
+  });
 });

--- a/TravelCostApp/__tests__/store/orientation-context.test.tsx
+++ b/TravelCostApp/__tests__/store/orientation-context.test.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { Dimensions, Text } from "react-native";
+
+import LayoutContextProvider from "../../store/layout-context";
+import OrientationContextProvider, {
+  OrientationContext,
+} from "../../store/orientation-context";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function Probe() {
+  const orientation = React.useContext(OrientationContext);
+  return (
+    <Text testID="orientation-probe">
+      {orientation.orientation}:{orientation.isTablet ? "tablet" : "phone"}:
+      {orientation.isPortrait ? "portrait" : "landscape"}
+    </Text>
+  );
+}
+
+describe("OrientationContext adapter", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("derives tablet and orientation flags from the layout profile", () => {
+    jest.spyOn(Dimensions, "get").mockReturnValue({
+      width: 700,
+      height: 900,
+      scale: 2,
+      fontScale: 2,
+    });
+
+    const screen = renderWithAppProviders(
+      <LayoutContextProvider>
+        <OrientationContextProvider>
+          <Probe />
+        </OrientationContextProvider>
+      </LayoutContextProvider>,
+      {
+        wrapNavigation: false,
+      }
+    );
+
+    expect(screen.getByTestId("orientation-probe")).toHaveTextContent(
+      "PORTRAIT:tablet:portrait"
+    );
+  });
+});

--- a/TravelCostApp/__tests__/styles/trip-period-layout-tokens.test.ts
+++ b/TravelCostApp/__tests__/styles/trip-period-layout-tokens.test.ts
@@ -1,21 +1,47 @@
+import { Dimensions } from "react-native";
+
 import { layoutFor } from "../../util/layout";
+import { dynamicScale } from "../../util/scalingUtil";
 import { tripPeriodLayoutTokens } from "../../styles/trip-period-layout-tokens";
 
 describe("trip-period-layout-tokens", () => {
-  it("builds period header spacing from fixed layout tokens instead of dynamicScale", () => {
-    const layout = layoutFor({ width: 390, height: 844 });
-    const tokens = tripPeriodLayoutTokens(layout);
+  const phoneViewport = { width: 390, height: 844 };
 
-    expect(tokens.periodHeaderRow.gap).toBe(16);
-    expect(tokens.periodHeaderRow.paddingHorizontal).toBe(16);
-    expect(tokens.periodHeaderLabelFontSize).toBe(28);
+  beforeEach(() => {
+    jest.spyOn(Dimensions, "get").mockReturnValue({
+      width: phoneViewport.width,
+      height: phoneViewport.height,
+      scale: 3,
+      fontScale: 1,
+    });
   });
 
-  it("uses layout type scale for period header label typography only", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("preserves narrow-phone period chrome sizes from the legacy dynamicScale baseline", () => {
+    const layout = layoutFor(phoneViewport);
+    const tokens = tripPeriodLayoutTokens(layout);
+
+    expect(tokens.headerCard.minHeight).toBe(dynamicScale(52, true));
+    expect(tokens.headerCard.paddingVertical).toBe(dynamicScale(4, true));
+    expect(tokens.dropdownContainer.marginTop).toBe(dynamicScale(2, true));
+    expect(tokens.periodHeaderRow.gap).toBe(dynamicScale(12, true));
+    expect(tokens.periodHeaderRow.marginTop).toBe(dynamicScale(18, true));
+    expect(tokens.periodHeaderRow.paddingHorizontal).toBe(dynamicScale(12));
+    expect(tokens.periodDateHeader.marginTop).toBe(dynamicScale(12, true));
+    expect(tokens.periodDateHeader.marginLeft).toBe(dynamicScale(18));
+    expect(tokens.periodDateHeader.marginBottom).toBe(dynamicScale(-4, true));
+    expect(tokens.periodHeaderLabelFontSize).toBe(dynamicScale(28, false, 0.5));
+  });
+
+  it("uses layout spacing tokens on wide breakpoints", () => {
     const wide = layoutFor({ width: 1024, height: 768 });
     const tokens = tripPeriodLayoutTokens(wide);
 
     expect(tokens.periodHeaderLabelFontSize).toBe(34);
     expect(tokens.periodHeaderRow.gap).toBe(20);
+    expect(tokens.headerCard.minHeight).toBe(40);
   });
 });

--- a/TravelCostApp/__tests__/styles/trip-period-layout-tokens.test.ts
+++ b/TravelCostApp/__tests__/styles/trip-period-layout-tokens.test.ts
@@ -1,0 +1,21 @@
+import { layoutFor } from "../../util/layout";
+import { tripPeriodLayoutTokens } from "../../styles/trip-period-layout-tokens";
+
+describe("trip-period-layout-tokens", () => {
+  it("builds period header spacing from fixed layout tokens instead of dynamicScale", () => {
+    const layout = layoutFor({ width: 390, height: 844 });
+    const tokens = tripPeriodLayoutTokens(layout);
+
+    expect(tokens.periodHeaderRow.gap).toBe(16);
+    expect(tokens.periodHeaderRow.paddingHorizontal).toBe(16);
+    expect(tokens.periodHeaderLabelFontSize).toBe(28);
+  });
+
+  it("uses layout type scale for period header label typography only", () => {
+    const wide = layoutFor({ width: 1024, height: 768 });
+    const tokens = tripPeriodLayoutTokens(wide);
+
+    expect(tokens.periodHeaderLabelFontSize).toBe(34);
+    expect(tokens.periodHeaderRow.gap).toBe(20);
+  });
+});

--- a/TravelCostApp/__tests__/util/layout-harness.test.ts
+++ b/TravelCostApp/__tests__/util/layout-harness.test.ts
@@ -1,0 +1,33 @@
+import { Dimensions } from "react-native";
+
+import { compareLayoutToLegacyScaling } from "../../util/layout-harness";
+import { layoutFor } from "../../util/layout";
+import { dynamicScale } from "../../util/scalingUtil";
+
+describe("layout harness", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows fixed layout spacing stays below legacy tablet-inflated gaps on wide iPad", () => {
+    jest.spyOn(Dimensions, "get").mockReturnValue({
+      width: 1024,
+      height: 768,
+      scale: 2,
+      fontScale: 2,
+    });
+
+    const comparison = compareLayoutToLegacyScaling({ width: 1024, height: 768 });
+
+    expect(comparison.layoutSpacing).toBe(24);
+    expect(comparison.layoutSpacing).toBeLessThan(comparison.legacySpacing);
+  });
+
+  it("documents breakpoint spacing and typography without using tabletScaleMult for gaps", () => {
+    const wide = layoutFor({ width: 1024, height: 768 });
+
+    expect(wide.space(4)).toBe(24);
+    expect(wide.type(20)).toBe(24);
+    expect(wide.space(4)).not.toBe(dynamicScale(20, true));
+  });
+});

--- a/TravelCostApp/__tests__/util/layout.test.ts
+++ b/TravelCostApp/__tests__/util/layout.test.ts
@@ -1,0 +1,50 @@
+import { layoutFor } from "../../util/layout";
+
+describe("layoutFor", () => {
+  it("maps a phone viewport to a narrow profile with 800 content max width", () => {
+    const layout = layoutFor({ width: 390, height: 844 });
+
+    expect(layout.breakpoint).toBe("narrow");
+    expect(layout.contentMaxWidth).toBe(800);
+  });
+
+  it("maps live window width to narrow, medium, and wide breakpoints", () => {
+    expect(layoutFor({ width: 599, height: 800 }).breakpoint).toBe("narrow");
+    expect(layoutFor({ width: 600, height: 800 }).breakpoint).toBe("medium");
+    expect(layoutFor({ width: 767, height: 800 }).breakpoint).toBe("medium");
+    expect(layoutFor({ width: 768, height: 800 }).breakpoint).toBe("wide");
+  });
+
+  it("includes orientation from live width and height", () => {
+    expect(layoutFor({ width: 390, height: 844 }).orientation).toBe("portrait");
+    expect(layoutFor({ width: 1024, height: 768 }).orientation).toBe("landscape");
+  });
+
+  it("returns fixed spacing tokens that do not scale with viewport width", () => {
+    const narrowPhone = layoutFor({ width: 320, height: 568 });
+    const narrowTablet = layoutFor({ width: 599, height: 800 });
+
+    expect(narrowPhone.space(1)).toBe(8);
+    expect(narrowPhone.space(4)).toBe(20);
+    expect(narrowTablet.space(4)).toBe(20);
+  });
+
+  it("uses slightly looser spacing tokens on wide breakpoints only", () => {
+    const narrow = layoutFor({ width: 390, height: 844 });
+    const wide = layoutFor({ width: 1024, height: 768 });
+
+    expect(narrow.space(3)).toBe(16);
+    expect(wide.space(3)).toBe(20);
+  });
+
+  it("caps typography scale for fonts and icons without affecting spacing", () => {
+    const narrow = layoutFor({ width: 390, height: 844 });
+    const medium = layoutFor({ width: 700, height: 900 });
+    const wide = layoutFor({ width: 1024, height: 768 });
+
+    expect(narrow.type(20)).toBe(20);
+    expect(medium.type(20)).toBe(21);
+    expect(wide.type(20)).toBe(24);
+    expect(wide.space(3)).not.toBe(wide.type(16));
+  });
+});

--- a/TravelCostApp/__tests__/util/shadow-styles.test.ts
+++ b/TravelCostApp/__tests__/util/shadow-styles.test.ts
@@ -2,13 +2,18 @@ import { StyleSheet } from "react-native";
 
 import { GlobalStyles } from "../../constants/styles";
 import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
-import { dynamicScale } from "../../util/scalingUtil";
+import { tripPeriodLayoutTokens } from "../../styles/trip-period-layout-tokens";
+import { layoutFor } from "../../util/layout";
 import {
   assertSolidBackgroundForShadow,
   styleHasShadow,
 } from "../../util/shadow-styles";
 
 describe("shadow styles", () => {
+  const periodLayout = tripPeriodLayoutTokens(
+    layoutFor({ width: 390, height: 844 })
+  );
+
   it("detects shadow props on a style object", () => {
     expect(styleHasShadow({ shadowColor: "#000", shadowOpacity: 0.5 })).toBe(
       true
@@ -40,7 +45,7 @@ describe("shadow styles", () => {
       shadowRegressionStyles.expenseGraphCategoryCard
     ) as Record<string, unknown>;
 
-    expect(flat.height).toBe(dynamicScale(52, true));
+    expect(flat.height).toBe(periodLayout.headerCard.minHeight);
     expect(flat.justifyContent).toBe("center");
   });
 
@@ -99,8 +104,8 @@ describe("shadow styles", () => {
       shadowRegressionStyles.overviewDropdownContainer
     ) as Record<string, unknown>;
 
-    expect(dropdown.minHeight).toBe(dynamicScale(52, true));
-    expect(dropdown.paddingVertical).toBe(dynamicScale(4, true));
+    expect(dropdown.minHeight).toBe(periodLayout.headerCard.minHeight);
+    expect(dropdown.paddingVertical).toBe(periodLayout.headerCard.paddingVertical);
   });
 
   it("overview period header row separates cards with explicit gap", () => {

--- a/TravelCostApp/components/layout/ContentFrame.tsx
+++ b/TravelCostApp/components/layout/ContentFrame.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { View, type StyleProp, type ViewStyle } from "react-native";
+
+import type { LayoutProfile } from "../../util/layout";
+
+type ContentFrameProps = {
+  layout: LayoutProfile;
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+export default function ContentFrame({
+  layout,
+  children,
+  style,
+  testID,
+}: ContentFrameProps) {
+  return (
+    <View
+      testID={testID}
+      style={[
+        {
+          width: "100%",
+          maxWidth: layout.contentMaxWidth,
+          alignSelf: "center",
+          paddingHorizontal: layout.space(3),
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}

--- a/TravelCostApp/components/layout/ModalFrame.tsx
+++ b/TravelCostApp/components/layout/ModalFrame.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { View, type StyleProp, type ViewStyle } from "react-native";
+
+import type { LayoutProfile } from "../../util/layout";
+import { isModalWide, MODAL_MAX_WIDTH } from "../../util/modal-frame-layout";
+
+type ModalFrameProps = {
+  layout: LayoutProfile;
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+export default function ModalFrame({
+  layout,
+  children,
+  style,
+  testID,
+}: ModalFrameProps) {
+  const wide = isModalWide(layout);
+
+  return (
+    <View
+      testID={testID}
+      style={[
+        {
+          width: "100%",
+          ...(wide
+            ? {
+                maxWidth: MODAL_MAX_WIDTH,
+                alignSelf: "center",
+              }
+            : {}),
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}

--- a/TravelCostApp/components/layout/ResponsiveGrid.tsx
+++ b/TravelCostApp/components/layout/ResponsiveGrid.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { View, type StyleProp, type ViewStyle } from "react-native";
+
+import type { LayoutProfile } from "../../util/layout";
+
+type ResponsiveGridItem = {
+  key: string;
+  render: () => React.ReactNode;
+};
+
+type ResponsiveGridProps = {
+  layout: LayoutProfile;
+  items: ResponsiveGridItem[];
+  columnWidths?: [number, number];
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+function splitColumnFirst(items: ResponsiveGridItem[]) {
+  const left: ResponsiveGridItem[] = [];
+  const right: ResponsiveGridItem[] = [];
+
+  items.forEach((item, index) => {
+    if (index % 2 === 0) {
+      left.push(item);
+      return;
+    }
+    right.push(item);
+  });
+
+  return [left, right] as const;
+}
+
+export default function ResponsiveGrid({
+  layout,
+  items,
+  columnWidths = [1, 1],
+  style,
+  testID,
+}: ResponsiveGridProps) {
+  const isWide = layout.breakpoint === "wide";
+  const [leftColumn, rightColumn] = splitColumnFirst(items);
+  const totalWidth = columnWidths[0] + columnWidths[1];
+
+  if (!isWide) {
+    return (
+      <View testID={testID} style={style}>
+        {items.map((item) => (
+          <React.Fragment key={item.key}>{item.render()}</React.Fragment>
+        ))}
+      </View>
+    );
+  }
+
+  return (
+    <View
+      testID={testID}
+      style={[{ flexDirection: "row", flexWrap: "wrap", gap: layout.space(3) }, style]}
+    >
+      <View
+        testID="responsive-grid-column"
+        style={{ flexGrow: columnWidths[0], flexBasis: `${(columnWidths[0] / totalWidth) * 100}%` }}
+      >
+        {leftColumn.map((item) => (
+          <React.Fragment key={item.key}>{item.render()}</React.Fragment>
+        ))}
+      </View>
+      <View
+        testID="responsive-grid-column"
+        style={{ flexGrow: columnWidths[1], flexBasis: `${(columnWidths[1] / totalWidth) * 100}%` }}
+      >
+        {rightColumn.map((item) => (
+          <React.Fragment key={item.key}>{item.render()}</React.Fragment>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/TravelCostApp/components/layout/ResponsiveGrid.tsx
+++ b/TravelCostApp/components/layout/ResponsiveGrid.tsx
@@ -38,11 +38,11 @@ export default function ResponsiveGrid({
   style,
   testID,
 }: ResponsiveGridProps) {
-  const isWide = layout.breakpoint === "wide";
+  const isMultiColumn = layout.breakpoint !== "narrow";
   const [leftColumn, rightColumn] = splitColumnFirst(items);
   const totalWidth = columnWidths[0] + columnWidths[1];
 
-  if (!isWide) {
+  if (!isMultiColumn) {
     return (
       <View testID={testID} style={style}>
         {items.map((item) => (

--- a/TravelCostApp/screens/LayoutHarnessScreen.tsx
+++ b/TravelCostApp/screens/LayoutHarnessScreen.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { ScrollView, Text, View } from "react-native";
+
+import { useWindowSize } from "../components/Hooks/useWindowSize";
+import { useLayoutProfile } from "../store/layout-context";
+import { compareLayoutToLegacyScaling } from "../util/layout-harness";
+
+const VIEWPORTS = [
+  { width: 390, height: 844 },
+  { width: 700, height: 900 },
+  { width: 1024, height: 768 },
+];
+
+export default function LayoutHarnessScreen() {
+  const liveLayout = useLayoutProfile();
+  const { width, height } = useWindowSize();
+  const liveComparison = compareLayoutToLegacyScaling({ width, height });
+
+  return (
+    <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <Text testID="layout-harness-live-breakpoint">
+        Live breakpoint: {liveLayout.breakpoint}
+      </Text>
+      <Text testID="layout-harness-live-spacing">
+        Live space(4): {liveLayout.space(4)}
+      </Text>
+      <Text testID="layout-harness-live-legacy-spacing">
+        Legacy dynamicScale(20): {liveComparison.legacySpacing}
+      </Text>
+
+      {VIEWPORTS.map((viewport) => {
+        const comparison = compareLayoutToLegacyScaling(viewport);
+
+        return (
+          <View key={`${viewport.width}x${viewport.height}`} testID="layout-harness-row">
+            <Text>
+              {viewport.width}x{viewport.height} · {comparison.breakpoint} ·{" "}
+              {comparison.orientation}
+            </Text>
+            <Text>
+              space(4) {comparison.layoutSpacing} vs legacy {comparison.legacySpacing}
+            </Text>
+            <Text>
+              type(20) {comparison.layoutTypography} vs legacy{" "}
+              {comparison.legacyTypography}
+            </Text>
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/TravelCostApp/screens/LayoutHarnessScreen.tsx
+++ b/TravelCostApp/screens/LayoutHarnessScreen.tsx
@@ -17,7 +17,12 @@ export default function LayoutHarnessScreen() {
   const liveComparison = compareLayoutToLegacyScaling({ width, height });
 
   return (
-    <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+    <ScrollView
+      contentContainerStyle={{
+        padding: liveLayout.space(3),
+        gap: liveLayout.space(3),
+      }}
+    >
       <Text testID="layout-harness-live-breakpoint">
         Live breakpoint: {liveLayout.breakpoint}
       </Text>

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -383,7 +383,10 @@ function RecentExpenses({ navigation }) {
   //   return <LoadingOverlay />;
   // }
   return (
-    <View style={[styles.container, isTablet && styles.tabletPaddingTop]}>
+    <View
+      testID="recent-expenses-screen"
+      style={[styles.container, isTablet && styles.tabletPaddingTop]}
+    >
       <View
         testID="period-date-header"
         style={[

--- a/TravelCostApp/store/layout-context.tsx
+++ b/TravelCostApp/store/layout-context.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useMemo } from "react";
+import PropTypes from "prop-types";
+
+import { useWindowSize } from "../components/Hooks/useWindowSize";
+import { layoutFor, type LayoutProfile } from "../util/layout";
+
+export const LayoutContext = createContext<LayoutProfile>(
+  layoutFor({ width: 390, height: 844 })
+);
+
+const LayoutContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const { width, height } = useWindowSize();
+  const profile = useMemo(() => layoutFor({ width, height }), [width, height]);
+
+  return (
+    <LayoutContext.Provider value={profile}>{children}</LayoutContext.Provider>
+  );
+};
+
+export function useLayoutProfile() {
+  return useContext(LayoutContext);
+}
+
+export default LayoutContextProvider;
+
+LayoutContextProvider.propTypes = {
+  children: PropTypes.node,
+};

--- a/TravelCostApp/store/orientation-context.tsx
+++ b/TravelCostApp/store/orientation-context.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { createContext } from "react";
 import PropTypes from "prop-types";
-import { useOrientation } from "../components/Hooks/useOrientation";
+
 import { useWindowSize } from "../components/Hooks/useWindowSize";
-import { isTablet as getIsTablet } from "../util/scalingUtil";
+import { useLayoutProfile } from "./layout-context";
 
 export const OrientationContext = createContext({
   orientation: "PORTRAIT",
@@ -15,15 +15,20 @@ export const OrientationContext = createContext({
 });
 
 const OrientationContextProvider = ({ children }) => {
-  const orientation = useOrientation();
+  const layout = useLayoutProfile();
   const { width, height } = useWindowSize();
-  const isPortrait = orientation === "PORTRAIT";
-  const isLandscape = orientation === "LANDSCAPE";
-  const isTablet = getIsTablet();
+  const orientation = layout.orientation === "portrait" ? "PORTRAIT" : "LANDSCAPE";
 
   return (
     <OrientationContext.Provider
-      value={{ orientation, isPortrait, isLandscape, isTablet, width, height }}
+      value={{
+        orientation,
+        isPortrait: layout.orientation === "portrait",
+        isLandscape: layout.orientation === "landscape",
+        isTablet: layout.breakpoint !== "narrow",
+        width,
+        height,
+      }}
     >
       {children}
     </OrientationContext.Provider>

--- a/TravelCostApp/styles/shadow-regression-styles.ts
+++ b/TravelCostApp/styles/shadow-regression-styles.ts
@@ -3,16 +3,21 @@ import { Platform, StyleSheet } from "react-native";
 import { GlobalStyles } from "../constants/styles";
 import { actionRowCardShell } from "./action-row-tokens";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
+import { layoutFor } from "../util/layout";
+import { tripPeriodLayoutTokens } from "./trip-period-layout-tokens";
 
-export const periodHeaderLabelFontSize = dynamicScale(28, false, 0.5);
+const defaultLayout = layoutFor({ width: 390, height: 844 });
+const periodLayout = tripPeriodLayoutTokens(defaultLayout);
+
+export const periodHeaderLabelFontSize = periodLayout.periodHeaderLabelFontSize;
 
 const statisticsCardShadow = {
   backgroundColor: GlobalStyles.colors.backgroundColor,
-  borderRadius: dynamicScale(10, false, 0.5),
+  borderRadius: 10,
   borderWidth: 1,
   borderColor: GlobalStyles.colors.gray300,
-  marginHorizontal: dynamicScale(16),
-  marginBottom: dynamicScale(20, true),
+  marginHorizontal: periodLayout.periodHeaderRow.paddingHorizontal,
+  marginBottom: periodLayout.periodHeaderRow.marginBottom,
   ...Platform.select({
     ios: {
       shadowColor: "#000",
@@ -43,28 +48,23 @@ const overviewHeaderCardShadow = Platform.select({
 });
 
 const overviewHeaderCardBase = {
-  flex: 1,
-  maxWidth: "50%" as const,
-  minHeight: dynamicScale(52, true),
+  ...periodLayout.headerCard,
   backgroundColor: GlobalStyles.colors.backgroundColor,
-  borderRadius: 10,
-  borderWidth: 1,
   borderColor: GlobalStyles.colors.gray300,
-  paddingVertical: dynamicScale(4, true),
   ...overviewHeaderCardShadow,
 };
 
 export const shadowRegressionStyles = StyleSheet.create({
   statisticsPieCategoryCard: statisticsCardShadow,
   expenseGraphCategoryCard: {
-    height: dynamicScale(52, true),
-    minWidth: dynamicScale(200),
+    height: periodLayout.headerCard.minHeight,
+    minWidth: 200,
     justifyContent: "center",
     ...statisticsCardShadow,
   },
   overviewDropdownContainer: {
     ...overviewHeaderCardBase,
-    marginTop: dynamicScale(2, true),
+    marginTop: periodLayout.periodDateHeader.marginTop,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -73,21 +73,8 @@ export const shadowRegressionStyles = StyleSheet.create({
     borderWidth: 0,
     backgroundColor: GlobalStyles.colors.backgroundColor,
   },
-  overviewPeriodHeaderRow: {
-    flexDirection: "row",
-    justifyContent: "space-evenly",
-    alignItems: "stretch",
-    gap: dynamicScale(12, true),
-    zIndex: 10,
-    marginTop: dynamicScale(18, true),
-    paddingHorizontal: dynamicScale(12),
-    marginBottom: dynamicScale(12, true),
-  },
-  overviewPeriodDateHeader: {
-    marginTop: dynamicScale(12, true),
-    marginLeft: dynamicScale(18),
-    marginBottom: dynamicScale(-4, true),
-  },
+  overviewPeriodHeaderRow: periodLayout.periodHeaderRow,
+  overviewPeriodDateHeader: periodLayout.periodDateHeader,
   expensesSummaryContainer: {
     ...overviewHeaderCardBase,
     alignItems: "center",

--- a/TravelCostApp/styles/shadow-regression-styles.ts
+++ b/TravelCostApp/styles/shadow-regression-styles.ts
@@ -64,7 +64,7 @@ export const shadowRegressionStyles = StyleSheet.create({
   },
   overviewDropdownContainer: {
     ...overviewHeaderCardBase,
-    marginTop: periodLayout.periodDateHeader.marginTop,
+    marginTop: periodLayout.dropdownContainer.marginTop,
     alignItems: "center",
     justifyContent: "center",
   },

--- a/TravelCostApp/styles/trip-period-layout-tokens.ts
+++ b/TravelCostApp/styles/trip-period-layout-tokens.ts
@@ -1,0 +1,32 @@
+import type { LayoutProfile } from "../util/layout";
+
+export function tripPeriodLayoutTokens(layout: LayoutProfile) {
+  return {
+    periodHeaderLabelFontSize: layout.type(28),
+    periodHeaderRow: {
+      flexDirection: "row" as const,
+      justifyContent: "space-evenly" as const,
+      alignItems: "stretch" as const,
+      gap: layout.space(3),
+      zIndex: 10,
+      marginTop: layout.space(4),
+      paddingHorizontal: layout.space(3),
+      marginBottom: layout.space(3),
+    },
+    periodDateHeader: {
+      marginTop: layout.space(3),
+      marginLeft: layout.space(4),
+      marginBottom: -layout.space(1),
+    },
+    headerCard: {
+      flex: 1,
+      maxWidth: "50%" as const,
+      minHeight: layout.space(6),
+      borderRadius: 10,
+      borderWidth: 1,
+      paddingVertical: layout.space(1),
+    },
+  };
+}
+
+export type TripPeriodLayoutTokens = ReturnType<typeof tripPeriodLayoutTokens>;

--- a/TravelCostApp/styles/trip-period-layout-tokens.ts
+++ b/TravelCostApp/styles/trip-period-layout-tokens.ts
@@ -1,14 +1,60 @@
 import type { LayoutProfile } from "../util/layout";
+import { dynamicScale } from "../util/scalingUtil";
 
-export function tripPeriodLayoutTokens(layout: LayoutProfile) {
+function sharedPeriodChrome(layout: LayoutProfile) {
   return {
-    periodHeaderLabelFontSize: layout.type(28),
     periodHeaderRow: {
       flexDirection: "row" as const,
       justifyContent: "space-evenly" as const,
       alignItems: "stretch" as const,
-      gap: layout.space(3),
       zIndex: 10,
+    },
+    headerCard: {
+      flex: 1,
+      maxWidth: "50%" as const,
+      borderRadius: 10,
+      borderWidth: 1,
+    },
+  };
+}
+
+/** Preserves pre-#387 phone/tablet-medium chrome until screens consume a live layout profile (#388). */
+function narrowAndMediumPeriodChrome(layout: LayoutProfile) {
+  const shared = sharedPeriodChrome(layout);
+
+  return {
+    periodHeaderLabelFontSize: dynamicScale(28, false, 0.5),
+    periodHeaderRow: {
+      ...shared.periodHeaderRow,
+      gap: dynamicScale(12, true),
+      marginTop: dynamicScale(18, true),
+      paddingHorizontal: dynamicScale(12),
+      marginBottom: dynamicScale(12, true),
+    },
+    periodDateHeader: {
+      marginTop: dynamicScale(12, true),
+      marginLeft: dynamicScale(18),
+      marginBottom: dynamicScale(-4, true),
+    },
+    headerCard: {
+      ...shared.headerCard,
+      minHeight: dynamicScale(52, true),
+      paddingVertical: dynamicScale(4, true),
+    },
+    dropdownContainer: {
+      marginTop: dynamicScale(2, true),
+    },
+  };
+}
+
+function widePeriodChrome(layout: LayoutProfile) {
+  const shared = sharedPeriodChrome(layout);
+
+  return {
+    periodHeaderLabelFontSize: layout.type(28),
+    periodHeaderRow: {
+      ...shared.periodHeaderRow,
+      gap: layout.space(3),
       marginTop: layout.space(4),
       paddingHorizontal: layout.space(3),
       marginBottom: layout.space(3),
@@ -19,14 +65,22 @@ export function tripPeriodLayoutTokens(layout: LayoutProfile) {
       marginBottom: -layout.space(1),
     },
     headerCard: {
-      flex: 1,
-      maxWidth: "50%" as const,
+      ...shared.headerCard,
       minHeight: layout.space(6),
-      borderRadius: 10,
-      borderWidth: 1,
       paddingVertical: layout.space(1),
     },
+    dropdownContainer: {
+      marginTop: layout.space(1),
+    },
   };
+}
+
+export function tripPeriodLayoutTokens(layout: LayoutProfile) {
+  if (layout.breakpoint === "wide") {
+    return widePeriodChrome(layout);
+  }
+
+  return narrowAndMediumPeriodChrome(layout);
 }
 
 export type TripPeriodLayoutTokens = ReturnType<typeof tripPeriodLayoutTokens>;

--- a/TravelCostApp/util/layout-harness.ts
+++ b/TravelCostApp/util/layout-harness.ts
@@ -1,0 +1,29 @@
+import type { LayoutViewport } from "./layout";
+import { layoutFor } from "./layout";
+import { dynamicScale } from "./scalingUtil";
+
+export type LayoutHarnessComparison = {
+  viewport: LayoutViewport;
+  breakpoint: string;
+  orientation: string;
+  layoutSpacing: number;
+  legacySpacing: number;
+  layoutTypography: number;
+  legacyTypography: number;
+};
+
+export function compareLayoutToLegacyScaling(
+  viewport: LayoutViewport
+): LayoutHarnessComparison {
+  const layout = layoutFor(viewport);
+
+  return {
+    viewport,
+    breakpoint: layout.breakpoint,
+    orientation: layout.orientation,
+    layoutSpacing: layout.space(4),
+    legacySpacing: dynamicScale(20, true),
+    layoutTypography: layout.type(20),
+    legacyTypography: dynamicScale(20, false, 0.5),
+  };
+}

--- a/TravelCostApp/util/layout.ts
+++ b/TravelCostApp/util/layout.ts
@@ -1,0 +1,78 @@
+export type LayoutBreakpoint = "narrow" | "medium" | "wide";
+export type LayoutOrientation = "portrait" | "landscape";
+export type LayoutSpaceToken = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export type LayoutViewport = {
+  width: number;
+  height: number;
+};
+
+export type LayoutProfile = {
+  breakpoint: LayoutBreakpoint;
+  orientation: LayoutOrientation;
+  contentMaxWidth: number;
+  space: (token: LayoutSpaceToken) => number;
+  type: (size: number) => number;
+};
+
+const NARROW_MEDIUM_SPACE_TOKENS: Record<LayoutSpaceToken, number> = {
+  1: 8,
+  2: 12,
+  3: 16,
+  4: 20,
+  5: 24,
+  6: 32,
+  7: 48,
+};
+
+const WIDE_SPACE_TOKENS: Record<LayoutSpaceToken, number> = {
+  1: 12,
+  2: 16,
+  3: 20,
+  4: 24,
+  5: 32,
+  6: 40,
+  7: 56,
+};
+
+const TYPE_SCALE_BY_BREAKPOINT: Record<LayoutBreakpoint, number> = {
+  narrow: 1,
+  medium: 1.05,
+  wide: 1.2,
+};
+
+function breakpointFor(width: number): LayoutBreakpoint {
+  if (width >= 768) {
+    return "wide";
+  }
+  if (width >= 600) {
+    return "medium";
+  }
+  return "narrow";
+}
+
+function orientationFor(viewport: LayoutViewport): LayoutOrientation {
+  return viewport.width < viewport.height ? "portrait" : "landscape";
+}
+
+function spaceForBreakpoint(breakpoint: LayoutBreakpoint, token: LayoutSpaceToken) {
+  const tokens =
+    breakpoint === "wide" ? WIDE_SPACE_TOKENS : NARROW_MEDIUM_SPACE_TOKENS;
+  return tokens[token];
+}
+
+function typeForBreakpoint(breakpoint: LayoutBreakpoint, size: number) {
+  return Math.round(size * TYPE_SCALE_BY_BREAKPOINT[breakpoint]);
+}
+
+export function layoutFor(viewport: LayoutViewport): LayoutProfile {
+  const breakpoint = breakpointFor(viewport.width);
+
+  return {
+    breakpoint,
+    orientation: orientationFor(viewport),
+    contentMaxWidth: 800,
+    space: (token) => spaceForBreakpoint(breakpoint, token),
+    type: (size) => typeForBreakpoint(breakpoint, size),
+  };
+}

--- a/TravelCostApp/util/modal-frame-layout.ts
+++ b/TravelCostApp/util/modal-frame-layout.ts
@@ -1,0 +1,8 @@
+import type { LayoutProfile } from "../util/layout";
+
+export const MODAL_WIDE_BREAKPOINT = 600;
+export const MODAL_MAX_WIDTH = 600;
+
+export function isModalWide(layout: LayoutProfile) {
+  return layout.breakpoint !== "narrow";
+}

--- a/TravelCostApp/util/modal-frame-layout.ts
+++ b/TravelCostApp/util/modal-frame-layout.ts
@@ -4,5 +4,6 @@ export const MODAL_WIDE_BREAKPOINT = 600;
 export const MODAL_MAX_WIDTH = 600;
 
 export function isModalWide(layout: LayoutProfile) {
+  // Layout narrow breakpoint is < MODAL_WIDE_BREAKPOINT (600).
   return layout.breakpoint !== "narrow";
 }

--- a/TravelCostApp/util/scalingUtil.ts
+++ b/TravelCostApp/util/scalingUtil.ts
@@ -1,3 +1,7 @@
+/**
+ * Legacy screen scaling helpers. Layout spacing and breakpoints belong in `util/layout`.
+ * Do not use dynamicScale/constantScale for padding, gaps, or margins on new work (#387).
+ */
 import { Dimensions, PixelRatio } from "react-native";
 
 // this Dimensions.get will only be called once at the start of the app
@@ -7,6 +11,7 @@ const { width: Startup_Width, height: Startup_Height } =
 //Guideline sizes are based on standard ~5" screen mobile device
 const guidelineBaseWidth = 375;
 const guidelineBaseHeight = 667;
+// Isolated legacy multiplier — must not be used for layout spacing tokens.
 const tabletScaleMult = 1.2;
 const phoneScaleMult = 0.9;
 


### PR DESCRIPTION
## Summary
- Add a deep Layout module (`layoutFor`) as the single source for breakpoints, fixed spacing tokens, capped typography, and content max width.
- Ship ContentFrame, ResponsiveGrid, and ModalFrame adapters for later tablet/macOS screen work (#388–#391).
- Extract trip-period layout tokens out of `shadow-regression-styles`, adapt `OrientationContext` from the layout profile, and add a dev layout harness for comparing new spacing vs legacy `dynamicScale`.

## Test plan
- [x] `pnpm test` (815 tests)
- [ ] Open `LayoutHarness` in a dev build and confirm breakpoint/spacing updates on resize/rotate
- [ ] Smoke Recent Expenses and Overview period headers on phone and iPad widths

Closes #387