### PR TITLE
Split Summary, Profile, and filtered lists tablet optimization (#390)

### DIFF
--- a/TravelCostApp/__tests__/screens/filtered-modals-tablet-layout.test.tsx
+++ b/TravelCostApp/__tests__/screens/filtered-modals-tablet-layout.test.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+import { Dimensions, StyleSheet } from "react-native";
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn(), pop: jest.fn() }),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+import FilteredExpenses from "../../screens/FilteredExpenses";
+import LayoutContextProvider from "../../store/layout-context";
+import { makeExpense } from "../fixtures/expense";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { toExpenseNavigationDtos } from "../../util/expense-navigation-dto";
+
+const expenses = [
+  makeExpense({ id: "e1", description: "Coffee", calcAmount: 5 }),
+  makeExpense({ id: "e2", description: "Lunch", calcAmount: 12 }),
+];
+
+function renderFilteredExpensesAt(width: number, height: number) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 3,
+    fontScale: 1,
+  });
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <FilteredExpenses
+        route={{
+          params: {
+            expenses: toExpenseNavigationDtos(expenses),
+            dayString: "Today",
+          },
+        }}
+      />
+    </LayoutContextProvider>,
+    {
+      wrapNavigation: false,
+      trip: { tripid: "t1", tripName: "Trip", tripCurrency: "EUR" },
+      expenses: {
+        expenses,
+        getDailyExpenses: jest.fn(() => []),
+      },
+    }
+  );
+}
+
+describe("Filtered modal tablet layout", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("wraps filtered expense lists in ModalFrame with a centered max width at 600px+", () => {
+    const screen = renderFilteredExpensesAt(700, 900);
+    const frame = StyleSheet.flatten(
+      screen.getByTestId("filtered-expenses-modal-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frame.maxWidth).toBe(600);
+    expect(frame.alignSelf).toBe("center");
+  });
+
+  it("uses a two-column expense grid once the modal breakpoint is wide", () => {
+    const screen = renderFilteredExpensesAt(700, 900);
+
+    expect(screen.getByTestId("filtered-expenses-grid")).toBeTruthy();
+    expect(screen.getAllByTestId("responsive-grid-column")).toHaveLength(2);
+  });
+
+  it("keeps filtered expenses in one column on narrow phones", () => {
+    const screen = renderFilteredExpensesAt(390, 844);
+
+    expect(screen.queryByTestId("filtered-expenses-grid")).toBeNull();
+    expect(screen.queryAllByTestId("responsive-grid-column")).toHaveLength(0);
+  });
+});

--- a/TravelCostApp/__tests__/screens/profile-tablet-layout.test.tsx
+++ b/TravelCostApp/__tests__/screens/profile-tablet-layout.test.tsx
@@ -1,0 +1,101 @@
+import * as React from "react";
+import { Dimensions } from "react-native";
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useFocusEffect: jest.fn(),
+    useNavigation: () => ({ navigate: jest.fn(), pop: jest.fn() }),
+  };
+});
+jest.mock("expo-notifications", () => ({
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn(async () => ({ status: "granted" })),
+  requestPermissionsAsync: jest.fn(async () => ({ status: "granted" })),
+  getExpoPushTokenAsync: jest.fn(async () => ({ data: "token" })),
+  setNotificationChannelAsync: jest.fn(),
+  addNotificationReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  removeNotificationSubscription: jest.fn(),
+}));
+
+jest.mock("expo-device", () => ({ isDevice: false }));
+
+jest.mock("expo-constants", () => ({
+  expoConfig: { extra: { eas: { projectId: "test" } } },
+}));
+
+jest.mock("react-native-purchases", () => ({
+  setAttributes: jest.fn(async () => {}),
+  setEmail: jest.fn(async () => {}),
+  setDisplayName: jest.fn(async () => {}),
+}));
+
+jest.mock("../../util/http", () => ({
+  storeExpoPushTokenInTrip: jest.fn(async () => {}),
+}));
+
+jest.mock("../../components/Premium/PremiumConstants", () => ({
+  setAttributesAsync: jest.fn(async () => {}),
+}));
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+import ProfileScreen from "../../screens/ProfileScreen";
+import LayoutContextProvider from "../../store/layout-context";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+
+function renderProfileAt(width: number, height: number) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 3,
+    fontScale: 1,
+  });
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <ProfileScreen navigation={{ navigate: jest.fn() } as any} />
+    </LayoutContextProvider>,
+    {
+      wrapNavigation: false,
+      user: {
+        userName: "Alice",
+        tripHistory: ["t1"],
+        updateTripHistory: jest.fn(async () => {}),
+        loadUserNameFromStorage: jest.fn(),
+      },
+    }
+  );
+}
+
+describe("Profile tablet layout", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("lays out profile action rows in a 50/50 grid on wide viewports", () => {
+    const screen = renderProfileAt(1024, 768);
+
+    expect(screen.getByTestId("profile-action-grid")).toBeTruthy();
+    expect(screen.getAllByTestId("responsive-grid-column")).toHaveLength(2);
+    expect(screen.getByTestId("profile-feedback")).toBeTruthy();
+    expect(screen.getByTestId("my-budgets-add-another")).toBeTruthy();
+    expect(screen.getByTestId("my-budgets-join")).toBeTruthy();
+  });
+
+  it("keeps profile actions in a single column on phones", () => {
+    const screen = renderProfileAt(390, 844);
+
+    expect(screen.queryByTestId("responsive-grid-column")).toBeNull();
+    expect(screen.getByTestId("profile-feedback")).toBeTruthy();
+  });
+});

