### PR TITLE
Recent Expenses tablet optimization (#388)

### DIFF
--- a/TravelCostApp/__tests__/components/expense-list-row-layout.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-list-row-layout.test.tsx
@@ -99,4 +99,13 @@ describe("ExpenseListRow layout", () => {
     expect(ledger.height).toBeUndefined();
     expect(templatePicker.height).toBeUndefined();
   });
+
+  it("groups medium tablet landscape ledger rows without the height hack", () => {
+    const screen = renderExpenseListRow("ledger", 736, 414);
+    const row = flattenRow(screen);
+
+    expect(row.height).toBeUndefined();
+    expect(row.justifyContent).toBe("flex-start");
+    expect(row.minHeight).not.toBe(dynamicScale(100, true));
+  });
 });

--- a/TravelCostApp/__tests__/components/expense-list-row-layout.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-list-row-layout.test.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import { Dimensions, StyleSheet } from "react-native";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("../../components/ExpensesOutput/ExpenseCountryFlag", () => {
+  const { View } = require("react-native");
+  return function MockExpenseCountryFlag({ containerStyle }: { containerStyle?: unknown }) {
+    return <View testID="expense-item-country-flag" style={containerStyle} />;
+  };
+});
+
+import ExpenseListRow from "../../components/ExpensesOutput/ExpenseListRow";
+import LayoutContextProvider from "../../store/layout-context";
+import { makeExpense } from "../fixtures/expense";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { dynamicScale } from "../../util/scalingUtil";
+
+const expense = makeExpense({
+  country: "Japan",
+  whoPaid: "Alice",
+  splitList: [
+    { userName: "Alice", amount: 50 },
+    { userName: "Bob", amount: 50 },
+  ],
+});
+
+function flattenRow(screen: { getByTestId: (id: string) => any }) {
+  return StyleSheet.flatten(
+    screen.getByTestId("expense-list-row-shell").props.style
+  ) as Record<string, unknown>;
+}
+
+function renderExpenseListRow(
+  layoutVariant: "ledger" | "templatePicker",
+  width: number,
+  height: number
+) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 2,
+    fontScale: 1,
+  });
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <ExpenseListRow
+        {...expense}
+        layoutVariant={layoutVariant}
+        onPress={jest.fn()}
+      />
+    </LayoutContextProvider>,
+    {
+      wrapNavigation: false,
+      settings: {
+        settings: {
+          showFlags: true,
+          showWhoPaid: true,
+        },
+      },
+    }
+  );
+}
+
+describe("ExpenseListRow layout", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("groups wide ledger columns without the landscape height hack", () => {
+    const screen = renderExpenseListRow("ledger", 1194, 834);
+    const row = flattenRow(screen);
+
+    expect(row.height).toBeUndefined();
+    expect(row.justifyContent).toBe("flex-start");
+    expect(row.minHeight).not.toBe(dynamicScale(100, true));
+  });
+
+  it("keeps template picker and ledger rows on the same grouped shell on wide", () => {
+    const ledger = flattenRow(renderExpenseListRow("ledger", 1194, 834));
+    const templatePicker = flattenRow(
+      renderExpenseListRow("templatePicker", 1194, 834)
+    );
+
+    expect(ledger.justifyContent).toBe("flex-start");
+    expect(templatePicker.justifyContent).toBe("flex-start");
+    expect(ledger.height).toBeUndefined();
+    expect(templatePicker.height).toBeUndefined();
+  });
+});

