### PR TITLE
Buttons and forms tablet optimization

### DIFF
--- a/TravelCostApp/__tests__/components/action-row-stack-layout.test.tsx
+++ b/TravelCostApp/__tests__/components/action-row-stack-layout.test.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { Dimensions, StyleSheet } from "react-native";
+
+import ActionRowStack from "../../components/UI/ActionRowStack";
+import LayoutContextProvider from "../../store/layout-context";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function renderActionRowStackAt(width: number, height: number) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 3,
+    fontScale: 1,
+  });
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <ActionRowStack
+        actions={[
+          {
+            testID: "sample-action",
+            label: "Add expense",
+            onPress: jest.fn(),
+            tier: "primary",
+          },
+        ]}
+      />
+    </LayoutContextProvider>,
+    { wrapNavigation: false }
+  );
+}
+
+describe("ActionRowStack layout", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("keeps actions full width on narrow phones", () => {
+    const screen = renderActionRowStackAt(390, 844);
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("action-row-stack-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.width).toBe("100%");
+    expect(frameStyle.alignSelf).toBe("stretch");
+    expect(frameStyle.maxWidth).toBeUndefined();
+  });
+
+  it("constrains actions on wide viewports", () => {
+    const screen = renderActionRowStackAt(1024, 768);
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("action-row-stack-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.maxWidth).toBe(480);
+    expect(frameStyle.alignSelf).toBe("center");
+    expect(frameStyle.minHeight).toBe(44);
+    expect(frameStyle.minWidth).toBe(44);
+  });
+});

--- a/TravelCostApp/__tests__/components/add-expenses-here-layout.test.tsx
+++ b/TravelCostApp/__tests__/components/add-expenses-here-layout.test.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { Dimensions, StyleSheet } from "react-native";
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+import AddExpensesHereButton from "../../components/UI/AddExpensesHereButton";
+import LayoutContextProvider from "../../store/layout-context";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function renderAddExpenseHereAt(width: number, height: number) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 3,
+    fontScale: 1,
+  });
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <AddExpensesHereButton dayISO="2026-01-15" />
+    </LayoutContextProvider>,
+    { wrapNavigation: false }
+  );
+}
+
+describe("AddExpensesHereButton layout", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("keeps add-expense-here full width on narrow phones", () => {
+    const screen = renderAddExpenseHereAt(390, 844);
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("add-expense-here-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.width).toBe("100%");
+    expect(frameStyle.alignSelf).toBe("stretch");
+    expect(frameStyle.maxWidth).toBeUndefined();
+  });
+
+  it("constrains add-expense-here on wide viewports", () => {
+    const screen = renderAddExpenseHereAt(1024, 768);
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("add-expense-here-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.maxWidth).toBe(480);
+    expect(frameStyle.alignSelf).toBe("center");
+    expect(frameStyle.minHeight).toBe(44);
+    expect(frameStyle.minWidth).toBe(44);
+  });
+});

--- a/TravelCostApp/__tests__/components/content-frame.test.tsx
+++ b/TravelCostApp/__tests__/components/content-frame.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import { renderWithAppProviders } from "../fixtures/app-providers";
-import ContentFrame from "../../components/layout/ContentFrame";
+import ContentFrame, { ControlFrame } from "../../components/layout/ContentFrame";
 import { layoutFor } from "../../util/layout";
 
 describe("ContentFrame", () => {
@@ -22,5 +22,44 @@ describe("ContentFrame", () => {
     expect(frameStyle.alignSelf).toBe("center");
     expect(frameStyle.width).toBe("100%");
     expect(frameStyle.paddingHorizontal).toBe(layout.space(3));
+  });
+});
+
+describe("ControlFrame", () => {
+  it("constrains wide fill controls to the layout control max width", () => {
+    const layout = layoutFor({ width: 1024, height: 768 });
+    const screen = renderWithAppProviders(
+      <ControlFrame testID="control-frame" layout={layout}>
+        <></>
+      </ControlFrame>,
+      { wrapNavigation: false }
+    );
+
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("control-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.maxWidth).toBe(480);
+    expect(frameStyle.alignSelf).toBe("center");
+    expect(frameStyle.minHeight).toBe(44);
+    expect(frameStyle.minWidth).toBe(44);
+  });
+
+  it("keeps narrow fill controls full width", () => {
+    const layout = layoutFor({ width: 390, height: 844 });
+    const screen = renderWithAppProviders(
+      <ControlFrame testID="control-frame" layout={layout}>
+        <></>
+      </ControlFrame>,
+      { wrapNavigation: false }
+    );
+
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("control-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.width).toBe("100%");
+    expect(frameStyle.alignSelf).toBe("stretch");
+    expect(frameStyle.maxWidth).toBeUndefined();
   });
 });

--- a/TravelCostApp/__tests__/components/expense-form-tablet-layout.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-form-tablet-layout.test.tsx
@@ -1,0 +1,187 @@
+import * as React from "react";
+import { Dimensions, StyleSheet, TextInput } from "react-native";
+import { fireEvent, waitFor } from "@testing-library/react-native";
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useFocusEffect: jest.fn(),
+  };
+});
+
+jest.mock("@react-navigation/elements", () => ({
+  useHeaderHeight: () => 0,
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  notificationAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+  NotificationFeedbackType: { Success: "Success" },
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+jest.mock("../../store/mmkv", () => ({
+  getExpenseDraft: jest.fn(() => undefined),
+  setExpenseDraft: jest.fn(),
+  clearExpenseDraft: jest.fn(),
+  getExpenseCat: jest.fn(() => undefined),
+  clearExpenseCat: jest.fn(),
+  getMMKVObject: jest.fn(() => undefined),
+  setExpenseCat: jest.fn(),
+  MMKV_KEYS: { CATEGORY_LIST: "categoryList" },
+}));
+
+jest.mock("../../store/secure-storage", () => ({
+  secureStoreSetItem: jest.fn(async () => {}),
+}));
+
+jest.mock("../../util/currencyExchange", () => ({
+  getRate: jest.fn(async () => 1),
+}));
+
+jest.mock("../../components/Premium/PremiumConstants", () => ({
+  isPremiumMember: jest.fn(async () => true),
+  ENTITLEMENT_ID: "premium",
+}));
+
+jest.mock("../../components/UI/DatePickerContainer", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  return function MockDatePickerContainer() {
+    return React.createElement(Text, { testID: "expense-form-date" }, "date");
+  };
+});
+
+jest.mock("../../components/UI/DatePickerModal", () => () => null);
+
+jest.mock("../../components/ExpensesOutput/ExpenseCountryFlag", () => () => null);
+jest.mock("../../components/Currency/CurrencyPicker", () => () => null);
+jest.mock("../../components/UI/BackButton", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return function MockBackButton() {
+    return React.createElement(View, { testID: "expense-form-back" });
+  };
+});
+
+jest.mock("../../components/Currency/CountryPicker", () => () => null);
+
+import ExpenseForm from "../../components/ManageExpense/ExpenseForm";
+import LayoutContextProvider from "../../store/layout-context";
+import { i18n } from "../../i18n/i18n";
+import { makeExpense } from "../fixtures/expense";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function renderExpenseFormAt(width: number, height: number) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 3,
+    fontScale: 1,
+  });
+
+  const navigation = { navigate: jest.fn(), pop: jest.fn(), popToTop: jest.fn() };
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <ExpenseForm
+        onCancel={jest.fn()}
+        onSubmit={jest.fn(async () => {})}
+        submitButtonLabel={i18n.t("add")}
+        isEditing={false}
+        defaultValues={makeExpense({
+          amount: 0,
+          description: "",
+          whoPaid: "",
+          splitList: [],
+          listEQUAL: [],
+        })}
+        pickedCat="food"
+        navigation={navigation as any}
+        editedExpenseId="TEMP_EXPENSE_ID"
+        newCat={false}
+        iconName="food"
+        dateISO=""
+      />
+    </LayoutContextProvider>,
+    {
+      wrapNavigation: false,
+      trip: {
+        tripid: "t1",
+        tripCurrency: "EUR",
+        travellers: [
+          { uid: "u1", userName: "Alice" },
+          { uid: "u2", userName: "Bob" },
+        ],
+        fetchAndSetTravellers: jest.fn(async () => {}),
+      },
+      user: {
+        userName: "Alice",
+        lastCountry: "DE",
+        lastCurrency: "EUR",
+      },
+    }
+  );
+}
+
+describe("ExpenseForm tablet layout", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses a single column grid in portrait on tablet widths", async () => {
+    const screen = renderExpenseFormAt(768, 1024);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expense-form-grid")).toBeTruthy();
+    });
+
+    expect(screen.queryAllByTestId("responsive-grid-column")).toHaveLength(0);
+  });
+
+  it("splits advanced fields into two columns in landscape", async () => {
+    const screen = renderExpenseFormAt(1024, 768);
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t("add"))).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+    fireEvent.changeText(screen.UNSAFE_getAllByType(TextInput)[0], "12");
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("responsive-grid-column")).toHaveLength(2);
+    });
+
+    expect(screen.getByTestId("expense-form-field-amount")).toBeTruthy();
+    expect(screen.getByTestId("expense-form-field-date")).toBeTruthy();
+    expect(screen.getByTestId("expense-form-field-country")).toBeTruthy();
+    expect(screen.getByTestId("expense-form-field-who-paid")).toBeTruthy();
+  });
+
+  it("constrains submit actions on wide viewports", async () => {
+    const screen = renderExpenseFormAt(1024, 768);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("action-row-stack-frame")).toBeTruthy();
+    });
+
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("action-row-stack-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.maxWidth).toBe(480);
+    expect(frameStyle.alignSelf).toBe("center");
+  });
+});