--- a/TravelCostApp/__tests__/screens/split-summary-tablet-layout.test.tsx
+++ b/TravelCostApp/__tests__/screens/split-summary-tablet-layout.test.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import { Dimensions, StyleSheet } from "react-native";
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useFocusEffect: jest.fn(),
+  };
+});
+
+jest.mock("../../util/vexo-tracking", () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(async () => {}),
+  ImpactFeedbackStyle: { Light: "Light" },
+}));
+
+jest.mock("react-native-toast-message", () => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+  default: { show: jest.fn(), hide: jest.fn() },
+}));
+
+import SplitSummaryScreen from "../../screens/SplitSummaryScreen";
+import LayoutContextProvider from "../../store/layout-context";
+import { makeExpense } from "../fixtures/expense";
+import { renderWithAppProviders } from "../fixtures/app-providers";
+import { layoutFor } from "../../util/layout";
+
+function renderSplitSummaryAt(width: number, height: number) {
+  jest.spyOn(Dimensions, "get").mockReturnValue({
+    width,
+    height,
+    scale: 3,
+    fontScale: 1,
+  });
+
+  const navigation = { navigate: jest.fn(), pop: jest.fn(), popToTop: jest.fn() };
+
+  return renderWithAppProviders(
+    <LayoutContextProvider>
+      <SplitSummaryScreen navigation={navigation as any} />
+    </LayoutContextProvider>,
+    {
+      wrapNavigation: false,
+      trip: {
+        tripid: "t1",
+        tripCurrency: "EUR",
+        isPaid: "notPaid",
+        isPaidTimestamp: 0,
+        fetchAndSettleCurrentTrip: jest.fn(async () => {}),
+      },
+      user: { userName: "Alice", freshlyCreated: false },
+      expenses: {
+        expenses: [
+          makeExpense({
+            whoPaid: "Alice",
+            amount: 100,
+            calcAmount: 100,
+            currency: "EUR",
+            splitList: [
+              { userName: "Alice", amount: 50 },
+              { userName: "Bob", amount: 50 },
+            ],
+          }),
+        ],
+      },
+      orientation: {
+        isPortrait: height > width,
+        isLandscape: width > height,
+        isTablet: width >= 768,
+      },
+    }
+  );
+}
+
+describe("SplitSummary tablet layout", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("wraps balances in a centered 800px ContentFrame on wide viewports", async () => {
+    const screen = renderSplitSummaryAt(1194, 834);
+    const frame = StyleSheet.flatten(
+      screen.getByTestId("split-summary-content-frame").props.style
+    ) as Record<string, unknown>;
+
+    expect(frame.maxWidth).toBe(800);
+    expect(frame.alignSelf).toBe("center");
+  });
+
+  it("spaces balance rows with layout tokens instead of stretched list padding", async () => {
+    const layout = layoutFor({ width: 1194, height: 834 });
+    const screen = renderSplitSummaryAt(1194, 834);
+    const list = screen.getByTestId("split-summary-balance-list");
+    const listStyle = StyleSheet.flatten(list.props.style) as Record<
+      string,
+      unknown
+    >;
+
+    expect(listStyle.paddingHorizontal).toBe(layout.space(3));
+  });
+});