--- a/TravelCostApp/__tests__/components/trip-period-chrome.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-period-chrome.test.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { Dimensions, StyleSheet } from "react-native";
+
+jest.mock("react-native-dropdown-picker", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return function MockDropDownPicker(props: { containerStyle?: object }) {
+    return <View testID="mock-dropdown-picker" style={props.containerStyle} />;
+  };
+});
+
+import TripPeriodChrome from "../../components/layout/TripPeriodChrome";
+import LayoutContextProvider from "../../store/layout-context";
+import { makeExpense } from "../fixtures/expense";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { layoutFor } from "../../util/layout";
+
+const monthExpenses = [
+  makeExpense({ id: "e1", calcAmount: 75, amount: 75 }),
+];
+
+function flattenStyle(screen: { getByTestId: (id: string) => any }, testID: string) {
+  return StyleSheet.flatten(
+    screen.getByTestId(testID).props.style
+  ) as Record<string, unknown>;
+}
+
+function renderTripPeriodChrome(width: number, height: number) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 2,
+    fontScale: 1,
+  });
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <TripPeriodChrome
+        tripLabel="Japan 2026 - Aug 2026"
+        periodValue="month"
+        periodItems={[{ label: "Month", value: "month" }]}
+        periodOpen={false}
+        onPeriodOpenChange={jest.fn()}
+        onPeriodValueChange={jest.fn()}
+        onPeriodItemsChange={jest.fn()}
+        expenses={monthExpenses}
+      />
+    </LayoutContextProvider>,
+    { wrapNavigation: false }
+  );
+}
+
+describe("TripPeriodChrome", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("keeps trip date header spacing non-overlapping on wide layouts", () => {
+    const layout = layoutFor({ width: 1194, height: 834 });
+    const screen = renderTripPeriodChrome(1194, 834);
+    const dateHeader = flattenStyle(screen, "period-date-header");
+
+    expect(dateHeader.marginBottom).toBe(layout.space(1));
+    expect(Number(dateHeader.marginBottom)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("uses layout spacing tokens for the period header row on wide", () => {
+    const wideLayout = layoutFor({ width: 1194, height: 834 });
+    const wide = flattenStyle(renderTripPeriodChrome(1194, 834), "period-header-row");
+
+    expect(wide.gap).toBe(wideLayout.space(3));
+    expect(wide.marginTop).toBe(wideLayout.space(4));
+    expect(wide.paddingHorizontal).toBe(wideLayout.space(3));
+  });
+});

--- a/TravelCostApp/__tests__/components/trip-period-chrome.test.tsx
+++ b/TravelCostApp/__tests__/components/trip-period-chrome.test.tsx
@@ -72,4 +72,13 @@ describe("TripPeriodChrome", () => {
     expect(wide.marginTop).toBe(wideLayout.space(4));
     expect(wide.paddingHorizontal).toBe(wideLayout.space(3));
   });
+
+  it("keeps trip date header spacing non-overlapping on medium tablet landscape", () => {
+    const layout = layoutFor({ width: 736, height: 414 });
+    const screen = renderTripPeriodChrome(736, 414);
+    const dateHeader = flattenStyle(screen, "period-date-header");
+
+    expect(dateHeader.marginBottom).toBe(layout.space(1));
+    expect(Number(dateHeader.marginBottom)).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/TravelCostApp/__tests__/screens/overview-screen.test.tsx
+++ b/TravelCostApp/__tests__/screens/overview-screen.test.tsx
@@ -49,9 +49,11 @@ jest.mock("../../components/ExpensesOutput/ExpensesOverview", () => {
 });
 
 import OverviewScreen from "../../screens/OverviewScreen";
+import LayoutContextProvider from "../../store/layout-context";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 import { makeExpense } from "../fixtures/expense";
 import { assertNoNestedVerticalFlatLists } from "../../test-utils/scroll-composition";
+import { Dimensions, StyleSheet } from "react-native";
 
 const graphExpensesContext = {
   expenses: [makeExpense({ category: "Food", calcAmount: 42 })],
@@ -187,5 +189,34 @@ describe("Overview screen", () => {
 
     expect(navigation.navigate).not.toHaveBeenCalledWith("Profile");
     expect(Toast.show).not.toHaveBeenCalled();
+  });
+
+  it("wraps overview content in an 800px ContentFrame on wide layouts", () => {
+    jest.spyOn(Dimensions, "get").mockReturnValue({
+      width: 1194,
+      height: 834,
+      scale: 2,
+      fontScale: 1,
+    });
+
+    const screen = renderWithAppProviders(
+      <LayoutContextProvider>
+        <OverviewScreen navigation={{ navigate: jest.fn() } as any} />
+      </LayoutContextProvider>,
+      {
+        user: {
+          isShowingGraph: false,
+          setIsShowingGraph: jest.fn(),
+        },
+        expenses: { expenses: [], getRecentExpenses: () => [] },
+      }
+    );
+
+    const frame = StyleSheet.flatten(
+      screen.getByTestId("overview-content-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frame.maxWidth).toBe(800);
+    expect(frame.alignSelf).toBe("center");
   });
 });

--- a/TravelCostApp/__tests__/screens/period-header-parity.test.tsx
+++ b/TravelCostApp/__tests__/screens/period-header-parity.test.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
-  return { ...actual, useScrollToTop: jest.fn() };
+  return {
+    ...actual,
+    useScrollToTop: jest.fn(),
+    useFocusEffect: jest.fn(),
+  };
 });
 
 jest.mock("expo-haptics", () => ({
@@ -25,7 +29,6 @@ jest.mock("react-native-dropdown-picker", () => {
     );
   };
 });
-
 
 jest.mock("../../util/vexo-tracking", () => ({
   trackEvent: jest.fn(),
@@ -73,11 +76,13 @@ jest.mock("../../util/refreshWithToast", () => ({
   refreshWithToast: jest.fn(async () => {}),
 }));
 
-import { StyleSheet } from "react-native";
+import { Dimensions, StyleSheet } from "react-native";
 
 import OverviewScreen from "../../screens/OverviewScreen";
 import RecentExpenses from "../../screens/RecentExpenses";
-import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
+import TripPeriodChrome from "../../components/layout/TripPeriodChrome";
+import LayoutContextProvider from "../../store/layout-context";
+import OrientationContextProvider from "../../store/orientation-context";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
@@ -97,89 +102,100 @@ function flattenDateHeaderStyle(screen: { getByTestId: (id: string) => any }) {
   ) as Record<string, unknown>;
 }
 
+function renderScreenWithLayout(
+  Screen: typeof OverviewScreen | typeof RecentExpenses,
+  width: number,
+  height: number
+) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 2,
+    fontScale: 1,
+  });
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <OrientationContextProvider>
+        <Screen navigation={{ navigate: jest.fn() } as any} />
+      </OrientationContextProvider>
+    </LayoutContextProvider>,
+    {
+      wrapNavigation: false,
+      user: {
+        isShowingGraph: false,
+        setIsShowingGraph: jest.fn(),
+        periodName: "month",
+      },
+      expenses: {
+        expenses: monthExpenses,
+        getRecentExpenses: () => monthExpenses,
+      },
+    }
+  );
+}
+
 describe("period header parity", () => {
-  it("Overview and Recent Expenses share the same period header row layout", () => {
-    const navigation = { navigate: jest.fn() };
-    const sharedRow = StyleSheet.flatten(
-      shadowRegressionStyles.overviewPeriodHeaderRow
-    ) as Record<string, unknown>;
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-    const overview = renderWithAppProviders(
-      <OverviewScreen navigation={navigation as any} />,
-      {
-        user: {
-          isShowingGraph: false,
-          setIsShowingGraph: jest.fn(),
-        },
-        expenses: {
-          expenses: monthExpenses,
-          getRecentExpenses: () => monthExpenses,
-        },
-      }
+  it("TripPeriodChrome keeps the same date header spacing with or without sync slot", () => {
+    const withSync = flattenDateHeaderStyle(
+      renderWithAppProviders(
+        <LayoutContextProvider>
+          <TripPeriodChrome
+            tripLabel="Japan 2026 - Aug 2026"
+            syncSlot={<></>}
+            periodValue="month"
+            periodItems={[{ label: "Month", value: "month" }]}
+            periodOpen={false}
+            onPeriodOpenChange={jest.fn()}
+            onPeriodValueChange={jest.fn()}
+            onPeriodItemsChange={jest.fn()}
+            expenses={monthExpenses}
+          />
+        </LayoutContextProvider>,
+        { wrapNavigation: false }
+      )
     );
 
-    const recent = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: {
-          expenses: monthExpenses,
-          getRecentExpenses: () => monthExpenses,
-        },
-        user: {
-          periodName: "month",
-        },
-      }
+    const withoutSync = flattenDateHeaderStyle(
+      renderWithAppProviders(
+        <LayoutContextProvider>
+          <TripPeriodChrome
+            tripLabel="Japan 2026 - Aug 2026"
+            periodValue="month"
+            periodItems={[{ label: "Month", value: "month" }]}
+            periodOpen={false}
+            onPeriodOpenChange={jest.fn()}
+            onPeriodValueChange={jest.fn()}
+            onPeriodItemsChange={jest.fn()}
+            expenses={monthExpenses}
+          />
+        </LayoutContextProvider>,
+        { wrapNavigation: false }
+      )
     );
+
+    expect(withSync.marginTop).toBe(withoutSync.marginTop);
+    expect(withSync.marginLeft).toBe(withoutSync.marginLeft);
+    expect(withSync.marginBottom).toBe(withoutSync.marginBottom);
+  });
+
+  it("Overview and Recent Expenses share TripPeriodChrome header layout on tablet landscape", () => {
+    const overview = renderScreenWithLayout(OverviewScreen, 1194, 834);
+    const recent = renderScreenWithLayout(RecentExpenses, 1194, 834);
 
     const overviewRow = flattenHeaderStyle(overview);
     const recentRow = flattenHeaderStyle(recent);
-
-    expect(overviewRow.gap).toBe(sharedRow.gap);
-    expect(recentRow.gap).toBe(sharedRow.gap);
-    expect(overviewRow.marginTop).toBe(recentRow.marginTop);
-    expect(overviewRow.paddingHorizontal).toBe(recentRow.paddingHorizontal);
-    expect(overviewRow.alignItems).toBe("stretch");
-  });
-
-  it("Overview and Recent Expenses share the same trip date header spacing", () => {
-    const navigation = { navigate: jest.fn() };
-    const sharedDateHeader = StyleSheet.flatten(
-      shadowRegressionStyles.overviewPeriodDateHeader
-    ) as Record<string, unknown>;
-
-    const overview = renderWithAppProviders(
-      <OverviewScreen navigation={navigation as any} />,
-      {
-        user: {
-          isShowingGraph: false,
-          setIsShowingGraph: jest.fn(),
-        },
-        expenses: {
-          expenses: monthExpenses,
-          getRecentExpenses: () => monthExpenses,
-        },
-      }
-    );
-
-    const recent = renderWithAppProviders(
-      <RecentExpenses navigation={navigation as any} />,
-      {
-        expenses: {
-          expenses: monthExpenses,
-          getRecentExpenses: () => monthExpenses,
-        },
-        user: {
-          periodName: "month",
-        },
-      }
-    );
-
     const overviewDate = flattenDateHeaderStyle(overview);
     const recentDate = flattenDateHeaderStyle(recent);
 
-    expect(overviewDate.marginTop).toBe(sharedDateHeader.marginTop);
-    expect(recentDate.marginTop).toBe(sharedDateHeader.marginTop);
-    expect(overviewDate.marginLeft).toBe(recentDate.marginLeft);
+    expect(overviewRow.gap).toBe(recentRow.gap);
+    expect(overviewRow.marginTop).toBe(recentRow.marginTop);
+    expect(overviewRow.paddingHorizontal).toBe(recentRow.paddingHorizontal);
     expect(overviewDate.marginBottom).toBe(recentDate.marginBottom);
+    expect(Number(overviewDate.marginBottom)).toBeGreaterThanOrEqual(0);
   });
 });

--- a/TravelCostApp/__tests__/screens/recent-expenses-tablet-layout.test.tsx
+++ b/TravelCostApp/__tests__/screens/recent-expenses-tablet-layout.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Dimensions, StyleSheet } from "react-native";
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
@@ -72,8 +73,6 @@ jest.mock("../../util/refreshWithToast", () => ({
   refreshWithToast: jest.fn(async () => {}),
 }));
 
-import { Dimensions, StyleSheet } from "react-native";
-
 import RecentExpenses from "../../screens/RecentExpenses";
 import LayoutContextProvider from "../../store/layout-context";
 import OrientationContextProvider from "../../store/orientation-context";
@@ -83,12 +82,6 @@ import { renderWithAppProviders } from "../fixtures/app-providers";
 const monthExpenses = [
   makeExpense({ id: "e1", calcAmount: 75, amount: 75 }),
 ];
-
-function flattenScreenContainer(screen: { getByTestId: (id: string) => any }) {
-  return StyleSheet.flatten(
-    screen.getByTestId("recent-expenses-screen").props.style
-  ) as Record<string, unknown>;
-}
 
 function renderRecentExpensesWithLayout(width: number, height: number) {
   jest.spyOn(Dimensions, "get").mockReturnValue({
@@ -124,16 +117,34 @@ describe("RecentExpenses tablet layout adapter", () => {
 
   it("does not apply tablet padding on phone portrait widths", () => {
     const screen = renderRecentExpensesWithLayout(390, 844);
-    const container = flattenScreenContainer(screen);
+    const container = StyleSheet.flatten(
+      screen.getByTestId("recent-expenses-screen").props.style
+    ) as Record<string, unknown>;
 
     expect(container.paddingTop).toBeUndefined();
   });
 
   it("applies tablet padding when the layout profile is no longer narrow", () => {
-    const portrait = flattenScreenContainer(renderRecentExpensesWithLayout(390, 844));
-    const landscape = flattenScreenContainer(renderRecentExpensesWithLayout(844, 390));
+    const portrait = StyleSheet.flatten(
+      renderRecentExpensesWithLayout(390, 844).getByTestId("recent-expenses-screen")
+        .props.style
+    ) as Record<string, unknown>;
+    const landscape = StyleSheet.flatten(
+      renderRecentExpensesWithLayout(844, 390).getByTestId("recent-expenses-screen")
+        .props.style
+    ) as Record<string, unknown>;
 
     expect(portrait.paddingTop).toBeUndefined();
     expect(landscape.paddingTop).toBeGreaterThan(0);
+  });
+
+  it("wraps ledger content in an 800px ContentFrame on wide layouts", () => {
+    const screen = renderRecentExpensesWithLayout(1194, 834);
+    const frame = StyleSheet.flatten(
+      screen.getByTestId("recent-expenses-content-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frame.maxWidth).toBe(800);
+    expect(frame.alignSelf).toBe("center");
   });
 });

--- a/TravelCostApp/__tests__/styles/expense-list-row-layout-tokens.test.ts
+++ b/TravelCostApp/__tests__/styles/expense-list-row-layout-tokens.test.ts
@@ -1,0 +1,41 @@
+import { layoutFor } from "../../util/layout";
+import {
+  expenseListRowLayoutTokens,
+} from "../../styles/expense-list-row-layout-tokens";
+import { constantScale, dynamicScale } from "../../util/scalingUtil";
+
+describe("expense-list-row-layout-tokens", () => {
+  it("does not inflate ledger row height on wide landscape", () => {
+    const layout = layoutFor({ width: 1194, height: 834 });
+    const tokens = expenseListRowLayoutTokens(layout, "ledger");
+
+    expect(tokens.rowShell.height).toBeUndefined();
+    expect(tokens.rowShell.minHeight).toBe(layout.space(6));
+    expect(tokens.rowShell.justifyContent).toBe("flex-start");
+    expect(tokens.rowShell.gap).toBe(layout.space(2));
+  });
+
+  it("keeps phone ledger rows compact with a fixed height", () => {
+    const layout = layoutFor({ width: 390, height: 844 });
+    const tokens = expenseListRowLayoutTokens(layout, "ledger");
+
+    expect(tokens.rowShell.height).toBe(constantScale(55, 0.5));
+    expect(tokens.rowShell.justifyContent).toBe("space-between");
+  });
+
+  it("right-aligns the amount column inside grouped wide ledger rows", () => {
+    const layout = layoutFor({ width: 1194, height: 834 });
+    const tokens = expenseListRowLayoutTokens(layout, "ledger");
+
+    expect(tokens.amountColumn.marginLeft).toBe("auto");
+  });
+
+  it("uses flex columns for template picker rows without landscape height hacks", () => {
+    const layout = layoutFor({ width: 1194, height: 834 });
+    const tokens = expenseListRowLayoutTokens(layout, "templatePicker");
+
+    expect(tokens.rowShell.height).toBeUndefined();
+    expect(tokens.rowShell.minHeight).toBe(constantScale(72, 0.5));
+    expect(dynamicScale(100, true)).not.toBe(tokens.rowShell.minHeight);
+  });
+});

--- a/TravelCostApp/__tests__/styles/expense-list-row-layout-tokens.test.ts
+++ b/TravelCostApp/__tests__/styles/expense-list-row-layout-tokens.test.ts
@@ -38,4 +38,22 @@ describe("expense-list-row-layout-tokens", () => {
     expect(tokens.rowShell.minHeight).toBe(constantScale(72, 0.5));
     expect(dynamicScale(100, true)).not.toBe(tokens.rowShell.minHeight);
   });
+
+  it("groups medium tablet landscape ledger rows with layout spacing", () => {
+    const layout = layoutFor({ width: 736, height: 414 });
+    const tokens = expenseListRowLayoutTokens(layout, "ledger");
+
+    expect(tokens.rowShell.height).toBeUndefined();
+    expect(tokens.rowShell.justifyContent).toBe("flex-start");
+    expect(tokens.rowShell.minHeight).toBe(layout.space(6));
+    expect(tokens.rowShell.gap).toBe(layout.space(2));
+    expect(tokens.amountColumn.marginLeft).toBe("auto");
+  });
+
+  it("uses layout spacing for template picker padding on medium breakpoints", () => {
+    const layout = layoutFor({ width: 736, height: 414 });
+    const tokens = expenseListRowLayoutTokens(layout, "templatePicker");
+
+    expect(tokens.rowShell.paddingVertical).toBe(layout.space(2));
+  });
 });

--- a/TravelCostApp/__tests__/styles/trip-period-layout-tokens.test.ts
+++ b/TravelCostApp/__tests__/styles/trip-period-layout-tokens.test.ts
@@ -44,4 +44,14 @@ describe("trip-period-layout-tokens", () => {
     expect(tokens.periodHeaderRow.gap).toBe(20);
     expect(tokens.headerCard.minHeight).toBe(40);
   });
+
+  it("uses non-overlapping layout spacing on medium tablet landscape", () => {
+    const mediumLandscape = layoutFor({ width: 736, height: 414 });
+    const tokens = tripPeriodLayoutTokens(mediumLandscape);
+
+    expect(tokens.periodDateHeader.marginBottom).toBe(mediumLandscape.space(1));
+    expect(Number(tokens.periodDateHeader.marginBottom)).toBeGreaterThanOrEqual(0);
+    expect(tokens.periodHeaderRow.gap).toBe(mediumLandscape.space(2));
+    expect(tokens.dividerBar.marginTop).toBe(mediumLandscape.space(3));
+  });
 });

--- a/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
@@ -29,7 +29,10 @@ import { ExpenseData } from "../../util/expense";
 import { useRef } from "react";
 import { constantScale, dynamicScale } from "../../util/scalingUtil";
 import { useLayoutProfile } from "../../store/layout-context";
-import { expenseListRowLayoutTokens } from "../../styles/expense-list-row-layout-tokens";
+import {
+  expenseListRowLayoutTokens,
+  type ExpenseListRowLayoutTokens,
+} from "../../styles/expense-list-row-layout-tokens";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 
@@ -42,6 +45,7 @@ function ExpenseItem(props): JSX.Element {
     onPressOverride,
     disableLongPressSelection,
     layoutVariant = "ledger",
+    rowLayout: rowLayoutProp,
   } = props;
   const isTemplatePickerRow = layoutVariant === "templatePicker";
   const { setSelectable, selectItem } = props;
@@ -288,7 +292,8 @@ function ExpenseItem(props): JSX.Element {
   configureDateString();
 
   const layout = useLayoutProfile();
-  const rowLayout = expenseListRowLayoutTokens(layout, layoutVariant);
+  const rowLayout: ExpenseListRowLayoutTokens =
+    rowLayoutProp ?? expenseListRowLayoutTokens(layout, layoutVariant);
 
   // if (!id) return <></>;
   return (
@@ -454,6 +459,7 @@ ExpenseItem.propTypes = {
   onPressOverride: PropTypes.func,
   disableLongPressSelection: PropTypes.bool,
   layoutVariant: PropTypes.oneOf(["ledger", "templatePicker"]),
+  rowLayout: PropTypes.object,
 };
 
 const styles = StyleSheet.create({

--- a/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseItem.tsx
@@ -28,7 +28,8 @@ import * as Haptics from "expo-haptics";
 import { ExpenseData } from "../../util/expense";
 import { useRef } from "react";
 import { constantScale, dynamicScale } from "../../util/scalingUtil";
-import { OrientationContext } from "../../store/orientation-context";
+import { useLayoutProfile } from "../../store/layout-context";
+import { expenseListRowLayoutTokens } from "../../styles/expense-list-row-layout-tokens";
 import { trackEvent } from "../../util/vexo-tracking";
 import { VexoEvents } from "../../util/vexo-constants";
 
@@ -286,7 +287,8 @@ function ExpenseItem(props): JSX.Element {
   }, [date, todayString]);
   configureDateString();
 
-  const { isLandscape } = useContext(OrientationContext);
+  const layout = useLayoutProfile();
+  const rowLayout = expenseListRowLayoutTokens(layout, layoutVariant);
 
   // if (!id) return <></>;
   return (
@@ -303,15 +305,10 @@ function ExpenseItem(props): JSX.Element {
         style={({ pressed }) => pressed && GlobalStyles.pressed}
       >
         <View
+          testID="expense-list-row-shell"
           style={[
             styles.expenseItem,
             {
-              minHeight: isTemplatePickerRow
-                ? constantScale(72, 0.5)
-                : constantScale(55, 0.5),
-              height: isTemplatePickerRow
-                ? undefined
-                : constantScale(55, 0.5),
               paddingLeft: dynamicScale(16),
               ...Platform.select({
                 ios: {
@@ -322,11 +319,8 @@ function ExpenseItem(props): JSX.Element {
                 },
               }),
             },
+            rowLayout.rowShell,
             isTemplatePickerRow && styles.expenseItemTemplatePicker,
-            isLandscape &&
-              !isTemplatePickerRow && {
-                height: dynamicScale(100, true),
-              },
           ]}
         >
           <View
@@ -416,6 +410,7 @@ function ExpenseItem(props): JSX.Element {
           <View
             style={[
               styles.amountContainer,
+              rowLayout.amountColumn,
               isTemplatePickerRow && styles.amountContainerTemplatePicker,
             ]}
           >
@@ -474,7 +469,6 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
   },
   expenseItemTemplatePicker: {
-    alignItems: "flex-start",
     paddingVertical: dynamicScale(10, true),
     width: "100%",
   },

--- a/TravelCostApp/components/ExpensesOutput/ExpenseListRow.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpenseListRow.tsx
@@ -2,9 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import ExpenseItem from "./ExpenseItem";
+import { useLayoutProfile } from "../../store/layout-context";
+import {
+  expenseListRowLayoutTokens,
+  type ExpenseListRowLayoutVariant,
+} from "../../styles/expense-list-row-layout-tokens";
 import type { ExpenseData } from "../../util/expense";
 
-export type ExpenseListRowLayoutVariant = "ledger" | "templatePicker";
+export type { ExpenseListRowLayoutVariant };
 
 export type ExpenseListRowProps = ExpenseData & {
   onPress: () => void;
@@ -17,12 +22,16 @@ function ExpenseListRow({
   layoutVariant = "ledger",
   ...expense
 }: ExpenseListRowProps) {
+  const layout = useLayoutProfile();
+  const rowLayout = expenseListRowLayoutTokens(layout, layoutVariant);
+
   return (
     <ExpenseItem
       {...expense}
       onPressOverride={onPress}
       disableLongPressSelection
       layoutVariant={layoutVariant}
+      rowLayout={rowLayout}
     />
   );
 }

--- a/TravelCostApp/components/layout/TripPeriodChrome.tsx
+++ b/TravelCostApp/components/layout/TripPeriodChrome.tsx
@@ -59,32 +59,14 @@ function TripPeriodChrome({
 
   return (
     <>
-      <View
-        testID="period-date-header"
-        style={[
-          styles.dateHeader,
-          tokens.periodDateHeader,
-          layout.breakpoint !== "wide" &&
-            layout.orientation === "landscape" &&
-            styles.landscapeDateHeader,
-        ]}
-      >
+      <View testID="period-date-header" style={tokens.periodDateHeader}>
         <View style={styles.dateHeaderContent}>
           <Text style={styles.dateString}>{tripLabel}</Text>
           {syncSlot}
         </View>
       </View>
 
-      <View
-        testID="period-header-row"
-        style={[
-          styles.header,
-          tokens.periodHeaderRow,
-          layout.breakpoint !== "wide" &&
-            layout.orientation === "landscape" &&
-            styles.landscapeHeader,
-        ]}
-      >
+      <View testID="period-header-row" style={tokens.periodHeaderRow}>
         <DropDownPicker
           open={periodOpen}
           value={periodValue}
@@ -126,41 +108,24 @@ function TripPeriodChrome({
         />
       </View>
 
-      <View style={[shadowRegressionStyles.overviewDividerBar, styles.dividerBar]} />
+      <View
+        style={[shadowRegressionStyles.overviewDividerBar, tokens.dividerBar]}
+      />
     </>
   );
 }
 
 function createStyles(periodHeaderLabelFontSize: number) {
   return StyleSheet.create({
-    dateHeader: {
-      ...shadowRegressionStyles.overviewPeriodDateHeader,
-    },
     dateHeaderContent: {
       flexDirection: "row",
       alignItems: "center",
       justifyContent: "space-between",
     },
-    landscapeDateHeader: {
-      marginTop: dynamicScale(4, true),
-      marginBottom: dynamicScale(-8, true),
-      alignSelf: "center",
-    },
     dateString: {
       fontSize: dynamicScale(12, false, 0.5),
       fontStyle: "italic",
       color: GlobalStyles.colors.gray700,
-    },
-    header: {
-      ...shadowRegressionStyles.overviewPeriodHeaderRow,
-    },
-    landscapeHeader: {
-      marginTop: dynamicScale(12, true),
-      marginBottom: dynamicScale(-12, true),
-      zIndex: 10,
-      justifyContent: "space-between",
-      alignItems: "center",
-      marginHorizontal: dynamicScale(12),
     },
     dropdownContainer: {
       ...shadowRegressionStyles.overviewDropdownContainer,
@@ -178,10 +143,6 @@ function createStyles(periodHeaderLabelFontSize: number) {
           ? dynamicScale(20, false, 0.5)
           : periodHeaderLabelFontSize,
       fontWeight: "bold",
-    },
-    dividerBar: {
-      marginTop: dynamicScale(12, true),
-      marginBottom: dynamicScale(-12, true),
     },
   });
 }

--- a/TravelCostApp/components/layout/TripPeriodChrome.tsx
+++ b/TravelCostApp/components/layout/TripPeriodChrome.tsx
@@ -1,0 +1,206 @@
+import * as React from "react";
+import { Platform, StyleSheet, Text, View, type StyleProp, type ViewStyle } from "react-native";
+import DropDownPicker from "react-native-dropdown-picker";
+import PropTypes from "prop-types";
+
+import ExpensesSummary from "../ExpensesOutput/ExpensesSummary";
+import { GlobalStyles } from "../../constants/styles";
+import { i18n } from "../../i18n/i18n";
+import { useLayoutProfile } from "../../store/layout-context";
+import { tripPeriodLayoutTokens } from "../../styles/trip-period-layout-tokens";
+import { shadowRegressionStyles } from "../../styles/shadow-regression-styles";
+import { dynamicScale } from "../../util/scalingUtil";
+import type { ExpenseData } from "../../util/expense";
+
+type PeriodItem = {
+  label: string;
+  value: string;
+};
+
+export type TripPeriodChromeProps = {
+  tripLabel: string;
+  syncSlot?: React.ReactNode;
+  periodValue: string;
+  periodItems: PeriodItem[];
+  periodOpen: boolean;
+  onPeriodOpenChange: (open: boolean) => void;
+  onPeriodValueChange: (value: string | ((current: string) => string)) => void;
+  onPeriodItemsChange: (items: PeriodItem[]) => void;
+  expenses: ExpenseData[];
+  summaryStyle?: StyleProp<ViewStyle>;
+  onPeriodOpen?: () => void;
+  onPeriodClose?: () => void;
+  onPeriodSelectItem?: (item: PeriodItem | null) => void;
+  periodModalProps?: object;
+};
+
+function TripPeriodChrome({
+  tripLabel,
+  syncSlot,
+  periodValue,
+  periodItems,
+  periodOpen,
+  onPeriodOpenChange,
+  onPeriodValueChange,
+  onPeriodItemsChange,
+  expenses,
+  summaryStyle,
+  onPeriodOpen,
+  onPeriodClose,
+  onPeriodSelectItem,
+  periodModalProps,
+}: TripPeriodChromeProps) {
+  const layout = useLayoutProfile();
+  const tokens = tripPeriodLayoutTokens(layout);
+  const styles = React.useMemo(
+    () => createStyles(tokens.periodHeaderLabelFontSize),
+    [tokens.periodHeaderLabelFontSize]
+  );
+
+  return (
+    <>
+      <View
+        testID="period-date-header"
+        style={[
+          styles.dateHeader,
+          tokens.periodDateHeader,
+          layout.breakpoint !== "wide" &&
+            layout.orientation === "landscape" &&
+            styles.landscapeDateHeader,
+        ]}
+      >
+        <View style={styles.dateHeaderContent}>
+          <Text style={styles.dateString}>{tripLabel}</Text>
+          {syncSlot}
+        </View>
+      </View>
+
+      <View
+        testID="period-header-row"
+        style={[
+          styles.header,
+          tokens.periodHeaderRow,
+          layout.breakpoint !== "wide" &&
+            layout.orientation === "landscape" &&
+            styles.landscapeHeader,
+        ]}
+      >
+        <DropDownPicker
+          open={periodOpen}
+          value={periodValue}
+          items={periodItems}
+          showTickIcon={false}
+          placeholder=""
+          modalProps={periodModalProps}
+          setOpen={(callback) => {
+            const nextOpen =
+              typeof callback === "function" ? callback(periodOpen) : callback;
+            onPeriodOpenChange(nextOpen);
+          }}
+          onOpen={onPeriodOpen}
+          onClose={onPeriodClose}
+          onSelectItem={onPeriodSelectItem}
+          setValue={onPeriodValueChange}
+          setItems={onPeriodItemsChange}
+          containerStyle={[
+            styles.dropdownContainer,
+            tokens.headerCard,
+            { marginTop: tokens.dropdownContainer.marginTop },
+          ]}
+          dropDownContainerStyle={styles.dropdownContainerDropdown}
+          itemProps={{
+            style: {
+              height: dynamicScale(50, false, 0.5),
+              padding: dynamicScale(4, false, 0.5),
+              marginLeft: dynamicScale(4),
+            },
+          }}
+          style={styles.dropdown}
+          textStyle={styles.dropdownTextStyle}
+        />
+
+        <ExpensesSummary
+          expenses={expenses}
+          periodName={periodValue}
+          style={summaryStyle}
+        />
+      </View>
+
+      <View style={[shadowRegressionStyles.overviewDividerBar, styles.dividerBar]} />
+    </>
+  );
+}
+
+function createStyles(periodHeaderLabelFontSize: number) {
+  return StyleSheet.create({
+    dateHeader: {
+      ...shadowRegressionStyles.overviewPeriodDateHeader,
+    },
+    dateHeaderContent: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+    },
+    landscapeDateHeader: {
+      marginTop: dynamicScale(4, true),
+      marginBottom: dynamicScale(-8, true),
+      alignSelf: "center",
+    },
+    dateString: {
+      fontSize: dynamicScale(12, false, 0.5),
+      fontStyle: "italic",
+      color: GlobalStyles.colors.gray700,
+    },
+    header: {
+      ...shadowRegressionStyles.overviewPeriodHeaderRow,
+    },
+    landscapeHeader: {
+      marginTop: dynamicScale(12, true),
+      marginBottom: dynamicScale(-12, true),
+      zIndex: 10,
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginHorizontal: dynamicScale(12),
+    },
+    dropdownContainer: {
+      ...shadowRegressionStyles.overviewDropdownContainer,
+    },
+    dropdownContainerDropdown: {
+      maxHeight: dynamicScale(600, true),
+      ...shadowRegressionStyles.dropdownListContainer,
+    },
+    dropdown: {
+      ...shadowRegressionStyles.overviewDropdownInner,
+    },
+    dropdownTextStyle: {
+      fontSize:
+        i18n.locale == "fr"
+          ? dynamicScale(20, false, 0.5)
+          : periodHeaderLabelFontSize,
+      fontWeight: "bold",
+    },
+    dividerBar: {
+      marginTop: dynamicScale(12, true),
+      marginBottom: dynamicScale(-12, true),
+    },
+  });
+}
+
+TripPeriodChrome.propTypes = {
+  tripLabel: PropTypes.string.isRequired,
+  syncSlot: PropTypes.node,
+  periodValue: PropTypes.string.isRequired,
+  periodItems: PropTypes.array.isRequired,
+  periodOpen: PropTypes.bool.isRequired,
+  onPeriodOpenChange: PropTypes.func.isRequired,
+  onPeriodValueChange: PropTypes.func.isRequired,
+  onPeriodItemsChange: PropTypes.func.isRequired,
+  expenses: PropTypes.array.isRequired,
+  summaryStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  onPeriodOpen: PropTypes.func,
+  onPeriodClose: PropTypes.func,
+  onPeriodSelectItem: PropTypes.func,
+  periodModalProps: PropTypes.object,
+};
+
+export default TripPeriodChrome;

--- a/TravelCostApp/screens/OverviewScreen.tsx
+++ b/TravelCostApp/screens/OverviewScreen.tsx
@@ -167,7 +167,11 @@ const OverviewScreen = ({ navigation }) => {
   const layout = useLayoutProfile();
   return (
     <View style={[styles.container, isTablet && styles.tabletPaddingTop]}>
-      <ContentFrame layout={layout} style={styles.contentFrame}>
+      <ContentFrame
+        layout={layout}
+        style={styles.contentFrame}
+        testID="overview-content-frame"
+      >
         <TripPeriodChrome
           tripLabel={`${truncateString(tripCtx.tripName, dynamicScale(23, false, 0.5))} - ${dateTimeString}${offlineString}`}
           periodValue={PeriodValue}

--- a/TravelCostApp/screens/OverviewScreen.tsx
+++ b/TravelCostApp/screens/OverviewScreen.tsx
@@ -5,20 +5,18 @@ import React, {
   useState,
   useCallback,
 } from "react";
-import DropDownPicker from "react-native-dropdown-picker";
 import { ExpensesContext } from "../store/expenses-context";
 import { UserContext } from "../store/user-context";
 import {
-  Platform,
   StyleSheet,
-  Text,
   View,
   RefreshControl,
   Pressable,
 } from "react-native";
-import ExpensesSummary from "../components/ExpensesOutput/ExpensesSummary";
 import { GlobalStyles } from "../constants/styles";
-import { shadowRegressionStyles, periodHeaderLabelFontSize } from "../styles/shadow-regression-styles";
+import { shadowRegressionStyles } from "../styles/shadow-regression-styles";
+import TripPeriodChrome from "../components/layout/TripPeriodChrome";
+import ContentFrame from "../components/layout/ContentFrame";
 import { MemoizedExpensesOverview } from "../components/ExpensesOutput/ExpensesOverview";
 import ToggleButton from "../assets/SVG/toggleButton";
 
@@ -40,6 +38,7 @@ import { Toast } from "react-native-toast-message/lib/src/Toast";
 import { showBanner } from "../components/UI/ToastComponent";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
 import { OrientationContext } from "../store/orientation-context";
+import { useLayoutProfile } from "../store/layout-context";
 import { OnboardingFlags } from "../types/onboarding";
 import { refreshWithToast } from "../util/refreshWithToast";
 import { getOfflineQueue } from "../util/offline-queue";
@@ -164,105 +163,64 @@ const OverviewScreen = ({ navigation }) => {
   //   expensesSum,
   //   tripCtx.tripCurrency
   // );
-  const { isPortrait, isTablet } = useContext(OrientationContext);
+  const { isTablet } = useContext(OrientationContext);
+  const layout = useLayoutProfile();
   return (
     <View style={[styles.container, isTablet && styles.tabletPaddingTop]}>
-      <View
-        testID="period-date-header"
-        style={[
-          styles.dateHeader,
-          !isPortrait && styles.landscapeDateHeader,
-          isTablet && styles.tabletDateHeader,
-        ]}
-      >
-        <Text style={styles.dateString}>
-          {truncateString(tripCtx.tripName, dynamicScale(23, false, 0.5))} -{" "}
-          {dateTimeString}
-          {offlineString}
-        </Text>
-      </View>
-      <View
-        testID="period-header-row"
-        style={[styles.header, !isPortrait && styles.landscapeHeader]}
-      >
-        <DropDownPicker
-          open={open}
-          value={PeriodValue}
-          items={items}
-          showTickIcon={false}
-          placeholder={""}
-          modalProps={{
-            animationType: "slide",
-          }}
-          setOpen={() => {
+      <ContentFrame layout={layout} style={styles.contentFrame}>
+        <TripPeriodChrome
+          tripLabel={`${truncateString(tripCtx.tripName, dynamicScale(23, false, 0.5))} - ${dateTimeString}${offlineString}`}
+          periodValue={PeriodValue}
+          periodItems={items}
+          periodOpen={open}
+          onPeriodOpenChange={(nextOpen) => {
             requestAnimationFrame(() => {
-              setOpen(!open);
+              setOpen(nextOpen);
               Toast.hide();
             });
           }}
-          onOpen={() => {
-            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-          }}
-          onClose={() => {
-            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-          }}
-          onSelectItem={(item) => {
-            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-            trackEvent(VexoEvents.PERIOD_SELECTOR_CHANGED, {
-              period: item.value,
-            });
-          }}
-          setValue={(callback) => {
+          onPeriodValueChange={(callback) => {
             userCtx.setPeriodString(callback(PeriodValue));
           }}
-          setItems={setItems}
-          containerStyle={styles.dropdownContainer}
-          dropDownContainerStyle={styles.dropdownContainerDropdown}
-          itemProps={{
-            style: {
-              height: dynamicScale(50, false, 0.5),
-              padding: dynamicScale(4, false, 0.5),
-              marginLeft: dynamicScale(4),
-            },
+          onPeriodItemsChange={setItems}
+          periodModalProps={{
+            animationType: "slide",
           }}
-          // customItemLabelStyle={styles.dropdownItemLabel}
-          style={styles.dropdown}
-          textStyle={styles.dropdownTextStyle}
-        />
-        <ExpensesSummary
+          onPeriodOpen={() => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+          }}
+          onPeriodClose={() => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+          }}
+          onPeriodSelectItem={(item) => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            trackEvent(VexoEvents.PERIOD_SELECTOR_CHANGED, {
+              period: item?.value,
+            });
+          }}
           expenses={recentExpenses}
-          periodName={PeriodValue}
-          style={styles.customSummaryStyle}
+          summaryStyle={styles.customSummaryStyle}
         />
-      </View>
-      {
-        <View
-          style={[
-            shadowRegressionStyles.overviewDividerBar,
-            !isPortrait && styles.landscapeBar,
-            !isPortrait && isTablet && styles.landscapeBarTablet,
-          ]}
-        ></View>
-      }
 
-      <View style={{ flex: 1 }}>
-        <MemoizedExpensesOverview
-          navigation={navigation}
-          expenses={recentExpenses}
-          periodName={PeriodValue}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing || isFetching}
-              onRefresh={onRefresh}
-              tintColor={GlobalStyles.colors.textColor}
-              colors={[GlobalStyles.colors.textColor]}
-              style={{
-                backgroundColor: "transparent",
-              }}
-            />
-          }
-        />
-      </View>
+        <View style={{ flex: 1 }}>
+          <MemoizedExpensesOverview
+            navigation={navigation}
+            expenses={recentExpenses}
+            periodName={PeriodValue}
+            refreshControl={
+              <RefreshControl
+                refreshing={refreshing || isFetching}
+                onRefresh={onRefresh}
+                tintColor={GlobalStyles.colors.textColor}
+                colors={[GlobalStyles.colors.textColor]}
+                style={{
+                  backgroundColor: "transparent",
+                }}
+              />
+            }
+          />
+        </View>
+      </ContentFrame>
 
       {/* FAB Toggle Button */}
       <Pressable
@@ -292,67 +250,12 @@ const styles = StyleSheet.create({
   tabletPaddingTop: {
     paddingTop: constantScale(12, 0.5),
   },
-  dateHeader: {
-    ...shadowRegressionStyles.overviewPeriodDateHeader,
+  contentFrame: {
+    flex: 1,
   },
-  landscapeDateHeader: {
-    marginTop: dynamicScale(4, true),
-    marginBottom: dynamicScale(-24, true),
-    alignSelf: "center",
+  customSummaryStyle: {
+    marginTop: dynamicScale(2, true),
   },
-  tabletDateHeader: {
-    marginTop: dynamicScale(4, true),
-    marginBottom: dynamicScale(-8, true),
-    alignSelf: "center",
-  },
-  dateString: {
-    fontSize: dynamicScale(12, false, 0.5),
-    fontStyle: "italic",
-    color: GlobalStyles.colors.gray700,
-  },
-  header: {
-    ...shadowRegressionStyles.overviewPeriodHeaderRow,
-  },
-  landscapeHeader: {
-    marginTop: dynamicScale(12, true),
-    marginBottom: dynamicScale(-12, true),
-    zIndex: 10,
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginHorizontal: dynamicScale(12),
-  },
-  dropdownContainer: {
-    ...shadowRegressionStyles.overviewDropdownContainer,
-  },
-  dropdownContainerDropdown: {
-    maxHeight: dynamicScale(600, true),
-    ...shadowRegressionStyles.dropdownListContainer,
-  },
-  dropdown: {
-    ...shadowRegressionStyles.overviewDropdownInner,
-  },
-  dropdownTextStyle: {
-    fontSize:
-      i18n.locale == "fr"
-        ? dynamicScale(20, false, 0.5)
-        : periodHeaderLabelFontSize,
-    fontWeight: "bold",
-  },
-  scaledUpTextStyle: {
-    fontSize: dynamicScale(24, false, 0.5),
-  },
-  zBehind: {
-    zIndex: 10,
-  },
-  landscapeBar: {
-    marginTop: dynamicScale(12, true),
-    marginBottom: dynamicScale(-12, true),
-  },
-  landscapeBarTablet: {
-    marginTop: dynamicScale(52, true, 1),
-    marginBottom: dynamicScale(4, true),
-  },
-  customSummaryStyle: {},
   fabToggleButton: {
     ...shadowRegressionStyles.overviewFabToggleButton,
   },

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -5,7 +5,6 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import DropDownPicker from "react-native-dropdown-picker";
 import { MemoizedExpensesOutput } from "../components/ExpensesOutput/ExpensesOutput";
 import ErrorOverlay from "../components/UI/ErrorOverlay";
 import MiniSyncIndicator from "../components/UI/MiniSyncIndicator";

--- a/TravelCostApp/screens/RecentExpenses.tsx
+++ b/TravelCostApp/screens/RecentExpenses.tsx
@@ -9,6 +9,8 @@ import DropDownPicker from "react-native-dropdown-picker";
 import { MemoizedExpensesOutput } from "../components/ExpensesOutput/ExpensesOutput";
 import ErrorOverlay from "../components/UI/ErrorOverlay";
 import MiniSyncIndicator from "../components/UI/MiniSyncIndicator";
+import TripPeriodChrome from "../components/layout/TripPeriodChrome";
+import ContentFrame from "../components/layout/ContentFrame";
 import { AuthContext } from "../store/auth-context";
 import {
   ExpenseContextType,
@@ -20,13 +22,8 @@ import { UserContext } from "../store/user-context";
 import { getOfflineQueue } from "../util/offline-queue";
 import { fetchTravelerIsTouched } from "../util/http";
 
-import { StyleSheet, Text, View, RefreshControl } from "react-native";
-import ExpensesSummary from "../components/ExpensesOutput/ExpensesSummary";
+import { StyleSheet, View, RefreshControl } from "react-native";
 import { GlobalStyles } from "../constants/styles";
-import {
-  periodHeaderLabelFontSize,
-  shadowRegressionStyles,
-} from "../styles/shadow-regression-styles";
 import AddExpenseButton from "../components/ManageExpense/AddExpenseButton";
 import NamingBanner from "../components/UI/NamingBanner";
 import { DateTime } from "luxon";
@@ -51,6 +48,7 @@ import { memo } from "react";
 import { getMMKVObject, MMKV_KEYS } from "../store/mmkv";
 import { constantScale, dynamicScale } from "../util/scalingUtil";
 import { OrientationContext } from "../store/orientation-context";
+import { useLayoutProfile } from "../store/layout-context";
 import { refreshWithToast } from "../util/refreshWithToast";
 import {
   dismissNamingBanner,
@@ -66,7 +64,8 @@ function RecentExpenses({ navigation }) {
   const userCtx = useContext(UserContext);
   const tripCtx = useContext(TripContext);
   const tripid = tripCtx.tripid;
-  const { isPortrait, isTablet } = useContext(OrientationContext);
+  const { isTablet } = useContext(OrientationContext);
+  const layout = useLayoutProfile();
   const netCtx = useContext(NetworkContext);
   const isOnline = netCtx.isConnected && netCtx.strongConnection;
   const { settings } = useContext(SettingsContext);
@@ -387,78 +386,46 @@ function RecentExpenses({ navigation }) {
       testID="recent-expenses-screen"
       style={[styles.container, isTablet && styles.tabletPaddingTop]}
     >
-      <View
-        testID="period-date-header"
-        style={[
-          styles.dateHeader,
-          !isPortrait && styles.landscapeDateHeader,
-          isTablet && styles.landscapeDateHeader,
-        ]}
+      <ContentFrame
+        layout={layout}
+        style={styles.contentFrame}
+        testID="recent-expenses-content-frame"
       >
-        <View style={styles.dateHeaderContent}>
-          <Text style={styles.dateString}>
-            {truncateString(tripCtx.tripName, 23)} - {dateTimeString}
-            {offlineString}
-          </Text>
-          <MiniSyncIndicator
-            isVisible={expensesCtx.isSyncing}
-            size={dynamicScale(16, false, 0.5)}
-          />
-        </View>
-      </View>
-
-      <View
-        testID="period-header-row"
-        style={[styles.header, !isPortrait && styles.landscapeHeader]}
-      >
-        <DropDownPicker
-          open={open}
-          value={PeriodValue}
-          items={items}
-          showTickIcon={false}
-          setOpen={() => {
+        <TripPeriodChrome
+          tripLabel={`${truncateString(tripCtx.tripName, 23)} - ${dateTimeString}${offlineString}`}
+          syncSlot={
+            <MiniSyncIndicator
+              isVisible={expensesCtx.isSyncing}
+              size={dynamicScale(16, false, 0.5)}
+            />
+          }
+          periodValue={PeriodValue}
+          periodItems={items}
+          periodOpen={open}
+          onPeriodOpenChange={(nextOpen) => {
             requestAnimationFrame(() => {
-              setOpen(!open);
+              setOpen(nextOpen);
               Toast.hide();
             });
           }}
-          placeholder={""}
-          onOpen={() => {
+          onPeriodValueChange={userCtx.setPeriodString}
+          onPeriodItemsChange={setItems}
+          onPeriodOpen={() => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           }}
-          onClose={() => {
+          onPeriodClose={() => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           }}
-          onSelectItem={() => {
+          onPeriodSelectItem={() => {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
           }}
-          setValue={userCtx.setPeriodString}
-          setItems={setItems}
-          containerStyle={styles.dropdownContainer}
-          dropDownContainerStyle={styles.dropdownContainerDropdown}
-          itemProps={{
-            style: {
-              height: dynamicScale(50, false, 0.5),
-              padding: dynamicScale(4, false, 0.5),
-              marginLeft: dynamicScale(4),
-            },
-          }}
-          style={styles.dropdown}
-          textStyle={styles.dropdownTextStyle}
+          expenses={recentExpenses}
         />
-
-        <ExpensesSummary expenses={recentExpenses} periodName={PeriodValue} />
-      </View>
-      <View
-        style={[
-          shadowRegressionStyles.overviewDividerBar,
-          !isPortrait && styles.landscapeBar,
-        ]}
-      ></View>
-      {showNamingBanner && (
-        <NamingBanner onNameIt={handleNameIt} onLater={handleNamingLater} />
-      )}
-      {ExpensesOutputJSX}
+        {showNamingBanner && (
+          <NamingBanner onNameIt={handleNameIt} onLater={handleNamingLater} />
+        )}
+        {ExpensesOutputJSX}
+      </ContentFrame>
 
       <AddExpenseButton navigation={navigation} />
     </View>
@@ -489,60 +456,7 @@ const styles = StyleSheet.create({
   tabletPaddingTop: {
     paddingTop: constantScale(16, 0.5),
   },
-  dateHeader: {
-    ...shadowRegressionStyles.overviewPeriodDateHeader,
-  },
-  dateHeaderContent: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  landscapeDateHeader: {
-    marginTop: dynamicScale(4, true),
-    marginBottom: dynamicScale(-24, true),
-    alignSelf: "center",
-  },
-  dateString: {
-    fontSize: dynamicScale(12, false, 0.5),
-    fontStyle: "italic",
-    color: GlobalStyles.colors.gray700,
-  },
-  header: {
-    ...shadowRegressionStyles.overviewPeriodHeaderRow,
-  },
-  landscapeHeader: {
-    marginTop: dynamicScale(4, true),
-    // marginBottom: dynamicScale(-12, true),
-    zIndex: 10,
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginHorizontal: dynamicScale(12),
-  },
-  dropdownContainer: {
-    ...shadowRegressionStyles.overviewDropdownContainer,
-  },
-  dropdownContainerDropdown: {
-    maxHeight: dynamicScale(600, true),
-    ...shadowRegressionStyles.dropdownListContainer,
-  },
-  dropdown: {
-    ...shadowRegressionStyles.overviewDropdownInner,
-  },
-  dropdownTextStyle: {
-    fontSize:
-      i18n.locale == "fr"
-        ? dynamicScale(20, false, 0.5)
-        : periodHeaderLabelFontSize,
-    fontWeight: "bold",
-  },
-  scaledUpTextStyle: {
-    fontSize: dynamicScale(24, false, 0.5),
-  },
-  zBehind: {
-    zIndex: 10,
-  },
-  landscapeBar: {
-    marginTop: dynamicScale(12, true),
-    marginBottom: dynamicScale(-12, true),
+  contentFrame: {
+    flex: 1,
   },
 });

--- a/TravelCostApp/styles/expense-list-row-layout-tokens.ts
+++ b/TravelCostApp/styles/expense-list-row-layout-tokens.ts
@@ -6,7 +6,10 @@ export type ExpenseListRowLayoutVariant = "ledger" | "templatePicker";
 function templatePickerRowShell(layout: LayoutProfile) {
   return {
     alignItems: "flex-start" as const,
-    paddingVertical: dynamicScale(10, true),
+    paddingVertical:
+      layout.breakpoint === "narrow"
+        ? dynamicScale(10, true)
+        : layout.space(2),
     width: "100%" as const,
     minHeight: constantScale(72, 0.5),
     height: undefined as number | undefined,
@@ -14,7 +17,7 @@ function templatePickerRowShell(layout: LayoutProfile) {
   };
 }
 
-function wideLedgerRowShell(layout: LayoutProfile) {
+function groupedLedgerRowShell(layout: LayoutProfile) {
   return {
     justifyContent: "flex-start" as const,
     alignItems: "center" as const,
@@ -30,6 +33,26 @@ function narrowLedgerRowShell() {
     justifyContent: "space-between" as const,
     minHeight: constantScale(55, 0.5),
     height: constantScale(55, 0.5),
+  };
+}
+
+function groupedAmountColumn() {
+  return {
+    flexShrink: 0,
+    width: constantScale(150, 0.5),
+    minHeight: constantScale(40, 0.5),
+    height: constantScale(40, 0.5),
+    marginLeft: "auto" as const,
+  };
+}
+
+function narrowAmountColumn() {
+  return {
+    flexShrink: 0,
+    width: constantScale(150, 0.5),
+    minHeight: constantScale(40, 0.5),
+    height: constantScale(40, 0.5),
+    marginLeft: undefined as "auto" | undefined,
   };
 }
 
@@ -50,28 +73,16 @@ export function expenseListRowLayoutTokens(
     };
   }
 
-  if (layout.breakpoint === "wide") {
+  if (layout.breakpoint !== "narrow") {
     return {
-      rowShell: wideLedgerRowShell(layout),
-      amountColumn: {
-        flexShrink: 0,
-        width: constantScale(150, 0.5),
-        minHeight: constantScale(40, 0.5),
-        height: constantScale(40, 0.5),
-        marginLeft: "auto" as const,
-      },
+      rowShell: groupedLedgerRowShell(layout),
+      amountColumn: groupedAmountColumn(),
     };
   }
 
   return {
     rowShell: narrowLedgerRowShell(),
-    amountColumn: {
-      flexShrink: 0,
-      width: constantScale(150, 0.5),
-      minHeight: constantScale(40, 0.5),
-      height: constantScale(40, 0.5),
-      marginLeft: undefined as "auto" | undefined,
-    },
+    amountColumn: narrowAmountColumn(),
   };
 }
 

--- a/TravelCostApp/styles/expense-list-row-layout-tokens.ts
+++ b/TravelCostApp/styles/expense-list-row-layout-tokens.ts
@@ -1,0 +1,80 @@
+import type { LayoutProfile } from "../util/layout";
+import { constantScale, dynamicScale } from "../util/scalingUtil";
+
+export type ExpenseListRowLayoutVariant = "ledger" | "templatePicker";
+
+function templatePickerRowShell(layout: LayoutProfile) {
+  return {
+    alignItems: "flex-start" as const,
+    paddingVertical: dynamicScale(10, true),
+    width: "100%" as const,
+    minHeight: constantScale(72, 0.5),
+    height: undefined as number | undefined,
+    justifyContent: "flex-start" as const,
+  };
+}
+
+function wideLedgerRowShell(layout: LayoutProfile) {
+  return {
+    justifyContent: "flex-start" as const,
+    alignItems: "center" as const,
+    minHeight: layout.space(6),
+    height: undefined as number | undefined,
+    paddingVertical: layout.space(1),
+    gap: layout.space(2),
+  };
+}
+
+function narrowLedgerRowShell() {
+  return {
+    justifyContent: "space-between" as const,
+    minHeight: constantScale(55, 0.5),
+    height: constantScale(55, 0.5),
+  };
+}
+
+export function expenseListRowLayoutTokens(
+  layout: LayoutProfile,
+  variant: ExpenseListRowLayoutVariant
+) {
+  if (variant === "templatePicker") {
+    return {
+      rowShell: templatePickerRowShell(layout),
+      amountColumn: {
+        flexShrink: 0,
+        width: constantScale(108, 0.5),
+        minHeight: constantScale(40, 0.5),
+        height: undefined as number | undefined,
+        marginLeft: undefined as "auto" | undefined,
+      },
+    };
+  }
+
+  if (layout.breakpoint === "wide") {
+    return {
+      rowShell: wideLedgerRowShell(layout),
+      amountColumn: {
+        flexShrink: 0,
+        width: constantScale(150, 0.5),
+        minHeight: constantScale(40, 0.5),
+        height: constantScale(40, 0.5),
+        marginLeft: "auto" as const,
+      },
+    };
+  }
+
+  return {
+    rowShell: narrowLedgerRowShell(),
+    amountColumn: {
+      flexShrink: 0,
+      width: constantScale(150, 0.5),
+      minHeight: constantScale(40, 0.5),
+      height: constantScale(40, 0.5),
+      marginLeft: undefined as "auto" | undefined,
+    },
+  };
+}
+
+export type ExpenseListRowLayoutTokens = ReturnType<
+  typeof expenseListRowLayoutTokens
+>;

--- a/TravelCostApp/styles/trip-period-layout-tokens.ts
+++ b/TravelCostApp/styles/trip-period-layout-tokens.ts
@@ -62,7 +62,7 @@ function widePeriodChrome(layout: LayoutProfile) {
     periodDateHeader: {
       marginTop: layout.space(3),
       marginLeft: layout.space(4),
-      marginBottom: -layout.space(1),
+      marginBottom: layout.space(1),
     },
     headerCard: {
       ...shared.headerCard,

--- a/TravelCostApp/styles/trip-period-layout-tokens.ts
+++ b/TravelCostApp/styles/trip-period-layout-tokens.ts
@@ -1,7 +1,7 @@
 import type { LayoutProfile } from "../util/layout";
 import { dynamicScale } from "../util/scalingUtil";
 
-function sharedPeriodChrome(layout: LayoutProfile) {
+function sharedPeriodChrome(_layout: LayoutProfile) {
   return {
     periodHeaderRow: {
       flexDirection: "row" as const,
@@ -18,9 +18,9 @@ function sharedPeriodChrome(layout: LayoutProfile) {
   };
 }
 
-/** Preserves pre-#387 phone/tablet-medium chrome until screens consume a live layout profile (#388). */
-function narrowAndMediumPeriodChrome(layout: LayoutProfile) {
-  const shared = sharedPeriodChrome(layout);
+/** Preserves pre-#387 narrow portrait phone chrome. */
+function narrowPortraitPeriodChrome(_layout: LayoutProfile) {
+  const shared = sharedPeriodChrome(_layout);
 
   return {
     periodHeaderLabelFontSize: dynamicScale(28, false, 0.5),
@@ -43,6 +43,46 @@ function narrowAndMediumPeriodChrome(layout: LayoutProfile) {
     },
     dropdownContainer: {
       marginTop: dynamicScale(2, true),
+    },
+    dividerBar: {
+      marginTop: dynamicScale(12, true),
+      marginBottom: dynamicScale(-12, true),
+    },
+  };
+}
+
+function landscapePeriodChrome(layout: LayoutProfile) {
+  const shared = sharedPeriodChrome(layout);
+
+  return {
+    periodHeaderLabelFontSize: layout.type(28),
+    periodHeaderRow: {
+      ...shared.periodHeaderRow,
+      gap: layout.space(2),
+      marginTop: layout.space(3),
+      paddingHorizontal: layout.space(3),
+      marginBottom: layout.space(2),
+      justifyContent: "space-between" as const,
+      alignItems: "center" as const,
+      marginHorizontal: layout.space(3),
+    },
+    periodDateHeader: {
+      marginTop: layout.space(1),
+      marginLeft: layout.space(3),
+      marginBottom: layout.space(1),
+      alignSelf: "center" as const,
+    },
+    headerCard: {
+      ...shared.headerCard,
+      minHeight: layout.space(6),
+      paddingVertical: layout.space(1),
+    },
+    dropdownContainer: {
+      marginTop: layout.space(1),
+    },
+    dividerBar: {
+      marginTop: layout.space(3),
+      marginBottom: layout.space(2),
     },
   };
 }
@@ -72,6 +112,10 @@ function widePeriodChrome(layout: LayoutProfile) {
     dropdownContainer: {
       marginTop: layout.space(1),
     },
+    dividerBar: {
+      marginTop: layout.space(3),
+      marginBottom: layout.space(2),
+    },
   };
 }
 
@@ -80,7 +124,11 @@ export function tripPeriodLayoutTokens(layout: LayoutProfile) {
     return widePeriodChrome(layout);
   }
 
-  return narrowAndMediumPeriodChrome(layout);
+  if (layout.orientation === "landscape") {
+    return landscapePeriodChrome(layout);
+  }
+
+  return narrowPortraitPeriodChrome(layout);
 }
 
 export type TripPeriodLayoutTokens = ReturnType<typeof tripPeriodLayoutTokens>;


### PR DESCRIPTION
## Summary
- Extract `TripPeriodChrome` so Recent Expenses and Overview share one period header module with layout-driven spacing instead of divergent `isTablet` overrides.
- Unify ledger and template-picker rows behind `expense-list-row-layout-tokens`, removing the landscape `dynamicScale(100)` height hack and grouping wide columns with layout `space()`.
- Wrap Recent Expenses ledger content in `ContentFrame` (800px) on wide breakpoints.

## Test plan
- [x] `pnpm test -- __tests__/components/trip-period-chrome.test.tsx __tests__/styles/expense-list-row-layout-tokens.test.ts __tests__/components/expense-list-row-layout.test.tsx __tests__/screens/period-header-parity.test.tsx __tests__/screens/recent-expenses-tablet-layout.test.tsx`
- [ ] HITL: iPad 11" landscape — trip name fully visible, ≥5–7 ledger rows on screen without scrolling

Closes #388