--- a/TravelCostApp/__tests__/components/expense-form-tablet-layout.test.tsx
+++ b/TravelCostApp/__tests__/components/expense-form-tablet-layout.test.tsx
@@ -83,7 +83,11 @@ import { i18n } from "../../i18n/i18n";
 import { makeExpense } from "../fixtures/expense";
 import { renderWithAppProviders } from "../fixtures/app-providers";
 
-function renderExpenseFormAt(width: number, height: number) {
+function renderExpenseFormAt(
+  width: number,
+  height: number,
+  overrides: Parameters<typeof renderWithAppProviders>[1] = {}
+) {
   jest.spyOn(Dimensions, "get").mockReturnValue({
     width,
     height,
@@ -117,6 +121,12 @@ function renderExpenseFormAt(width: number, height: number) {
     </LayoutContextProvider>,
     {
       wrapNavigation: false,
+      settings: {
+        settings: {
+          askAiForGoodPrices: false,
+          ...overrides.settings?.settings,
+        },
+      },
       trip: {
         tripid: "t1",
         tripCurrency: "EUR",
@@ -125,12 +135,15 @@ function renderExpenseFormAt(width: number, height: number) {
           { uid: "u2", userName: "Bob" },
         ],
         fetchAndSetTravellers: jest.fn(async () => {}),
+        ...overrides.trip,
       },
       user: {
         userName: "Alice",
         lastCountry: "DE",
         lastCurrency: "EUR",
+        ...overrides.user,
       },
+      ...overrides,
     }
   );
 }
@@ -179,6 +192,35 @@ describe("ExpenseForm tablet layout", () => {
 
     const frameStyle = StyleSheet.flatten(
       screen.getByTestId("action-row-stack-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frameStyle.maxWidth).toBe(480);
+    expect(frameStyle.alignSelf).toBe("center");
+  });
+
+  it("constrains get local price action on wide viewports", async () => {
+    const screen = renderExpenseFormAt(1024, 768, {
+      settings: {
+        settings: {
+          askAiForGoodPrices: true,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t("showMoreOptions"))).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText(i18n.t("showMoreOptions")));
+    fireEvent.changeText(screen.UNSAFE_getAllByType(TextInput)[0], "12");
+    fireEvent.changeText(screen.UNSAFE_getAllByType(TextInput)[1], "Coffee");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("expense-form-get-local-price-frame")).toBeTruthy();
+    });
+
+    const frameStyle = StyleSheet.flatten(
+      screen.getByTestId("expense-form-get-local-price-frame").props.style
     ) as Record<string, unknown>;
 
     expect(frameStyle.maxWidth).toBe(480);

--- a/TravelCostApp/__tests__/components/responsive-grid.test.tsx
+++ b/TravelCostApp/__tests__/components/responsive-grid.test.tsx
@@ -55,4 +55,64 @@ describe("ResponsiveGrid", () => {
 
     expect(screen.getAllByTestId("responsive-grid-column")).toHaveLength(2);
   });
+
+  it("uses a single column in portrait even on wide breakpoints when multiColumnWhen is landscape", () => {
+    const layout = layoutFor({ width: 768, height: 1024 });
+    const screen = renderWithAppProviders(
+      <ResponsiveGrid
+        testID="responsive-grid"
+        layout={layout}
+        multiColumnWhen="landscape"
+        items={[
+          { key: "one", render: () => <Text testID="grid-item-one">One</Text> },
+          { key: "two", render: () => <Text testID="grid-item-two">Two</Text> },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
+    expect(screen.queryAllByTestId("responsive-grid-column")).toHaveLength(0);
+    expect(screen.getByTestId("grid-item-one")).toBeTruthy();
+    expect(screen.getByTestId("grid-item-two")).toBeTruthy();
+  });
+
+  it("places items in explicit left and right columns when column is set", () => {
+    const layout = layoutFor({ width: 1024, height: 768 });
+    const screen = renderWithAppProviders(
+      <ResponsiveGrid
+        testID="responsive-grid"
+        layout={layout}
+        multiColumnWhen="landscape"
+        items={[
+          {
+            key: "amount",
+            column: "left",
+            render: () => <Text testID="grid-item-amount">Amount</Text>,
+          },
+          {
+            key: "who-paid",
+            column: "right",
+            render: () => <Text testID="grid-item-who-paid">Who paid</Text>,
+          },
+          {
+            key: "date",
+            column: "left",
+            render: () => <Text testID="grid-item-date">Date</Text>,
+          },
+          {
+            key: "country",
+            column: "right",
+            render: () => <Text testID="grid-item-country">Country</Text>,
+          },
+        ]}
+      />,
+      { wrapNavigation: false }
+    );
+
+    const [leftColumn, rightColumn] = screen.getAllByTestId("responsive-grid-column");
+    expect(within(leftColumn).getByTestId("grid-item-amount")).toBeTruthy();
+    expect(within(leftColumn).getByTestId("grid-item-date")).toBeTruthy();
+    expect(within(rightColumn).getByTestId("grid-item-who-paid")).toBeTruthy();
+    expect(within(rightColumn).getByTestId("grid-item-country")).toBeTruthy();
+  });
 });

--- a/TravelCostApp/__tests__/util/layout.test.ts
+++ b/TravelCostApp/__tests__/util/layout.test.ts
@@ -1,4 +1,46 @@
-import { layoutFor } from "../../util/layout";
+import { controlWidthStyle, layoutFor } from "../../util/layout";
+
+describe("controlWidthStyle", () => {
+  it("stretches fill controls full width on narrow viewports", () => {
+    const layout = layoutFor({ width: 390, height: 844 });
+    expect(controlWidthStyle(layout, "fill")).toEqual({
+      alignSelf: "stretch",
+      width: "100%",
+      minHeight: 44,
+      minWidth: 44,
+    });
+  });
+
+  it("hugs back controls on narrow viewports without forcing full width", () => {
+    const layout = layoutFor({ width: 390, height: 844 });
+    expect(controlWidthStyle(layout, "hug")).toEqual({
+      alignSelf: "flex-start",
+      minHeight: 44,
+      minWidth: 44,
+    });
+  });
+
+  it("centers fill controls with a max width on wide viewports", () => {
+    const layout = layoutFor({ width: 1024, height: 768 });
+    expect(controlWidthStyle(layout, "fill")).toEqual({
+      alignSelf: "center",
+      width: "100%",
+      maxWidth: 480,
+      minHeight: 44,
+      minWidth: 44,
+    });
+  });
+
+  it("hugs back controls with a max width on wide viewports", () => {
+    const layout = layoutFor({ width: 1024, height: 768 });
+    expect(controlWidthStyle(layout, "hug")).toEqual({
+      alignSelf: "flex-start",
+      maxWidth: 480,
+      minHeight: 44,
+      minWidth: 44,
+    });
+  });
+});
 
 describe("layoutFor", () => {
   it("maps a phone viewport to a narrow profile with 800 content max width", () => {

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -2011,6 +2011,15 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
     },
   ];
 
+  const expenseFormGrid = (
+    <ResponsiveGrid
+      testID="expense-form-grid"
+      layout={layout}
+      multiColumnWhen="landscape"
+      items={expenseFormGridItems}
+    />
+  );
+
   return (
     <>
       {datepickerJSX}
@@ -2045,20 +2054,10 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
                   .delay(100)}
                 exiting={FadeOutUp.duration(50)}
               >
-                <ResponsiveGrid
-                  testID="expense-form-grid"
-                  layout={layout}
-                  multiColumnWhen="landscape"
-                  items={expenseFormGridItems}
-                />
+                {expenseFormGrid}
               </Animated.View>
             ) : (
-              <ResponsiveGrid
-                testID="expense-form-grid"
-                layout={layout}
-                multiColumnWhen="landscape"
-                items={expenseFormGridItems}
-              />
+              expenseFormGrid
             )}
             {formIsInvalid && !hideAdvanced && (
               <Text style={styles.errorText}>{i18n.t("invalidInput")} </Text>
@@ -2071,16 +2070,21 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
             inputs.currency.value &&
             inputs.country.value && (
               <View style={styles.getLocalPriceContainer}>
-                <ActionRow
-                  testID="expense-form-get-local-price"
-                  tier="gradient"
-                  label={i18n.t("getLocalPriceTitle")}
-                  hint={getLocalPriceRowHint}
-                  imageIconSource={require("../../assets/chatgpt-logo.jpeg")}
-                  onPress={askChatGPTHandler}
-                  showChevron={false}
-                  style={styles.getLocalPriceButton}
-                />
+                <ControlFrame
+                  layout={layout}
+                  testID="expense-form-get-local-price-frame"
+                >
+                  <ActionRow
+                    testID="expense-form-get-local-price"
+                    tier="gradient"
+                    label={i18n.t("getLocalPriceTitle")}
+                    hint={getLocalPriceRowHint}
+                    imageIconSource={require("../../assets/chatgpt-logo.jpeg")}
+                    onPress={askChatGPTHandler}
+                    showChevron={false}
+                    style={styles.getLocalPriceButton}
+                  />
+                </ControlFrame>
               </View>
             )}
           <View style={styles.buttonContainer}>

--- a/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
+++ b/TravelCostApp/components/ManageExpense/ExpenseForm.tsx
@@ -17,7 +17,6 @@ import {
   Pressable,
   FlatList,
   KeyboardAvoidingView,
-  InputAccessoryView,
 } from "react-native";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { useFocusEffect } from "@react-navigation/native";
@@ -138,7 +137,9 @@ import { Platform } from "react-native";
 import { isPremiumMember } from "../Premium/PremiumConstants";
 import { MAX_EXPENSES_PERTRIP_NONPREMIUM } from "../../confAppConstants";
 import { constantScale, dynamicScale } from "../../util/scalingUtil";
-import { OrientationContext } from "../../store/orientation-context";
+import { useLayoutProfile } from "../../store/layout-context";
+import ResponsiveGrid from "../layout/ResponsiveGrid";
+import { ControlFrame } from "../layout/ContentFrame";
 import { callDebounced } from "../Hooks/useDebounce";
 import { NavigationProp } from "@react-navigation/native";
 import { trackEvent } from "../../util/vexo-tracking";
@@ -190,7 +191,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   const netCtx = useContext(NetworkContext);
   const expCtx = useContext(ExpensesContext);
   const { settings } = useContext(SettingsContext);
-  const { isPortrait, isTablet } = useContext(OrientationContext);
+  const layout = useLayoutProfile();
   const hideSpecial = settings.hideSpecialExpenses;
   const alwaysShowAdvancedSetting = settings.alwaysShowAdvanced || isEditing;
   const editingValues = defaultValues;
@@ -1222,12 +1223,14 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   );
 
   const backButtonJsx = (
-    <BackButton
-      style={{
-        flex: 0,
-        paddingRight: dynamicScale(100, false, 0.5),
-      }}
-    />
+    <ControlFrame layout={layout} mode="hug" testID="expense-form-back-frame">
+      <BackButton
+        style={{
+          flex: 0,
+          paddingRight: dynamicScale(100, false, 0.5),
+        }}
+      />
+    </ControlFrame>
   );
   const confirmButtonJSX = (
     <Pressable
@@ -1364,29 +1367,650 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
   const headerHeight = useHeaderHeight();
   const hideBottomBorder = duplOrSplit == 1 || duplOrSplit == 2;
 
-  const onPressHandlerQuickSum = () => {
-    if (inputs.amount.value) {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-      const _tempAmount = +tempAmount;
-      const newAmount = _tempAmount + Number(inputs.amount.value);
-      setTempAmount(newAmount.toFixed(2));
-      inputChangedHandler("amount", "");
-      trackEvent(VexoEvents.QUICK_SUM_PRESSED, {
-        action: "add",
-        amount: inputs.amount.value,
-        total: newAmount.toFixed(2),
-      });
-    } else if (tempAmount) {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-      const _tempAmount = +tempAmount;
-      inputChangedHandler("amount", _tempAmount.toFixed(2));
-      setTempAmount("");
-      trackEvent(VexoEvents.QUICK_SUM_PRESSED, {
-        action: "restore",
-        amount: _tempAmount.toFixed(2),
-      });
-    }
+  const formLayoutStyle = {
+    margin: layout.space(3),
+    padding: layout.space(2),
+    paddingBottom: layout.space(3),
   };
+  const fieldLabelStyle = {
+    fontSize: layout.type(12),
+  };
+
+  const expenseFormGridItems = [
+    {
+      key: "left-fields",
+      column: "left" as const,
+      render: () => (
+        <>
+          <View testID="expense-form-field-amount" style={styles.inputsRow}>
+            <Input
+              inputStyle={styles.amountInput}
+              label={
+                i18n.t("priceIn") + getCurrencySymbol(inputs.currency.value)
+              }
+              textInputConfig={{
+                keyboardType: "decimal-pad",
+                onChangeText: inputChangedHandler.bind(this, "amount"),
+                value: inputs.amount.value,
+              }}
+              invalid={!inputs.amount.isValid}
+              autoFocus={!isEditing ?? false}
+            />
+            {inputs.amount.value && isAndroid && (
+              <IconButton
+                buttonStyle={styles.quickSumButton}
+                icon={"add-outline"}
+                color={GlobalStyles.colors.textColor}
+                size={dynamicScale(24, false, 0.5)}
+                onPress={() => {
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                  const _tempAmount = +tempAmount;
+                  const newAmount = _tempAmount + Number(inputs.amount.value);
+                  setTempAmount(newAmount.toFixed(2));
+                  inputChangedHandler("amount", "");
+                }}
+              />
+            )}
+            {!inputs.amount.value && tempAmount && (
+              <IconButton
+                buttonStyle={styles.quickSumButton}
+                icon={"return-down-back-outline"}
+                color={GlobalStyles.colors.textColor}
+                size={dynamicScale(24, false, 0.5)}
+                onPress={() => {
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                  const _tempAmount = +tempAmount;
+                  inputChangedHandler("amount", _tempAmount.toFixed(2));
+                  setTempAmount("");
+                }}
+              />
+            )}
+            {tempAmount && (
+              <Text style={styles.tempAmount}>
+                +{" "}
+                {formatExpenseWithCurrency(tempAmount, inputs.currency.value)}
+              </Text>
+            )}
+            {hasCalcAmount && (
+              <Text
+                style={[!tempAmount ? styles.tempAmount : styles.calcAmount]}
+              >
+                ={" "}
+                {formatExpenseWithCurrency(calcAmount, tripCtx.tripCurrency)}
+              </Text>
+            )}
+            <IconButton
+              buttonStyle={styles.iconButton}
+              icon={icon}
+              color={GlobalStyles.colors.primary500}
+              size={layout.type(48)}
+              onPress={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                const idCatData: IDCat = {
+                  expenseId: editedExpenseId,
+                  category: inputs.category.value,
+                };
+                setExpenseCat(editedExpenseId, idCatData);
+                saveDraftData();
+                navigation.navigate("CategoryPick", {
+                  expenseId: editedExpenseId,
+                  isUpdating: isEditing,
+                });
+              }}
+            />
+          </View>
+          <Autocomplete
+            value={inputs.description.value}
+            containerStyle={[
+              styles.descriptionContainer,
+              { marginTop: layout.space(2) },
+            ]}
+            onChange={inputChangedHandler.bind(this, "description")}
+            label={i18n.t("descriptionLabel")}
+            data={suggestionData}
+            style={styles.autoCompleteStyle}
+            menuStyle={styles.autoCompleteMenuStyle}
+            showOnEmpty={false}
+            placeholder=""
+          />
+          {!alwaysShowAdvancedSetting && (
+            <Pressable onPress={toggleAdvancedHandler}>
+              <Animated.View style={styles.advancedRow}>
+                <Ionicons
+                  name={
+                    hideAdvanced
+                      ? "arrow-down-circle-outline"
+                      : "arrow-forward-circle-outline"
+                  }
+                  size={layout.type(28)}
+                  color={GlobalStyles.colors.primary500}
+                />
+                {hideAdvanced && (
+                  <Text style={[styles.advancedText, fieldLabelStyle]}>
+                    {i18n.t("showMoreOptions")}
+                  </Text>
+                )}
+                {!hideAdvanced && (
+                  <Text style={[styles.advancedText, fieldLabelStyle]}>
+                    {i18n.t("showLessOptions")}
+                  </Text>
+                )}
+              </Animated.View>
+            </Pressable>
+          )}
+          {!hideAdvanced && (
+            <>
+              <View style={styles.currencyContainer}>
+                <Text style={[styles.currencyLabel, fieldLabelStyle]}>
+                  {i18n.t("currencyLabel")}
+                </Text>
+                <CurrencyPicker
+                  countryValue={currencyPickerValue}
+                  setCountryValue={setCurrencyPickerValue}
+                  onChangeValue={updateCurrency}
+                  placeholder={currencyPlaceholder}
+                  inputCurrencyCode={inputs.currency.value}
+                ></CurrencyPicker>
+              </View>
+              <View testID="expense-form-field-date" style={styles.dateLabel}>
+                <Text style={[styles.dateLabelText, fieldLabelStyle]}>
+                  {i18n.t("dateLabel")}
+                </Text>
+              </View>
+              {DatePickerContainer({
+                openDatePickerRange,
+                startDate,
+                endDate,
+                dateIsRanged,
+                hideBottomBorder,
+              })}
+              <View
+                style={
+                  duplOrSplit !== 0 && {
+                    paddingBottom: layout.space(1),
+                    marginHorizontal: "5%",
+                    borderBottomColor: GlobalStyles.colors.textColor,
+                    borderBottomWidth: 1,
+                  }
+                }
+              >
+                {duplOrSplit !== 0 && (
+                  <View style={styles.duplOrSplitContainer}>
+                    <Text style={[styles.dateLabelDuplSplitText, fieldLabelStyle]}>
+                      {duplOrSplitString(duplOrSplit)}
+                    </Text>
+                  </View>
+                )}
+              </View>
+            </>
+          )}
+        </>
+      ),
+    },
+    {
+      key: "right-fields",
+      column: "right" as const,
+      render: () =>
+        !hideAdvanced ? (
+          <>
+            <View style={[styles.inputsRowSecond]}>
+              <View
+                testID="expense-form-field-country"
+                style={styles.countryContainer}
+              >
+                <Text style={[styles.currencyLabel, fieldLabelStyle]}>
+                  {i18n.t("countryLabel")}
+                </Text>
+                <View style={{ flexDirection: "row" }}>
+                  <View
+                    style={[
+                      {
+                        minWidth: "77%",
+                        maxWidth: "77%",
+                      },
+                    ]}
+                  >
+                    <CountryPicker
+                      countryValue={countryPickerValue}
+                      setCountryValue={setCountryPickerValue}
+                      onChangeValue={updateCountry}
+                      placeholder={countryPlaceholder}
+                    ></CountryPicker>
+                  </View>
+                  <ExpenseCountryFlag
+                    countryName={inputs.country.value?.split("- ")[0].trim()}
+                    style={styles.countryFlag}
+                    containerStyle={styles.countryFlagContainer}
+                  ></ExpenseCountryFlag>
+                </View>
+              </View>
+            </View>
+            <View style={styles.inputsRowSecond}>
+              {showWhoPaid && (
+                <View
+                  testID="expense-form-field-who-paid"
+                  style={styles.whoPaidContainer}
+                >
+                  <Text
+                    style={[
+                      styles.whoPaidLabel,
+                      fieldLabelStyle,
+                      !inputs.whoPaid.isValid && styles.invalidLabel,
+                    ]}
+                  >
+                    {i18n.t("whoPaid")}
+                  </Text>
+                  {loadingTravellers && (
+                    <ActivityIndicator
+                      size={"large"}
+                      color={GlobalStyles.colors.backgroundColor}
+                    ></ActivityIndicator>
+                  )}
+                  {!loadingTravellers && (
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        marginLeft: layout.space(3),
+                        marginTop: layout.space(1),
+                      }}
+                    >
+                      {!IsSoloTraveller && (
+                        <IconButton
+                          icon="people-circle-outline"
+                          size={constantScale(28, 0.5)}
+                          buttonStyle={styles.whoPaidSplitButton}
+                          color={GlobalStyles.colors.primary500}
+                          onPress={() => {
+                            Haptics.impactAsync(
+                              Haptics.ImpactFeedbackStyle.Light
+                            );
+                            const tempSplitType: splitType = splitTypes.EXACT;
+                            const userNames =
+                              travellerUserNames(currentTravellers);
+                            const listSplits = calcSplitList(
+                              tempSplitType,
+                              +amountValue,
+                              userCtx.userName,
+                              userNames
+                            );
+                            if (listSplits) {
+                              setSplitType(tempSplitType);
+                              const splitsWithoutOrder =
+                                resetEditOrder(listSplits);
+                              setSplitList(splitsWithoutOrder);
+                              setSplitListValid(
+                                validateSplitList(
+                                  splitsWithoutOrder,
+                                  tempSplitType,
+                                  +amountValue
+                                )
+                              );
+                            }
+                          }}
+                        ></IconButton>
+                      )}
+                      <DropDownPicker
+                        containerStyle={styles.dropdownContainer}
+                        open={modalFlow === MODAL_FLOW_STATE.WHO_PAID}
+                        value={whoPaid}
+                        items={items}
+                        setOpen={(open) => {
+                          setModalFlow(
+                            open
+                              ? MODAL_FLOW_STATE.WHO_PAID
+                              : MODAL_FLOW_STATE.CLOSED
+                          );
+                        }}
+                        setValue={handleWhoPaidChange}
+                        setItems={setItems}
+                        onClose={() => {
+                          if (modalFlow === MODAL_FLOW_STATE.WHO_PAID) {
+                            setModalFlow(MODAL_FLOW_STATE.CLOSED);
+                          }
+                        }}
+                        onOpen={() => {
+                          setModalFlow(MODAL_FLOW_STATE.WHO_PAID);
+                          Haptics.impactAsync(
+                            Haptics.ImpactFeedbackStyle.Light
+                          );
+                        }}
+                        onSelectItem={(item) => {
+                          Haptics.impactAsync(
+                            Haptics.ImpactFeedbackStyle.Light
+                          );
+
+                          if (item.value === MODAL_FLOW_ADD_TRAVELLER) {
+                            setWhoPaidWithLogging(userCtx.userName);
+                            setSplitType(splitTypes.SELF);
+                          } else {
+                            setWhoPaidWithLogging(item.value);
+                          }
+
+                          nextModal(item.value);
+                        }}
+                        listMode="MODAL"
+                        modalProps={{
+                          animationType: "slide",
+                          presentationStyle: "pageSheet",
+                        }}
+                        searchable={false}
+                        modalTitle={i18n.t("whoPaid")}
+                        modalContentContainerStyle={{
+                          backgroundColor:
+                            GlobalStyles.colors.backgroundColor,
+                          marginTop: "2%",
+                          elevation: 2,
+                          shadowColor: GlobalStyles.colors.textColor,
+                          shadowOffset: { width: 1, height: 1 },
+                          shadowOpacity: 0.35,
+                          shadowRadius: 4,
+                        }}
+                        placeholder={userCtx.userName}
+                        style={
+                          !inputs.whoPaid.isValid
+                            ? [
+                                styles.whoPaidDropdownContainer,
+                                styles.invalidInput,
+                              ]
+                            : styles.whoPaidDropdownContainer
+                        }
+                        textStyle={styles.dropdownTextStyle}
+                      />
+                    </View>
+                  )}
+                </View>
+              )}
+              {whoPaidValid && !IsSoloTraveller && (
+                <DropDownPicker
+                  open={modalFlow === MODAL_FLOW_STATE.HOW_SHARED}
+                  value={splitType}
+                  items={splitItems}
+                  setOpen={(open) => {
+                    setModalFlow(
+                      open
+                        ? MODAL_FLOW_STATE.HOW_SHARED
+                        : MODAL_FLOW_STATE.CLOSED
+                    );
+                  }}
+                  setValue={setSplitType}
+                  setItems={setSplitTypeItems}
+                  onSelectItem={(item) => {
+                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                    if (item.value === splitTypes.EXACT) {
+                      setSplitType(item.value);
+                    }
+                    nextModal(item.value);
+                  }}
+                  onClose={() => {
+                    if (modalFlow === MODAL_FLOW_STATE.HOW_SHARED) {
+                      setModalFlow(MODAL_FLOW_STATE.CLOSED);
+                    }
+                  }}
+                  onOpen={() => {
+                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                  }}
+                  listMode="MODAL"
+                  modalProps={{
+                    animationType: "slide",
+                    presentationStyle: "pageSheet",
+                  }}
+                  searchable={false}
+                  modalTitle={i18n.t("howShared")}
+                  modalContentContainerStyle={{
+                    backgroundColor: GlobalStyles.colors.backgroundColor,
+                  }}
+                  placeholder={i18n.t("placeholderSharedExpense")}
+                  containerStyle={[
+                    styles.dropdownContainer,
+                    hidePickers && styles.hidePickersStyle,
+                  ]}
+                  style={[
+                    styles.whoPaidDropdownContainer,
+                    hidePickers && styles.hidePickersStyle,
+                  ]}
+                  textStyle={styles.dropdownTextStyle}
+                />
+              )}
+            </View>
+            {!loadingTravellers && !splitTypeSelf && !IsSoloTraveller && (
+              <DropDownPicker
+                open={
+                  modalFlow === MODAL_FLOW_STATE.EXACT_SHARING || openEQUAL
+                }
+                value={splitTravellersList}
+                items={splitItemsEQUAL}
+                setOpen={(open) => {
+                  if (open) {
+                    setModalFlow(MODAL_FLOW_STATE.EXACT_SHARING);
+                  } else {
+                    setModalFlow(MODAL_FLOW_STATE.CLOSED);
+                    setOpenEQUAL(false);
+                  }
+                }}
+                onOpen={() => {
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                }}
+                onSelectItem={() => {
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                }}
+                setValue={setSplitTravellersList}
+                setItems={setSplitItemsEQUAL}
+                onClose={() => {
+                  setModalFlow(MODAL_FLOW_STATE.CLOSED);
+                  splitHandler(splitType);
+                }}
+                listMode="MODAL"
+                multiple={true}
+                CloseIconComponent={() => (
+                  <Text
+                    style={{
+                      color: GlobalStyles.colors.textColor,
+                      fontSize: layout.type(24),
+                      fontWeight: "bold",
+                      padding: layout.space(1),
+                    }}
+                  >
+                    {i18n.t("confirm2")}
+                  </Text>
+                )}
+                min={1}
+                max={99}
+                labelProps={{ style: { padding: layout.space(1) } }}
+                modalProps={{
+                  animationType: "slide",
+                  presentationStyle: "pageSheet",
+                }}
+                searchable={false}
+                modalTitle={i18n.t("whoShared")}
+                modalContentContainerStyle={{
+                  backgroundColor: GlobalStyles.colors.backgroundColor,
+                }}
+                placeholder={i18n.t("placeholderSharedBetween")}
+                containerStyle={[
+                  styles.dropdownContainer,
+                  hidePickers && styles.hidePickersStyle,
+                ]}
+                style={[
+                  styles.whoPaidDropdownContainer,
+                  hidePickers && styles.hidePickersStyle,
+                ]}
+                textStyle={styles.dropdownTextStyle}
+              />
+            )}
+            <View
+              style={[
+                styles.advancedRowSplit,
+                {
+                  marginTop: layout.space(2),
+                  marginLeft: layout.space(2),
+                },
+              ]}
+            >
+              {!splitTypeSelf &&
+                whoPaidValid &&
+                !IsSoloTraveller &&
+                splitListHasNonZeroEntries && (
+                  <Text style={[styles.whoSharedLabel, fieldLabelStyle]}>
+                    {i18n.t("whoShared")}
+                  </Text>
+                )}
+            </View>
+            {!splitTypeSelf && (
+              <KeyboardAvoidingView
+                behavior={Platform.select({
+                  android: undefined,
+                  ios: "position",
+                })}
+                keyboardVerticalOffset={Platform.select({
+                  android: headerHeight,
+                  ios: 0,
+                })}
+                contentContainerStyle={{
+                  flex: 1,
+                  justifyContent: "flex-start",
+                  alignItems: "flex-start",
+                  overflow: "visible",
+                  backgroundColor: GlobalStyles.colors.gray500,
+                }}
+              >
+                <FlatList
+                  data={splitList}
+                  horizontal={true}
+                  contentContainerStyle={{
+                    flex: 1,
+                    minWidth: splitList?.length
+                      ? splitList?.length * dynamicScale(100, false, 0.5) +
+                        dynamicScale(200, false, 0.5)
+                      : 0,
+                    marginLeft: layout.space(1),
+                    marginRight: layout.space(1),
+                    justifyContent: "flex-start",
+                    alignItems: "flex-start",
+                  }}
+                  ListHeaderComponent={null}
+                  ListFooterComponent={
+                    <View
+                      style={{ width: dynamicScale(300, false, 0.5) }}
+                    ></View>
+                  }
+                  renderItem={(itemData) => {
+                    const splitValue = splitAmountDisplayValue(itemData.item);
+                    return (
+                      <View style={styles.splitEditorCard}>
+                        <View
+                          style={{
+                            flexDirection: "row",
+                            paddingHorizontal: layout.space(1),
+                            justifyContent: "space-between",
+                            flex: 1,
+                          }}
+                        >
+                          <Text
+                            style={{
+                              color: splitListValid
+                                ? GlobalStyles.colors.textColor
+                                : GlobalStyles.colors.error500,
+                              textAlign: "left",
+                              marginLeft: layout.space(1),
+                              paddingTop: dynamicScale(2, true),
+                              fontSize: layout.type(14),
+                            }}
+                          >
+                            {truncateString(itemData.item.userName, 10)}
+                          </Text>
+                          <Pressable
+                            style={{
+                              paddingLeft: layout.space(3),
+                              paddingBottom: layout.space(3),
+                            }}
+                            onPress={() => {
+                              removeUserFromSplit(itemData.item.userName);
+                            }}
+                          >
+                            <Text
+                              style={{
+                                fontSize: layout.type(14),
+                                color: GlobalStyles.colors.accent500,
+                                textAlign: "left",
+                                fontWeight: "600",
+                              }}
+                            >
+                              x
+                            </Text>
+                          </Pressable>
+                        </View>
+                        <View
+                          style={{
+                            flexDirection: "row",
+                            justifyContent: "flex-start",
+                            alignItems: "flex-end",
+                            overflow: "visible",
+                            marginLeft: dynamicScale(-16),
+                            marginRight: dynamicScale(-8),
+                          }}
+                        >
+                          <Input
+                            hasCurrency={!!inputs.currency}
+                            inputStyle={[
+                              splitTypeEqual && {
+                                color: GlobalStyles.colors.textColor,
+                              },
+                              {
+                                paddingBottom: dynamicScale(4, true),
+                                marginTop: dynamicScale(-26, true),
+                              },
+                              {
+                                backgroundColor:
+                                  GlobalStyles.colors.backgroundColor,
+                              },
+                            ]}
+                            textInputConfig={{
+                              onFocus: () => {
+                                if (splitType === splitTypes.EQUAL) {
+                                  setSplitType(splitTypes.EXACT);
+                                }
+                              },
+                              keyboardType: "decimal-pad",
+                              onChangeText: inputSplitListHandler.bind(
+                                this,
+                                itemData.index,
+                                itemData.item
+                              ),
+                              value: splitValue,
+                            }}
+                          ></Input>
+                          <Text
+                            style={{
+                              paddingBottom: dynamicScale(11, true),
+                              marginLeft: dynamicScale(-18, false, 1.3),
+                              marginRight: layout.space(1),
+                            }}
+                          >
+                            {getCurrencySymbol(inputs.currency.value)}
+                          </Text>
+                        </View>
+                        {splitListCalcAmounts[itemData.index] && (
+                          <Text style={styles.splitListCalcAmount}>
+                            {"= "}
+                            {formatExpenseWithCurrency(
+                              splitListCalcAmounts[itemData.index],
+                              tripCtx.tripCurrency
+                            )}
+                          </Text>
+                        )}
+                      </View>
+                    );
+                  }}
+                ></FlatList>
+              </KeyboardAvoidingView>
+            )}
+            {!splitTypeSelf && splitListHasNonZeroEntries && paidBackJSX}
+            {isSpecialExpenseJSX}
+          </>
+        ) : null,
+    },
+  ];
+
   return (
     <>
       {datepickerJSX}
@@ -1410,648 +2034,31 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
             {backButtonJsx}
             {Platform.OS == "ios" && confirmButtonJSX}
           </View>
-          <Animated.View layout={LinearTransition} style={styles.form}>
-            <View style={styles.inputsRow}>
-              <Input
-                inputStyle={styles.amountInput}
-                label={
-                  i18n.t("priceIn") + getCurrencySymbol(inputs.currency.value)
-                }
-                textInputConfig={{
-                  keyboardType: "decimal-pad",
-                  onChangeText: inputChangedHandler.bind(this, "amount"),
-                  value: inputs.amount.value,
-                }}
-                // inputAccessoryViewID="amountID"
-                invalid={!inputs.amount.isValid}
-                autoFocus={!isEditing ?? false}
-              />
-              {inputs.amount.value && isAndroid && (
-                <IconButton
-                  buttonStyle={styles.quickSumButton}
-                  icon={"add-outline"}
-                  color={GlobalStyles.colors.textColor}
-                  size={dynamicScale(24, false, 0.5)}
-                  onPress={() => {
-                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                    const _tempAmount = +tempAmount;
-                    const newAmount = _tempAmount + Number(inputs.amount.value);
-                    setTempAmount(newAmount.toFixed(2));
-                    inputChangedHandler("amount", "");
-                  }}
-                />
-              )}
-              {!inputs.amount.value && tempAmount && (
-                <IconButton
-                  buttonStyle={styles.quickSumButton}
-                  icon={"return-down-back-outline"}
-                  color={GlobalStyles.colors.textColor}
-                  size={dynamicScale(24, false, 0.5)}
-                  onPress={() => {
-                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                    const _tempAmount = +tempAmount;
-                    inputChangedHandler("amount", _tempAmount.toFixed(2));
-                    setTempAmount("");
-                  }}
-                />
-              )}
-              {tempAmount && (
-                <Text style={styles.tempAmount}>
-                  +{" "}
-                  {formatExpenseWithCurrency(tempAmount, inputs.currency.value)}
-                </Text>
-              )}
-              {hasCalcAmount && (
-                <Text
-                  style={[!tempAmount ? styles.tempAmount : styles.calcAmount]}
-                >
-                  ={" "}
-                  {formatExpenseWithCurrency(calcAmount, tripCtx.tripCurrency)}
-                </Text>
-              )}
-              <IconButton
-                buttonStyle={styles.iconButton}
-                icon={icon}
-                color={GlobalStyles.colors.primary500}
-                size={dynamicScale(48, false, 0.4)}
-                onPress={() => {
-                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  // Store current form state in MMKV before navigation
-                  const idCatData: IDCat = {
-                    expenseId: editedExpenseId,
-                    category: inputs.category.value,
-                  };
-                  setExpenseCat(editedExpenseId, idCatData);
-                  // Also save to draft storage
-                  saveDraftData();
-                  // Navigate with minimal params
-                  navigation.navigate("CategoryPick", {
-                    expenseId: editedExpenseId,
-                    isUpdating: isEditing,
-                  });
-                }}
-              />
-            </View>
-
-            {/* Description field - moved from advanced options for better UX */}
-            <Autocomplete
-              value={inputs.description.value}
-              containerStyle={styles.descriptionContainer}
-              onChange={inputChangedHandler.bind(this, "description")}
-              label={i18n.t("descriptionLabel")}
-              data={suggestionData}
-              style={styles.autoCompleteStyle}
-              menuStyle={styles.autoCompleteMenuStyle}
-              showOnEmpty={false}
-              placeholder=""
-            />
-
-            {/* always show more options when editing */}
-            {!alwaysShowAdvancedSetting && (
-              <Pressable onPress={toggleAdvancedHandler}>
-                <Animated.View style={styles.advancedRow}>
-                  <Ionicons
-                    name={
-                      hideAdvanced
-                        ? "arrow-down-circle-outline"
-                        : "arrow-forward-circle-outline"
-                    }
-                    size={dynamicScale(28, false, 0.5)}
-                    color={GlobalStyles.colors.primary500}
-                  />
-                  {hideAdvanced && (
-                    <Text style={styles.advancedText}>
-                      {i18n.t("showMoreOptions")}
-                    </Text>
-                  )}
-                  {!hideAdvanced && (
-                    <Text style={styles.advancedText}>
-                      {i18n.t("showLessOptions")}
-                    </Text>
-                  )}
-                </Animated.View>
-              </Pressable>
-            )}
-            {/* toggleable content */}
-            {!hideAdvanced && (
+          <Animated.View
+            layout={LinearTransition}
+            style={[styles.form, formLayoutStyle]}
+          >
+            {!hideAdvanced ? (
               <Animated.View
                 entering={FadeInUp.duration(1000)
                   .easing(Easing.out(Easing.exp))
                   .delay(100)}
                 exiting={FadeOutUp.duration(50)}
               >
-                <View style={styles.currencyContainer}>
-                  <Text style={styles.currencyLabel}>
-                    {i18n.t("currencyLabel")}
-                  </Text>
-                  <CurrencyPicker
-                    countryValue={currencyPickerValue}
-                    setCountryValue={setCurrencyPickerValue}
-                    onChangeValue={updateCurrency}
-                    placeholder={currencyPlaceholder}
-                    inputCurrencyCode={inputs.currency.value}
-                  ></CurrencyPicker>
-                </View>
-                <View style={[styles.inputsRowSecond]}>
-                  <View style={styles.countryContainer}>
-                    <Text style={styles.currencyLabel}>
-                      {i18n.t("countryLabel")}
-                    </Text>
-                    <View style={{ flexDirection: "row" }}>
-                      <View
-                        style={[
-                          {
-                            minWidth: "77%",
-                            maxWidth: "77%",
-                          },
-                        ]}
-                      >
-                        <CountryPicker
-                          countryValue={countryPickerValue}
-                          setCountryValue={setCountryPickerValue}
-                          onChangeValue={updateCountry}
-                          placeholder={countryPlaceholder}
-                        ></CountryPicker>
-                      </View>
-                      <ExpenseCountryFlag
-                        countryName={inputs.country.value
-                          ?.split("- ")[0]
-                          .trim()}
-                        style={styles.countryFlag}
-                        containerStyle={styles.countryFlagContainer}
-                      ></ExpenseCountryFlag>
-                    </View>
-                  </View>
-                </View>
-                <View style={styles.dateLabel}>
-                  <Text style={styles.dateLabelText}>
-                    {i18n.t("dateLabel")}
-                  </Text>
-                </View>
-
-                {DatePickerContainer({
-                  openDatePickerRange,
-                  startDate,
-                  endDate,
-                  dateIsRanged,
-                  hideBottomBorder,
-                })}
-
-                <View
-                  style={
-                    duplOrSplit !== 0 && {
-                      paddingBottom: dynamicScale(5, true),
-                      marginHorizontal: "5%",
-                      borderBottomColor: GlobalStyles.colors.textColor,
-                      borderBottomWidth: 1,
-                    }
-                  }
-                >
-                  {duplOrSplit !== 0 && (
-                    <View style={styles.duplOrSplitContainer}>
-                      <Text style={styles.dateLabelDuplSplitText}>
-                        {duplOrSplitString(duplOrSplit)}
-                      </Text>
-                    </View>
-                  )}
-                </View>
-
-                <View style={styles.inputsRowSecond}>
-                  {/* !IsSoloTraveller && */}
-                  {showWhoPaid && (
-                    <View style={styles.whoPaidContainer}>
-                      <Text
-                        style={[
-                          styles.whoPaidLabel,
-                          !inputs.whoPaid.isValid && styles.invalidLabel,
-                        ]}
-                      >
-                        {i18n.t("whoPaid")}
-                      </Text>
-                      {loadingTravellers && (
-                        <ActivityIndicator
-                          size={"large"}
-                          color={GlobalStyles.colors.backgroundColor}
-                        ></ActivityIndicator>
-                      )}
-                      {!loadingTravellers && (
-                        <View
-                          style={{
-                            flexDirection: "row",
-                            marginLeft: dynamicScale(16),
-                            marginTop: dynamicScale(4),
-                          }}
-                        >
-                          {/* equal share equal pay button scale waage */}
-                          {/* share-social-outline */}
-                          {/* checkmark-done-outline */}
-                          {/* "expand-outline" */}
-                          {!IsSoloTraveller && (
-                            <IconButton
-                              icon="people-circle-outline"
-                              size={constantScale(28, 0.5)}
-                              buttonStyle={styles.whoPaidSplitButton}
-                              color={GlobalStyles.colors.primary500}
-                              onPress={() => {
-                                Haptics.impactAsync(
-                                  Haptics.ImpactFeedbackStyle.Light
-                                );
-                                const tempSplitType: splitType =
-                                  splitTypes.EXACT;
-                                const userNames =
-                                  travellerUserNames(currentTravellers);
-                                const listSplits = calcSplitList(
-                                  tempSplitType,
-                                  +amountValue,
-                                  userCtx.userName,
-                                  userNames
-                                );
-                                if (listSplits) {
-                                  setSplitType(tempSplitType);
-                                  // Reset edit order when split type changes
-                                  const splitsWithoutOrder =
-                                    resetEditOrder(listSplits);
-                                  setSplitList(splitsWithoutOrder);
-                                  setSplitListValid(
-                                    validateSplitList(
-                                      splitsWithoutOrder,
-                                      tempSplitType,
-                                      +amountValue
-                                    )
-                                  );
-                                }
-                              }}
-                            ></IconButton>
-                          )}
-                          <DropDownPicker
-                            // renderListItem={(props) =>
-                            //   renderDropDownList(props)
-                            // }
-                            containerStyle={styles.dropdownContainer}
-                            open={modalFlow === MODAL_FLOW_STATE.WHO_PAID}
-                            value={whoPaid}
-                            items={items}
-                            setOpen={(open) => {
-                              setModalFlow(
-                                open ? MODAL_FLOW_STATE.WHO_PAID : MODAL_FLOW_STATE.CLOSED
-                              );
-                            }}
-                            setValue={handleWhoPaidChange}
-                            setItems={setItems}
-                            onClose={() => {
-                              // Only reset modal flow if we're not transitioning to another modal
-                              if (modalFlow === MODAL_FLOW_STATE.WHO_PAID) {
-                                setModalFlow(MODAL_FLOW_STATE.CLOSED);
-                              }
-                            }}
-                            onOpen={() => {
-                              setModalFlow(MODAL_FLOW_STATE.WHO_PAID);
-                              Haptics.impactAsync(
-                                Haptics.ImpactFeedbackStyle.Light
-                              );
-                            }}
-                            onSelectItem={(item) => {
-                              Haptics.impactAsync(
-                                Haptics.ImpactFeedbackStyle.Light
-                              );
-
-                              // Set whoPaid value first
-                              if (item.value === MODAL_FLOW_ADD_TRAVELLER) {
-                                setWhoPaidWithLogging(userCtx.userName);
-                                setSplitType(splitTypes.SELF);
-                              } else {
-                                setWhoPaidWithLogging(item.value);
-                              }
-
-                              // Use state machine to handle modal flow
-                              nextModal(item.value);
-                            }}
-                            listMode="MODAL"
-                            modalProps={{
-                              animationType: "slide",
-                              presentationStyle: "pageSheet",
-                            }}
-                            searchable={false}
-                            modalTitle={i18n.t("whoPaid")}
-                            modalContentContainerStyle={{
-                              backgroundColor:
-                                GlobalStyles.colors.backgroundColor,
-                              marginTop: "2%",
-                              elevation: 2,
-                              shadowColor: GlobalStyles.colors.textColor,
-                              shadowOffset: { width: 1, height: 1 },
-                              shadowOpacity: 0.35,
-                              shadowRadius: 4,
-                            }}
-                            placeholder={userCtx.userName}
-                            style={
-                              !inputs.whoPaid.isValid
-                                ? [
-                                    styles.whoPaidDropdownContainer,
-                                    styles.invalidInput,
-                                  ]
-                                : styles.whoPaidDropdownContainer
-                            }
-                            textStyle={styles.dropdownTextStyle}
-                          />
-                        </View>
-                      )}
-                    </View>
-                  )}
-                  {whoPaidValid && !IsSoloTraveller && (
-                    <DropDownPicker
-                      // renderListItem={(props) => renderDropDownList(props)}
-                      open={modalFlow === MODAL_FLOW_STATE.HOW_SHARED}
-                      value={splitType}
-                      items={splitItems}
-                      setOpen={(open) => {
-                        setModalFlow(
-                          open ? MODAL_FLOW_STATE.HOW_SHARED : MODAL_FLOW_STATE.CLOSED
-                        );
-                      }}
-                      setValue={setSplitType}
-                      setItems={setSplitTypeItems}
-                      onSelectItem={(item) => {
-                        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                        if (item.value === splitTypes.EXACT) {
-                          setSplitType(item.value);
-                        }
-                        nextModal(item.value);
-                      }}
-                      onClose={() => {
-                        // Only reset modal flow if we're not transitioning to another modal
-                        // Don't reset if we're about to go to EXACT_SHARING
-                        if (modalFlow === MODAL_FLOW_STATE.HOW_SHARED) {
-                          setModalFlow(MODAL_FLOW_STATE.CLOSED);
-                        }
-                      }}
-                      onOpen={() => {
-                        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                      }}
-                      listMode="MODAL"
-                      modalProps={{
-                        animationType: "slide",
-                        presentationStyle: "pageSheet",
-                      }}
-                      searchable={false}
-                      modalTitle={i18n.t("howShared")}
-                      modalContentContainerStyle={{
-                        backgroundColor: GlobalStyles.colors.backgroundColor,
-                      }}
-                      placeholder={i18n.t("placeholderSharedExpense")}
-                      containerStyle={[
-                        styles.dropdownContainer,
-                        hidePickers && styles.hidePickersStyle,
-                      ]}
-                      style={[
-                        styles.whoPaidDropdownContainer,
-                        hidePickers && styles.hidePickersStyle,
-                      ]}
-                      textStyle={styles.dropdownTextStyle}
-                    />
-                  )}
-                </View>
-                {!loadingTravellers && !splitTypeSelf && !IsSoloTraveller && (
-                  <DropDownPicker
-                    // renderListItem={(props) => renderDropDownList(props)}
-                    open={modalFlow === MODAL_FLOW_STATE.EXACT_SHARING || openEQUAL}
-                    value={splitTravellersList}
-                    items={splitItemsEQUAL}
-                    setOpen={(open) => {
-                      if (open) {
-                        setModalFlow(MODAL_FLOW_STATE.EXACT_SHARING);
-                      } else {
-                        setModalFlow(MODAL_FLOW_STATE.CLOSED);
-                        setOpenEQUAL(false);
-                      }
-                    }}
-                    onOpen={() => {
-                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                    }}
-                    onSelectItem={() => {
-                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                    }}
-                    setValue={setSplitTravellersList}
-                    setItems={setSplitItemsEQUAL}
-                    onClose={() => {
-                      setModalFlow(MODAL_FLOW_STATE.CLOSED);
-                      splitHandler(splitType);
-                    }}
-                    listMode="MODAL"
-                    multiple={true}
-                    CloseIconComponent={() => (
-                      <Text
-                        style={{
-                          color: GlobalStyles.colors.textColor,
-                          fontSize: dynamicScale(24, false, 0.3),
-                          fontWeight: "bold",
-                          padding: dynamicScale(4),
-                        }}
-                      >
-                        {i18n.t("confirm2")}
-                      </Text>
-                    )}
-                    min={1}
-                    max={99}
-                    labelProps={{ style: { padding: dynamicScale(4) } }}
-                    modalProps={{
-                      animationType: "slide",
-                      presentationStyle: "pageSheet",
-                    }}
-                    searchable={false}
-                    modalTitle={i18n.t("whoShared")}
-                    modalContentContainerStyle={{
-                      backgroundColor: GlobalStyles.colors.backgroundColor,
-                    }}
-                    placeholder={i18n.t("placeholderSharedBetween")}
-                    containerStyle={[
-                      styles.dropdownContainer,
-                      hidePickers && styles.hidePickersStyle,
-                    ]}
-                    style={[
-                      styles.whoPaidDropdownContainer,
-                      hidePickers && styles.hidePickersStyle,
-                    ]}
-                    textStyle={styles.dropdownTextStyle}
-                  />
-                )}
-                <View
-                  style={[
-                    styles.advancedRowSplit,
-                    {
-                      marginTop: dynamicScale(12, false, 0.5),
-                      marginLeft: dynamicScale(12, false, 0.5),
-                    },
-                  ]}
-                >
-                  {!splitTypeSelf &&
-                    whoPaidValid &&
-                    !IsSoloTraveller &&
-                    splitListHasNonZeroEntries && (
-                      <Text style={[styles.whoSharedLabel]}>
-                        {i18n.t("whoShared")}
-                      </Text>
-                    )}
-                </View>
-
-                {!splitTypeSelf && (
-                  <KeyboardAvoidingView
-                    behavior={Platform.select({
-                      android: undefined,
-                      ios: "position",
-                    })}
-                    keyboardVerticalOffset={Platform.select({
-                      android: headerHeight,
-                      ios: 0,
-                    })}
-                    contentContainerStyle={{
-                      flex: 1,
-                      justifyContent: "flex-start",
-                      alignItems: "flex-start",
-                      overflow: "visible",
-                      backgroundColor: GlobalStyles.colors.gray500,
-                    }}
-                  >
-                    <FlatList
-                      // numColumns={2}
-                      data={splitList}
-                      horizontal={true}
-                      contentContainerStyle={{
-                        flex: 1,
-                        minWidth: splitList?.length
-                          ? splitList?.length * dynamicScale(100, false, 0.5) +
-                            dynamicScale(200, false, 0.5)
-                          : 0,
-                        marginLeft: dynamicScale(8, false, 0.5),
-                        marginRight: dynamicScale(8, false, 0.5),
-                        justifyContent: "flex-start",
-                        alignItems: "flex-start",
-                      }}
-                      ListHeaderComponent={null}
-                      ListFooterComponent={
-                        <View
-                          style={{ width: dynamicScale(300, false, 0.5) }}
-                        ></View>
-                      }
-                      renderItem={(itemData) => {
-                        const splitValue = splitAmountDisplayValue(itemData.item);
-                        return (
-                          <View style={styles.splitEditorCard}>
-                            <View
-                              style={{
-                                flexDirection: "row",
-                                paddingHorizontal: dynamicScale(4, false, 0.5),
-                                // space out
-                                justifyContent: "space-between",
-                                flex: 1,
-                              }}
-                            >
-                              <Text
-                                style={{
-                                  color: splitListValid
-                                    ? GlobalStyles.colors.textColor
-                                    : GlobalStyles.colors.error500,
-                                  textAlign: "left",
-                                  marginLeft: dynamicScale(4),
-                                  paddingTop: dynamicScale(2, true),
-                                  fontSize: dynamicScale(14, false, 0.3),
-                                }}
-                              >
-                                {truncateString(itemData.item.userName, 10)}
-                              </Text>
-                              <Pressable
-                                style={{
-                                  paddingLeft: dynamicScale(16),
-                                  paddingBottom: dynamicScale(16, true),
-                                }}
-                                onPress={() => {
-                                  removeUserFromSplit(
-                                    itemData.item.userName
-                                  );
-                                }}
-                              >
-                                <Text
-                                  style={{
-                                    fontSize: dynamicScale(14, false, 0.3),
-                                    color: GlobalStyles.colors.accent500,
-                                    textAlign: "left",
-                                    fontWeight: "600",
-                                  }}
-                                >
-                                  x
-                                </Text>
-                              </Pressable>
-                            </View>
-                            {/* Horizontal container  */}
-                            <View
-                              style={{
-                                flexDirection: "row",
-                                justifyContent: "flex-start",
-                                alignItems: "flex-end",
-                                overflow: "visible",
-                                // borderWidth: 1,
-                                marginLeft: dynamicScale(-16),
-                                marginRight: dynamicScale(-8),
-                              }}
-                            >
-                              <Input
-                                hasCurrency={!!inputs.currency}
-                                inputStyle={[
-                                  splitTypeEqual && {
-                                    color: GlobalStyles.colors.textColor,
-                                  },
-                                  {
-                                    paddingBottom: dynamicScale(4, true),
-                                    marginTop: dynamicScale(-26, true),
-                                  },
-                                  {
-                                    backgroundColor:
-                                      GlobalStyles.colors.backgroundColor,
-                                  },
-                                ]}
-                                textInputConfig={{
-                                  onFocus: () => {
-                                    if (splitType === splitTypes.EQUAL) {
-                                      setSplitType(splitTypes.EXACT);
-                                    }
-                                  },
-                                  keyboardType: "decimal-pad",
-                                  onChangeText: inputSplitListHandler.bind(
-                                    this,
-                                    itemData.index,
-                                    itemData.item
-                                  ),
-                                  value: splitValue,
-                                }}
-                              ></Input>
-                              <Text
-                                style={{
-                                  paddingBottom: dynamicScale(11, true),
-                                  marginLeft: dynamicScale(-18, false, 1.3),
-                                  marginRight: dynamicScale(8),
-                                }}
-                              >
-                                {getCurrencySymbol(inputs.currency.value)}
-                              </Text>
-                            </View>
-                            {splitListCalcAmounts[itemData.index] && (
-                              <Text style={styles.splitListCalcAmount}>
-                                {"= "}
-                                {formatExpenseWithCurrency(
-                                  splitListCalcAmounts[itemData.index],
-                                  tripCtx.tripCurrency
-                                )}
-                              </Text>
-                            )}
-                          </View>
-                        );
-                      }}
-                    ></FlatList>
-                  </KeyboardAvoidingView>
-                )}
-                {!splitTypeSelf && splitListHasNonZeroEntries && paidBackJSX}
-                {isSpecialExpenseJSX}
+                <ResponsiveGrid
+                  testID="expense-form-grid"
+                  layout={layout}
+                  multiColumnWhen="landscape"
+                  items={expenseFormGridItems}
+                />
               </Animated.View>
+            ) : (
+              <ResponsiveGrid
+                testID="expense-form-grid"
+                layout={layout}
+                multiColumnWhen="landscape"
+                items={expenseFormGridItems}
+              />
             )}
             {formIsInvalid && !hideAdvanced && (
               <Text style={styles.errorText}>{i18n.t("invalidInput")} </Text>
@@ -2098,68 +2105,6 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
           </View>
         </Animated.View>
       </Animated.View>
-      {false && ( //Platform.OS == "ios" && ( // comment this out for now, it's not working (not pressable)
-        // QuickSum Button on ios
-        <InputAccessoryView nativeID="amountID">
-          <View
-            style={{
-              flex: 1,
-              flexDirection: "row",
-              justifyContent: "space-between",
-              paddingLeft: "44%",
-              paddingRight: "4%",
-              alignContent: "center",
-              alignItems: "center",
-              backgroundColor: GlobalStyles.colors.backgroundColorLight,
-              borderTopWidth: 1,
-              borderColor: GlobalStyles.colors.gray700,
-              minWidth: isTablet ? (isPortrait ? "90%" : "135%") : "100%",
-            }}
-          >
-            <Pressable
-              style={{
-                flex: 1,
-                flexDirection: "row",
-                justifyContent: "center",
-                alignContent: "center",
-                alignItems: "center",
-                // backgroundColor: "white",
-                // borderWidth: 1,
-                // borderColor: "black",
-              }}
-              onPress={onPressHandlerQuickSum}
-            >
-              {/* <Text style={{ borderWidth: 1, borderColor: "blue" }}>Test</Text> */}
-              {inputs.amount.value && (
-                <IconButton
-                  buttonStyle={styles.taskBarButtons}
-                  icon={"add-outline"}
-                  color={GlobalStyles.colors.textColor}
-                  size={dynamicScale(24, false, 0.5)}
-                  onPress={onPressHandlerQuickSum}
-                />
-              )}
-              {!inputs.amount.value && tempAmount && (
-                <IconButton
-                  buttonStyle={styles.taskBarButtons}
-                  icon={"return-down-back-outline"}
-                  color={GlobalStyles.colors.textColor}
-                  size={dynamicScale(24, false, 0.5)}
-                  onPress={() => {}}
-                />
-              )}
-            </Pressable>
-            {!inputs.amount.value ||
-              (!tempAmount && (
-                <Pressable>
-                  <Text style={{ color: GlobalStyles.colors.primary700 }}>
-                    {i18n.t("confirm2")}
-                  </Text>
-                </Pressable>
-              ))}
-          </View>
-        </InputAccessoryView>
-      )}
     </>
   );
 };

--- a/TravelCostApp/components/UI/ActionRowStack.tsx
+++ b/TravelCostApp/components/UI/ActionRowStack.tsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 
 import ActionRow, { type ActionRowTier } from "./ActionRow";
 import { ActionRowTokens } from "../../styles/action-row-tokens";
+import { ControlFrame } from "../layout/ContentFrame";
+import { useLayoutProfile } from "../../store/layout-context";
 
 export type ActionRowAction = {
   testID?: string;
@@ -24,23 +26,27 @@ type ActionRowStackProps = {
 
 /** Vertical stack of ActionRows — modal footers, form actions, settings lists. */
 function ActionRowStack({ actions, showChevron = false }: ActionRowStackProps) {
+  const layout = useLayoutProfile();
+
   return (
-    <View testID="action-row-stack" style={styles.stack}>
-      {actions.map((action, index) => (
-        <ActionRow
-          key={action.testID ?? `${action.label}-${index}`}
-          testID={action.testID}
-          label={action.label}
-          hint={action.hint}
-          icon={action.icon}
-          tier={action.tier ?? "secondary"}
-          onPress={action.onPress}
-          showChevron={showChevron}
-          disabled={action.disabled}
-          style={styles.row}
-        />
-      ))}
-    </View>
+    <ControlFrame layout={layout} testID="action-row-stack-frame">
+      <View testID="action-row-stack" style={styles.stack}>
+        {actions.map((action, index) => (
+          <ActionRow
+            key={action.testID ?? `${action.label}-${index}`}
+            testID={action.testID}
+            label={action.label}
+            hint={action.hint}
+            icon={action.icon}
+            tier={action.tier ?? "secondary"}
+            onPress={action.onPress}
+            showChevron={showChevron}
+            disabled={action.disabled}
+            style={styles.row}
+          />
+        ))}
+      </View>
+    </ControlFrame>
   );
 }
 

--- a/TravelCostApp/components/UI/AddExpensesHereButton.tsx
+++ b/TravelCostApp/components/UI/AddExpensesHereButton.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { i18n } from "../../i18n/i18n";
 
 import ActionRow from "./ActionRow";
+import { ControlFrame } from "../layout/ContentFrame";
+import { useLayoutProfile } from "../../store/layout-context";
 import { useNavigation } from "@react-navigation/native";
 import { DateTime } from "luxon";
 import PropTypes from "prop-types";
@@ -41,6 +43,7 @@ export function buildAddExpenseHereAction(
 
 const AddExpenseHereButton = ({ dayISO }) => {
   const navigation = useNavigation();
+  const layout = useLayoutProfile();
   const action = buildAddExpenseHereAction(dayISO, (screen, params) =>
     navigation.navigate(screen as never, params as never)
   );
@@ -50,15 +53,17 @@ const AddExpenseHereButton = ({ dayISO }) => {
   }
 
   return (
-    <ActionRow
-      testID={action.testID}
-      tier={action.tier}
-      label={action.label}
-      hint={action.hint}
-      icon={action.icon}
-      onPress={action.onPress}
-      showChevron={false}
-    />
+    <ControlFrame layout={layout} testID="add-expense-here-frame">
+      <ActionRow
+        testID={action.testID}
+        tier={action.tier}
+        label={action.label}
+        hint={action.hint}
+        icon={action.icon}
+        onPress={action.onPress}
+        showChevron={false}
+      />
+    </ControlFrame>
   );
 };
 

--- a/TravelCostApp/components/layout/ContentFrame.tsx
+++ b/TravelCostApp/components/layout/ContentFrame.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { View, type StyleProp, type ViewStyle } from "react-native";
 
-import type { LayoutProfile } from "../../util/layout";
+import {
+  controlWidthStyle,
+  type ControlWidthMode,
+  type LayoutProfile,
+} from "../../util/layout";
 
 type ContentFrameProps = {
   layout: LayoutProfile;
@@ -29,6 +33,28 @@ export default function ContentFrame({
         style,
       ]}
     >
+      {children}
+    </View>
+  );
+}
+
+type ControlFrameProps = {
+  layout: LayoutProfile;
+  children: React.ReactNode;
+  mode?: ControlWidthMode;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+export function ControlFrame({
+  layout,
+  children,
+  mode = "fill",
+  style,
+  testID,
+}: ControlFrameProps) {
+  return (
+    <View testID={testID} style={[controlWidthStyle(layout, mode), style]}>
       {children}
     </View>
   );

--- a/TravelCostApp/components/layout/ContentFrame.tsx
+++ b/TravelCostApp/components/layout/ContentFrame.tsx
@@ -46,6 +46,7 @@ type ControlFrameProps = {
   testID?: string;
 };
 
+/** Constrains interactive controls on wide viewports. Use `mode="hug"` for back/navigation chrome. */
 export function ControlFrame({
   layout,
   children,

--- a/TravelCostApp/components/layout/ResponsiveGrid.tsx
+++ b/TravelCostApp/components/layout/ResponsiveGrid.tsx
@@ -5,23 +5,28 @@ import type { LayoutProfile } from "../../util/layout";
 
 type ResponsiveGridItem = {
   key: string;
+  column?: "left" | "right";
   render: () => React.ReactNode;
 };
+
+type ResponsiveGridColumnMode = "breakpoint" | "landscape";
 
 type ResponsiveGridProps = {
   layout: LayoutProfile;
   items: ResponsiveGridItem[];
   columnWidths?: [number, number];
+  multiColumnWhen?: ResponsiveGridColumnMode;
   style?: StyleProp<ViewStyle>;
   testID?: string;
 };
 
-function splitColumnFirst(items: ResponsiveGridItem[]) {
+function assignColumns(items: ResponsiveGridItem[]) {
   const left: ResponsiveGridItem[] = [];
   const right: ResponsiveGridItem[] = [];
 
   items.forEach((item, index) => {
-    if (index % 2 === 0) {
+    const side = item.column ?? (index % 2 === 0 ? "left" : "right");
+    if (side === "left") {
       left.push(item);
       return;
     }
@@ -35,11 +40,15 @@ export default function ResponsiveGrid({
   layout,
   items,
   columnWidths = [1, 1],
+  multiColumnWhen = "breakpoint",
   style,
   testID,
 }: ResponsiveGridProps) {
-  const isMultiColumn = layout.breakpoint !== "narrow";
-  const [leftColumn, rightColumn] = splitColumnFirst(items);
+  const isMultiColumn =
+    multiColumnWhen === "landscape"
+      ? layout.orientation === "landscape"
+      : layout.breakpoint !== "narrow";
+  const [leftColumn, rightColumn] = assignColumns(items);
   const totalWidth = columnWidths[0] + columnWidths[1];
 
   if (!isMultiColumn) {

--- a/TravelCostApp/util/layout.ts
+++ b/TravelCostApp/util/layout.ts
@@ -7,10 +7,15 @@ export type LayoutViewport = {
   height: number;
 };
 
+export const CONTROL_MAX_WIDTH = 480;
+
+export type ControlWidthMode = "fill" | "hug";
+
 export type LayoutProfile = {
   breakpoint: LayoutBreakpoint;
   orientation: LayoutOrientation;
   contentMaxWidth: number;
+  controlMaxWidth: number;
   space: (token: LayoutSpaceToken) => number;
   type: (size: number) => number;
 };
@@ -65,6 +70,35 @@ function typeForBreakpoint(breakpoint: LayoutBreakpoint, size: number) {
   return Math.round(size * TYPE_SCALE_BY_BREAKPOINT[breakpoint]);
 }
 
+export function controlWidthStyle(
+  layout: LayoutProfile,
+  mode: ControlWidthMode = "fill"
+) {
+  const touchTarget = { minHeight: 44, minWidth: 44 };
+
+  if (layout.breakpoint === "narrow") {
+    if (mode === "hug") {
+      return { alignSelf: "flex-start" as const, ...touchTarget };
+    }
+    return { alignSelf: "stretch" as const, width: "100%" as const, ...touchTarget };
+  }
+
+  if (mode === "hug") {
+    return {
+      alignSelf: "flex-start" as const,
+      maxWidth: layout.controlMaxWidth,
+      ...touchTarget,
+    };
+  }
+
+  return {
+    alignSelf: "center" as const,
+    width: "100%" as const,
+    maxWidth: layout.controlMaxWidth,
+    ...touchTarget,
+  };
+}
+
 export function layoutFor(viewport: LayoutViewport): LayoutProfile {
   const breakpoint = breakpointFor(viewport.width);
 
@@ -72,6 +106,7 @@ export function layoutFor(viewport: LayoutViewport): LayoutProfile {
     breakpoint,
     orientation: orientationFor(viewport),
     contentMaxWidth: 800,
+    controlMaxWidth: CONTROL_MAX_WIDTH,
     space: (token) => spaceForBreakpoint(breakpoint, token),
     type: (size) => typeForBreakpoint(breakpoint, size),
   };


### PR DESCRIPTION
## Summary
- Add `ControlFrame` and `controlWidthStyle` so wide buttons (Add Expense, form actions, back) are constrained to 480px max while phones stay full-width with 44×44 touch targets
- Refactor `ExpenseForm` to use `ResponsiveGrid` with landscape two-column layout (amount/category/date | who paid/split/country) and layout `space()` / `type()` tokens
- Remove the dead tablet `minWidth: 135%` overflow hack from the expense form

## Test plan
- [x] `pnpm exec jest` layout + expense form tablet tests pass locally
- [ ] iPad/macOS portrait: expense form stays single column; buttons not full-window width
- [ ] iPad/macOS landscape: expense form uses two columns; less scrolling than portrait
- [ ] Phone: Add Expense and form submit buttons remain full width

Closes #391