--- a/TravelCostApp/changelog.txt
+++ b/TravelCostApp/changelog.txt
@@ -8,6 +8,7 @@ __Newest Changes:
 - Improved ranged local-price deal prompts
 - Improved Overview and Recent Expenses on tablet and Mac
 - Improved expense forms and action buttons on larger screens
+- Improved Split Summary, Profile, and filtered lists on tablet and Mac
 - Bugfixes and performance improvements
 
 __Other Changes:

--- a/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
+++ b/TravelCostApp/components/ExpensesOutput/ExpensesOutput.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, Text, View, ScrollView, Dimensions } from "react-native";
 
 import { GlobalStyles } from "../../constants/styles";
 import ExpensesList from "./ExpensesList";
+import FilteredExpensesGrid from "./FilteredExpensesGrid";
 import React from "react-native";
 import Animated, { SlideOutLeft } from "react-native-reanimated";
 import LoadingOverlay from "../UI/LoadingOverlay";
@@ -62,6 +63,9 @@ function ExpensesOutput({
   const memoizedContent = useMemo(() => {
     if (expenses?.length > 0) {
       if (fallback) setFallback(false);
+      if (isFiltered) {
+        return <FilteredExpensesGrid expenses={expenses} />;
+      }
       return (
         <ExpensesList
           expenses={expenses}

--- a/TravelCostApp/components/ExpensesOutput/FilteredExpensesGrid.tsx
+++ b/TravelCostApp/components/ExpensesOutput/FilteredExpensesGrid.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback } from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import * as Haptics from "expo-haptics";
+
+import ResponsiveGrid from "../layout/ResponsiveGrid";
+import ExpenseListRow from "./ExpenseListRow";
+import { useLayoutProfile } from "../../store/layout-context";
+import { GlobalStyles } from "../../constants/styles";
+import type { ExpenseData } from "../../util/expense";
+
+type FilteredExpensesGridProps = {
+  expenses: ExpenseData[];
+};
+
+export default function FilteredExpensesGrid({
+  expenses,
+}: FilteredExpensesGridProps) {
+  const layout = useLayoutProfile();
+  const navigation = useNavigation();
+  const isWide = layout.breakpoint !== "narrow";
+
+  const navigateToExpense = useCallback(
+    (expenseId: string) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      navigation.navigate("ManageExpense" as never, { expenseId } as never);
+    },
+    [navigation]
+  );
+
+  if (!isWide) {
+    return (
+      <ScrollView
+        testID="filtered-expenses-list"
+        contentContainerStyle={styles.listContent}
+      >
+        {expenses.map((expense) => (
+          <ExpenseListRow
+            key={expense.id}
+            {...expense}
+            layoutVariant="ledger"
+            onPress={() => navigateToExpense(expense.id)}
+          />
+        ))}
+      </ScrollView>
+    );
+  }
+
+  return (
+    <ScrollView
+      testID="filtered-expenses-list"
+      contentContainerStyle={styles.listContent}
+    >
+      <ResponsiveGrid
+        testID="filtered-expenses-grid"
+        layout={layout}
+        columnWidths={[1, 1]}
+        items={expenses.map((expense) => ({
+          key: expense.id,
+          render: () => (
+            <ExpenseListRow
+              {...expense}
+              layoutVariant="ledger"
+              onPress={() => navigateToExpense(expense.id)}
+            />
+          ),
+        }))}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingBottom: 16,
+    backgroundColor: GlobalStyles.colors.backgroundColor,
+  },
+});

--- a/TravelCostApp/components/UI/ActionRowStack.tsx
+++ b/TravelCostApp/components/UI/ActionRowStack.tsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import ActionRow, { type ActionRowTier } from "./ActionRow";
 import { ActionRowTokens } from "../../styles/action-row-tokens";
 import { ControlFrame } from "../layout/ContentFrame";
+import ResponsiveGrid from "../layout/ResponsiveGrid";
 import { useLayoutProfile } from "../../store/layout-context";
 
 export type ActionRowAction = {
@@ -22,11 +23,68 @@ export type ActionRowAction = {
 type ActionRowStackProps = {
   actions: ActionRowAction[];
   showChevron?: boolean;
+  gridOnWide?: boolean;
 };
 
-/** Vertical stack of ActionRows — modal footers, form actions, settings lists. */
-function ActionRowStack({ actions, showChevron = false }: ActionRowStackProps) {
+export type ActionRowGridItem = {
+  key: string;
+  render: () => React.ReactNode;
+};
+
+type ActionRowGridProps = {
+  items: ActionRowGridItem[];
+  testID?: string;
+};
+
+/** Responsive 50/50 grid for heterogeneous profile-style action rows. */
+export function ActionRowGrid({ items, testID }: ActionRowGridProps) {
   const layout = useLayoutProfile();
+
+  return (
+    <ResponsiveGrid
+      layout={layout}
+      items={items}
+      testID={testID}
+      columnWidths={[1, 1]}
+    />
+  );
+}
+
+/** Vertical stack of ActionRows — modal footers, form actions, settings lists. */
+function ActionRowStack({
+  actions,
+  showChevron = false,
+  gridOnWide = false,
+}: ActionRowStackProps) {
+  const layout = useLayoutProfile();
+
+  if (gridOnWide && layout.breakpoint !== "narrow") {
+    return (
+      <ControlFrame layout={layout} testID="action-row-stack-frame">
+        <ResponsiveGrid
+          layout={layout}
+          testID="action-row-stack-grid"
+          columnWidths={[1, 1]}
+          items={actions.map((action, index) => ({
+            key: action.testID ?? `${action.label}-${index}`,
+            render: () => (
+              <ActionRow
+                testID={action.testID}
+                label={action.label}
+                hint={action.hint}
+                icon={action.icon}
+                tier={action.tier ?? "secondary"}
+                onPress={action.onPress}
+                showChevron={showChevron}
+                disabled={action.disabled}
+                style={styles.row}
+              />
+            ),
+          }))}
+        />
+      </ControlFrame>
+    );
+  }
 
   return (
     <ControlFrame layout={layout} testID="action-row-stack-frame">
@@ -65,6 +123,17 @@ ActionRowStack.propTypes = {
     })
   ).isRequired,
   showChevron: PropTypes.bool,
+  gridOnWide: PropTypes.bool,
+};
+
+ActionRowGrid.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      render: PropTypes.func.isRequired,
+    })
+  ).isRequired,
+  testID: PropTypes.string,
 };
 
 const styles = StyleSheet.create({

--- a/TravelCostApp/screens/FilteredExpenses.tsx
+++ b/TravelCostApp/screens/FilteredExpenses.tsx
@@ -9,10 +9,12 @@ import PropTypes from "prop-types";
 import BackButton from "../components/UI/BackButton";
 import BlurPremium from "../components/Premium/BlurPremium";
 import ActionRowStack from "../components/UI/ActionRowStack";
+import ModalFrame from "../components/layout/ModalFrame";
 import { buildAddExpenseHereAction } from "../components/UI/AddExpensesHereButton";
 import { useNavigation } from "@react-navigation/native";
 import { getEarliestDate } from "../util/date";
 import { ExpenseData } from "../util/expense";
+import { useLayoutProfile } from "../store/layout-context";
 import {
   expenseDateToIsoString,
   hydrateExpensesFromNavigationDtos,
@@ -32,6 +34,7 @@ const FilteredExpenses = ({ route, expensesAsArg, dayStringAsArg }) => {
       };
   const withArgs = expensesAsArg ? true : false;
   const navigation = useNavigation();
+  const layout = useLayoutProfile();
   const earliestDate = getEarliestDate(
     expenses.map((exp: ExpenseData) => expenseDateToIsoString(exp.date))
   );
@@ -51,56 +54,62 @@ const FilteredExpenses = ({ route, expensesAsArg, dayStringAsArg }) => {
   // }
   return (
     <View style={styles.container}>
-      {!withArgs && (
-        <>
-          <View style={styles.titleContainer}>
-            <BackButton
-              style={{ marginTop: -20, marginBottom: 0, padding: 4 }}
-            ></BackButton>
-            <Text style={styles.titleText}>{dayString}</Text>
-          </View>
+      <ModalFrame
+        layout={layout}
+        testID="filtered-expenses-modal-frame"
+        style={styles.modalFrame}
+      >
+        {!withArgs && (
+          <>
+            <View style={styles.titleContainer}>
+              <BackButton
+                style={{ marginTop: -20, marginBottom: 0, padding: 4 }}
+              ></BackButton>
+              <Text style={styles.titleText}>{dayString}</Text>
+            </View>
 
-          <View style={styles.shadow}></View>
-        </>
-      )}
-      <ExpensesOutput
-        expenses={expenses}
-        showSumForTravellerName={showSumForTravellerName}
-        isFiltered
-      />
-      {/* <BlurPremium canBack /> */}
-      {!withArgs && (
-        <View style={styles.footerActions}>
-          {addExpenseAction ? (
-            <ActionRowStack
-              showChevron={false}
-              actions={[
-                addExpenseAction,
-                {
-                  testID: "filtered-expenses-back",
-                  tier: "secondary",
-                  label: i18n.t("back"),
-                  icon: "arrow-back-outline",
-                  onPress: () => navigation.pop(),
-                },
-              ]}
-            />
-          ) : (
-            <ActionRowStack
-              showChevron={false}
-              actions={[
-                {
-                  testID: "filtered-expenses-back",
-                  tier: "secondary",
-                  label: i18n.t("back"),
-                  icon: "arrow-back-outline",
-                  onPress: () => navigation.pop(),
-                },
-              ]}
-            />
-          )}
-        </View>
-      )}
+            <View style={styles.shadow}></View>
+          </>
+        )}
+        <ExpensesOutput
+          expenses={expenses}
+          showSumForTravellerName={showSumForTravellerName}
+          isFiltered
+        />
+        {/* <BlurPremium canBack /> */}
+        {!withArgs && (
+          <View style={styles.footerActions}>
+            {addExpenseAction ? (
+              <ActionRowStack
+                showChevron={false}
+                actions={[
+                  addExpenseAction,
+                  {
+                    testID: "filtered-expenses-back",
+                    tier: "secondary",
+                    label: i18n.t("back"),
+                    icon: "arrow-back-outline",
+                    onPress: () => navigation.pop(),
+                  },
+                ]}
+              />
+            ) : (
+              <ActionRowStack
+                showChevron={false}
+                actions={[
+                  {
+                    testID: "filtered-expenses-back",
+                    tier: "secondary",
+                    label: i18n.t("back"),
+                    icon: "arrow-back-outline",
+                    onPress: () => navigation.pop(),
+                  },
+                ]}
+              />
+            )}
+          </View>
+        )}
+      </ModalFrame>
     </View>
   );
 };
@@ -119,8 +128,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: "1%",
-    // center the content
     justifyContent: "center",
+  },
+  modalFrame: {
+    flex: 1,
   },
   titleText: {
     fontSize: 20,

--- a/TravelCostApp/screens/FilteredPieCharts.tsx
+++ b/TravelCostApp/screens/FilteredPieCharts.tsx
@@ -12,13 +12,15 @@ import ExpenseTravellers from "../components/ExpensesOutput/ExpenseStatistics/Ex
 import ExpenseCountries from "../components/ExpensesOutput/ExpenseStatistics/ExpenseCountries";
 import ExpenseCurrencies from "../components/ExpensesOutput/ExpenseStatistics/ExpenseCurrencies";
 import ActionRowStack from "../components/UI/ActionRowStack";
+import ModalFrame from "../components/layout/ModalFrame";
 import { buildAddExpenseHereAction } from "../components/UI/AddExpensesHereButton";
 import FilteredExpenses from "./FilteredExpenses";
 import BackButton from "../components/UI/BackButton";
 import { ExpenseData } from "../util/expense";
 import { getEarliestDate } from "../util/date";
-import { constantScale, dynamicScale } from "../util/scalingUtil";
+import { dynamicScale } from "../util/scalingUtil";
 import { OrientationContext } from "../store/orientation-context";
+import { useLayoutProfile } from "../store/layout-context";
 import {
   expenseDateToIsoString,
   hydrateExpensesFromNavigationDtos,
@@ -32,7 +34,8 @@ const FilteredPieCharts = ({ navigation, route }) => {
   );
   const [toggleGraphEnum, setToggleGraphEnum] = useState(0);
 
-  const { isPortrait, isTablet } = useContext(OrientationContext);
+  const { isPortrait } = useContext(OrientationContext);
+  const layout = useLayoutProfile();
   // contents and titleStrings have to match in legth and correspond!
   const titleStrings = [
     i18n.t("categories"),
@@ -122,12 +125,16 @@ const FilteredPieCharts = ({ navigation, route }) => {
 
   return (
     <View style={styles.container}>
-      <View
-        style={[
-          !isPortrait && styles.landscapeTitleContainer,
-          isTablet && styles.tabletContainer,
-        ]}
+      <ModalFrame
+        layout={layout}
+        testID="filtered-pie-charts-modal-frame"
+        style={styles.modalFrame}
       >
+        <View
+          style={[
+            !isPortrait && styles.landscapeTitleContainer,
+          ]}
+        >
         <View style={styles.firstTitleContainer}>
           <BackButton
             style={{ marginTop: dynamicScale(-16, false, 0.5) }}
@@ -154,7 +161,6 @@ const FilteredPieCharts = ({ navigation, route }) => {
               style={[
                 styles.titleText,
                 !isPortrait && styles.landScapetitleText,
-                isTablet && styles.tabletTitleText,
               ]}
             >
               {" "}
@@ -170,19 +176,20 @@ const FilteredPieCharts = ({ navigation, route }) => {
             ></IconButton>
           </View>
         </View>
-      </View>
-      <View style={styles.shadow}></View>
-      {contents[toggleGraphEnum]}
-      <View style={styles.footerContainer}>
-        <ActionRowStack
-          showChevron={false}
-          actions={
-            addExpenseAction
-              ? [addExpenseAction, backAction]
-              : [backAction]
-          }
-        />
-      </View>
+        </View>
+        <View style={styles.shadow}></View>
+        {contents[toggleGraphEnum]}
+        <View style={styles.footerContainer}>
+          <ActionRowStack
+            showChevron={false}
+            actions={
+              addExpenseAction
+                ? [addExpenseAction, backAction]
+                : [backAction]
+            }
+          />
+        </View>
+      </ModalFrame>
     </View>
   );
 };
@@ -195,6 +202,9 @@ FilteredPieCharts.propTypes = {
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+  },
+  modalFrame: {
     flex: 1,
   },
   firstTitleTextContainer: {
@@ -215,11 +225,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: dynamicScale(80, false, 0.5),
     marginTop: dynamicScale(-24, true),
     backgroundColor: GlobalStyles.colors.backgroundColor,
-  },
-  tabletContainer: {
-    marginTop: 0,
-    padding: constantScale(12, 0.5),
-    paddingHorizontal: constantScale(12, 0.5),
   },
   firstTitleContainer: {
     marginVertical: "4%",
@@ -260,9 +265,6 @@ const styles = StyleSheet.create({
   },
   landScapetitleText: {
     marginTop: dynamicScale(30, true),
-  },
-  tabletTitleText: {
-    marginTop: constantScale(16, 0.5),
   },
   chevronContainer: {
     justifyContent: "center",

--- a/TravelCostApp/screens/ProfileScreen.tsx
+++ b/TravelCostApp/screens/ProfileScreen.tsx
@@ -19,7 +19,6 @@ import uniqBy from "lodash.uniqby";
 import ProfileIdentity from "../components/ManageProfile/ProfileIdentity";
 import ProfileToolbar from "../components/ManageProfile/ProfileToolbar";
 import TripListRow from "../components/ProfileOutput/TripListRow";
-import MyBudgetsHubActions from "../components/ProfileOutput/MyBudgetsHubActions";
 import FeedbackForm from "../components/FeedbackForm/FeedbackForm";
 import { GlobalStyles } from "../constants/styles";
 import { shadowRegressionStyles } from "../styles/shadow-regression-styles";
@@ -47,6 +46,7 @@ import { NetworkContext } from "../store/network-context";
 import { dynamicScale, constantScale } from "../util/scalingUtil";
 import GetLocalPriceButton from "../components/Settings/GetLocalPriceButton";
 import ActionRow from "../components/UI/ActionRow";
+import { ActionRowGrid } from "../components/UI/ActionRowStack";
 import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
 import IconButton from "../components/UI/IconButton";
@@ -237,29 +237,66 @@ const ProfileScreen = ({ navigation }) => {
     () => (
       <View testID="profile-scroll-header">
         <ProfileIdentity navigation={navigation} />
-        <View style={styles.profileActions}>
-          <GetLocalPriceButton navigation={navigation} />
-          <ActionRow
-            testID="profile-feedback"
-            tier="secondary"
-            label={i18n.t("supportFeedbackLabel")}
-            hint={i18n.t("supportFeedbackHint")}
-            icon="chatbubble-ellipses-outline"
-            showChevron={false}
-            onPress={() => {
-              trackEvent(VexoEvents.FEEDBACK_BUTTON_PRESSED);
-              setIsFeedbackModalVisible(true);
-            }}
-          />
-        </View>
+        <ActionRowGrid
+          testID="profile-action-grid"
+          items={[
+            {
+              key: "local-price",
+              render: () => <GetLocalPriceButton navigation={navigation} />,
+            },
+            {
+              key: "feedback",
+              render: () => (
+                <ActionRow
+                  testID="profile-feedback"
+                  tier="secondary"
+                  label={i18n.t("supportFeedbackLabel")}
+                  hint={i18n.t("supportFeedbackHint")}
+                  icon="chatbubble-ellipses-outline"
+                  showChevron={false}
+                  onPress={() => {
+                    trackEvent(VexoEvents.FEEDBACK_BUTTON_PRESSED);
+                    setIsFeedbackModalVisible(true);
+                  }}
+                />
+              ),
+            },
+            {
+              key: "add-budget",
+              render: () => (
+                <ActionRow
+                  testID="my-budgets-add-another"
+                  tier="primary"
+                  label={i18n.t("addAnotherBudget")}
+                  hint={i18n.t("addAnotherBudgetHint")}
+                  icon="add-circle-outline"
+                  onPress={() => {
+                    trackEvent(VexoEvents.CREATE_TRIP_FROM_PROFILE_PRESSED);
+                    navigation.navigate("ManageTrip", { mode: "addAnother" });
+                  }}
+                />
+              ),
+            },
+            {
+              key: "join-budget",
+              render: () => (
+                <ActionRow
+                  testID="my-budgets-join"
+                  tier="secondary"
+                  label={i18n.t("joinBudget")}
+                  hint={i18n.t("joinBudgetHint")}
+                  icon="people-outline"
+                  onPress={() => {
+                    trackEvent(VexoEvents.TRIP_JOINED);
+                    navigation.navigate("Join");
+                  }}
+                />
+              ),
+            },
+          ]}
+        />
         <View style={styles.tripHubSection}>
           <Text style={styles.tripListTitle}>{i18n.t("myBudgets")}</Text>
-          <MyBudgetsHubActions
-            onJoin={() => navigation.navigate("Join")}
-            onAddAnother={() =>
-              navigation.navigate("ManageTrip", { mode: "addAnother" })
-            }
-          />
           <Text style={styles.listSectionLabel}>{i18n.t("yourBudgets")}</Text>
         </View>
       </View>
@@ -357,9 +394,6 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingHorizontal: dynamicScale(16, false, 0.5),
     paddingBottom: dynamicScale(8, true),
-  },
-  profileActions: {
-    marginBottom: dynamicScale(8, true),
   },
   tripHubSection: {
     marginBottom: dynamicScale(8, true),

--- a/TravelCostApp/screens/SplitSummaryScreen.tsx
+++ b/TravelCostApp/screens/SplitSummaryScreen.tsx
@@ -48,6 +48,8 @@ import { OrientationContext } from "../store/orientation-context";
 import safeLogError from "../util/error";
 import { trackEvent } from "../util/vexo-tracking";
 import { VexoEvents } from "../util/vexo-constants";
+import ContentFrame from "../components/layout/ContentFrame";
+import { useLayoutProfile } from "../store/layout-context";
 
 const SplitSummaryScreen = ({ navigation }) => {
   const {
@@ -63,6 +65,7 @@ const SplitSummaryScreen = ({ navigation }) => {
   const [isFetching, setIsFetching] = useState(false);
   const [error, setError] = useState();
   const { isPortrait } = useContext(OrientationContext);
+  const layout = useLayoutProfile();
 
   const [splits, setSplits] = useState<Split[]>([]);
   const hasOpenSplits = splits?.length > 0;
@@ -441,8 +444,9 @@ const SplitSummaryScreen = ({ navigation }) => {
 
         {isPortrait ? (
           <StaticList
+            testID="split-summary-balance-list"
             style={{
-              paddingHorizontal: dynamicScale(8, false, 0.5),
+              paddingHorizontal: layout.space(3),
               flex: 1,
             }}
             contentContainerStyle={{
@@ -477,8 +481,9 @@ const SplitSummaryScreen = ({ navigation }) => {
           />
         ) : (
           <FlatList
+            testID="split-summary-balance-list"
             style={{
-              paddingHorizontal: dynamicScale(8, false, 0.5),
+              paddingHorizontal: layout.space(3),
               flex: 1,
             }}
             contentContainerStyle={{
@@ -517,7 +522,17 @@ const SplitSummaryScreen = ({ navigation }) => {
     </Animated.View>
   );
 
-  return <View style={styles.container}>{splitSummaryContent}</View>;
+  return (
+    <View style={styles.container}>
+      <ContentFrame
+        layout={layout}
+        testID="split-summary-content-frame"
+        style={styles.contentFrame}
+      >
+        {splitSummaryContent}
+      </ContentFrame>
+    </View>
+  );
 };
 
 export default SplitSummaryScreen;
@@ -541,6 +556,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: GlobalStyles.colors.backgroundColor,
+  },
+  contentFrame: {
+    flex: 1,
   },
   cardContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Split Summary balances use `ContentFrame` (800px centered) with layout-token list spacing
- Profile action rows use `ActionRowGrid` (ResponsiveGrid 50/50 column-first on wide)
- Filtered expense and pie modals use `ModalFrame` with 2-column expense grids on wide viewports

Closes #390

## Test plan
- [x] `npm test` — 859 tests pass
- [ ] iPad 11" landscape: Split Summary balances readable without full-width stretch
- [ ] Profile action rows show 2-column grid on tablet
- [ ] Filtered expense list modal shows 2-column grid at 600px+